### PR TITLE
performance: Avoid write interception when not needed

### DIFF
--- a/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.cs
+++ b/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.cs
@@ -134,6 +134,8 @@ public class DynamicSubjectTests
             return result;
         }
 
+        public bool ShouldInterceptWrite => true;
+
         public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
         {
             _logs.Add($"{_name}: Before write {context.Property.Name}");

--- a/src/Namotion.Interceptor.Tests/InterceptorTests.cs
+++ b/src/Namotion.Interceptor.Tests/InterceptorTests.cs
@@ -76,6 +76,8 @@ public class InterceptorTests
             _logs = logs;
         }
 
+        public bool ShouldInterceptWrite => true;
+
         public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
         {
             _logs.Add($"{_name}: Before write {context.Property.Name}");

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -1,4 +1,5 @@
-﻿using Namotion.Interceptor.Interceptors;
+﻿using System.Runtime.CompilerServices;
+using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Tracking.Lifecycle;
 
 namespace Namotion.Interceptor.Tracking.Change;
@@ -11,7 +12,13 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
 {
     [ThreadStatic]
     private static Stack<HashSet<PropertyReference>>? _currentTouchedProperties;
-    
+
+    public bool ShouldInterceptWrite
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => true;
+    }
+
     public void AttachProperty(SubjectPropertyLifecycleChange change)
     {
         if (change.Property.Metadata.IsDerived)
@@ -30,6 +37,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
     {
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public TProperty ReadProperty<TProperty>(ref PropertyReadContext context, ReadInterceptionDelegate<TProperty> next)
     {
         var result = next(ref context);
@@ -37,6 +45,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
     {
         next(ref context);

--- a/src/Namotion.Interceptor.Tracking/Change/PropertyChangeObservable.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/PropertyChangeObservable.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
 using Namotion.Interceptor.Interceptors;
 
 namespace Namotion.Interceptor.Tracking.Change;
@@ -13,18 +14,17 @@ public class PropertyChangeObservable : IObservable<SubjectPropertyChange>, IWri
         _syncSubject = Subject.Synchronize(_subject);
     }
 
+    public bool ShouldInterceptWrite
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _subject.HasObservers;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
     {
-        if (!_subject.HasObservers)
-        {
-            next(ref context);
-            return;
-        }
-
         var oldValue = context.CurrentValue;
-        
         next(ref context);
-
         var newValue = context.GetFinalValue();
 
         var changeContext = SubjectChangeContext.Current;

--- a/src/Namotion.Interceptor.Tracking/Change/PropertyChangeQueue.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/PropertyChangeQueue.cs
@@ -46,17 +46,17 @@ public sealed class PropertyChangeQueue : IWriteInterceptor, IDisposable
             }
         }
     }
-
-    public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
+    
+    public bool ShouldInterceptWrite
     {
         // ReSharper disable once InconsistentlySynchronizedField
-        var subscriptions = _subscriptions; // volatile read
-        if (subscriptions.Length == 0)
-        {
-            next(ref context);
-            return;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _subscriptions.Length > 0;
+    }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
+    {
         var oldValue = context.CurrentValue;
         next(ref context);
         var newValue = context.GetFinalValue();

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
@@ -125,6 +125,13 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
         }
     }
 
+    public bool ShouldInterceptWrite
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
     {
         var currentValue = context.CurrentValue;

--- a/src/Namotion.Interceptor.Tracking/PropertyValueEqualityCheckHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/PropertyValueEqualityCheckHandler.cs
@@ -1,9 +1,17 @@
-﻿using Namotion.Interceptor.Interceptors;
+﻿using System.Runtime.CompilerServices;
+using Namotion.Interceptor.Interceptors;
 
 namespace Namotion.Interceptor.Tracking;
 
 public class PropertyValueEqualityCheckHandler : IWriteInterceptor
 {
+    public bool ShouldInterceptWrite
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
     {
         if (!EqualityComparer<TProperty>.Default.Equals(context.CurrentValue, context.NewValue))

--- a/src/Namotion.Interceptor.Validation/ValidationInterceptor.cs
+++ b/src/Namotion.Interceptor.Validation/ValidationInterceptor.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Namotion.Interceptor.Interceptors;
 
@@ -6,6 +7,13 @@ namespace Namotion.Interceptor.Validation;
 
 public class ValidationInterceptor : IWriteInterceptor
 {
+    public bool ShouldInterceptWrite
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
     {
         var validators = context.Property.Subject.Context.GetServices<IPropertyValidator>();

--- a/src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs
+++ b/src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs
@@ -14,7 +14,17 @@ internal static class WriteInterceptorFactory<TProperty>
 
         var chain = new WriteInterceptorChain<IWriteInterceptor, TProperty>(
             interceptorArray,
-            static (interceptor, ref context, next) => interceptor.WriteProperty(ref context, next),
+            static (interceptor, ref context, next) =>
+            {
+                if (interceptor.ShouldInterceptWrite)
+                {
+                    interceptor.WriteProperty(ref context, next);
+                }
+                else
+                {
+                    next(ref context);
+                }
+            },
             static (ref interception, innerWriteValue) =>
             {
                 innerWriteValue(interception.Property.Subject, interception.NewValue);

--- a/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
@@ -1,7 +1,18 @@
-﻿namespace Namotion.Interceptor.Interceptors;
+﻿using System.Runtime.CompilerServices;
+
+namespace Namotion.Interceptor.Interceptors;
 
 public interface IWriteInterceptor
 {
+    /// <summary>
+    /// Gets a value indicating whether this interceptor should intercept write operations (otherwise it is skipped for performance reasons).
+    /// </summary>
+    bool ShouldInterceptWrite
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get;
+    }
+    
     void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next);
 }
 


### PR DESCRIPTION
- Write interceptors which are not needed (observable, queue) are not called when not needed but registered
- It improves performance when there are interceptors which are not needed (no subscriptions)
- Might degrade performance when they are used
- Maybe better to not register them at all (conditional register when other features require them)