### PR TITLE
fix: Ignore changes for already detached subjects

### DIFF
--- a/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
@@ -49,6 +49,7 @@ public static class SubjectRegistryExtensions
     /// <param name="propertyName">The property name to find.</param>
     /// <param name="registry">The optional registry, otherwise the registry is resolved dynamically.</param>
     /// <returns>The registered property.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static RegisteredSubjectProperty? TryGetRegisteredProperty(this IInterceptorSubject subject, string propertyName, ISubjectRegistry? registry = null)
     {
         registry ??= subject.Context.GetService<ISubjectRegistry>();
@@ -62,6 +63,20 @@ public static class SubjectRegistryExtensions
     /// </summary>
     /// <param name="propertyReference">The property to find.</param>
     /// <returns>The registered property.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static RegisteredSubjectProperty? TryGetRegisteredProperty(this PropertyReference propertyReference)
+    {
+        return propertyReference.Subject
+            .TryGetRegisteredSubject()?
+            .TryGetProperty(propertyReference.Name);
+    }
+    
+    /// <summary>
+    /// Gets a registered property by name.
+    /// </summary>
+    /// <param name="propertyReference">The property to find.</param>
+    /// <returns>The registered property.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static RegisteredSubjectProperty GetRegisteredProperty(this PropertyReference propertyReference)
     {
         return propertyReference.Subject

--- a/src/Namotion.Interceptor.Sources/Updates/SubjectUpdate.cs
+++ b/src/Namotion.Interceptor.Sources/Updates/SubjectUpdate.cs
@@ -142,7 +142,7 @@ public class SubjectUpdate
                 var change = propertyChanges[index];
                 
                 var subjectUpdate = GetOrCreateSubjectUpdate(change.Property.Subject, knownSubjectUpdates);
-                var registeredProperty = change.Property.Subject.TryGetRegisteredProperty(change.Property.Name);
+                var registeredProperty = change.Property.TryGetRegisteredProperty();
                 if (registeredProperty is null)
                 {
                     continue; // property not registered because subject has been detached since update is detected (change not valid anymore)


### PR DESCRIPTION
There could be a race condition: 

```
person.Mother.FirstName = "Foo"  => triggers FullName change
person.Mother = null; => detaches mother from registry (person.Mother.FullName not attached anymore)

---

// subject updater sees both changes and 
// tries to process person.Mother.FirstName change 
// but cannot resolve property anymore (avoid exception)
```

subject updater is not sync but uses queue and batching that's why firstname change and mother set to null could be batched (firstname change buffered) and thus it is not valid and should be just thrown away when registered property is missing (ie the whole person has been detached) 