### PR TITLE
fix: Dictionary value replacement bug

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.WhenValueReplacedAtSameKey_ThenInsertAndRemoveOperationsAreCreated.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.WhenValueReplacedAtSameKey_ThenInsertAndRemoveOperationsAreCreated.verified.txt
@@ -1,0 +1,51 @@
+﻿{
+  Root: 1,
+  Subjects: {
+    1: {
+      Lookup: {
+        Kind: Collection,
+        Timestamp: DateTimeOffset_1,
+        Operations: [
+          {
+            Action: Insert,
+            Index: key1,
+            Id: 2
+          },
+          {
+            Index: key1
+          }
+        ],
+        Count: 1
+      }
+    },
+    2: {
+      Child: {
+        Kind: Item
+      },
+      Items: {
+        Kind: Collection,
+        Count: 0
+      },
+      Lookup: {
+        Kind: Collection,
+        Count: 0
+      },
+      Name: {
+        Kind: Value,
+        Value: ReplacementItem,
+        Attributes: {
+          Status: {
+            Kind: Value,
+            Value: active
+          }
+        }
+      },
+      Parent: {
+        Kind: Item
+      },
+      Self: {
+        Kind: Item
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Problem:** When replacing a value at an existing dictionary key with a different object, the diff algorithm only compared keys, not values. The new object was silently ignored.

```csharp
dict["key1"] = item1;
// later...
dict["key1"] = item2;  // Different object - was NOT included in update!
```

**Solution:** Modified `CollectionDiffBuilder.GetDictionaryChanges` to compare object references at existing keys. If the value changed, it's now treated as a Remove + Insert operation.

**Files Changed:**
- `src/Namotion.Interceptor.Connectors/Updates/Internal/CollectionDiffBuilder.cs`

## Test Coverage

### Attributes

| Scenario | Behavior | Status |
|----------|----------|--------|
| Complete update | All attributes included recursively | ✅ Tested |
| Partial: Attribute first, then value | Both included | ✅ **Fixed & Tested** |
| Partial: Value first, then attribute | Both included | ✅ Tested |
| Partial: Only value change | No unchanged attributes | ✅ Tested |
| Partial: Only attribute change | Only attributes (no value) | ✅ Tested |
| Nested attributes | Handled recursively | ✅ Tested |

### Properties (Values & Subject References)

| Scenario | Behavior | Status |
|----------|----------|--------|
| Complete: Value property | All values included | ✅ Tested |
| Complete: Subject reference | Nested subjects with ID refs | ✅ Tested |
| Complete: Null reference | `Kind: Item` with no Id | ✅ Tested |
| Partial: Value change | Only changed properties | ✅ Tested |
| Partial: Subject reference assigned | Path + new subject | ✅ Tested |
| Partial: Subject reference set to null | Null update generated | ✅ Tested |
| Partial: Multiple changes same subject | All properties accumulated | ✅ Tested |
| Partial: Timestamp preservation | Timestamps carried through | ✅ Tested |
| Cycles: Self-reference | ID refs prevent infinite loops | ✅ Tested |
| Cycles: Parent-child back-reference | Flat structure handles correctly | ✅ Tested |

### Collections (Arrays/Lists)

| Scenario | Behavior | Status |
|----------|----------|--------|
| Complete | All items with full data | ✅ Tested |
| Partial: Insert at end | Insert operation at correct index | ✅ Tested |
| Partial: Insert at beginning | Insert operation at index 0 | ✅ Tested |
| Partial: Remove | Remove operation at correct index | ✅ Tested |
| Partial: Move/reorder | Move operation (FromIndex → Index) | ✅ Tested |
| Partial: Item property change | Sparse update by index | ✅ Tested |
| Partial: Multiple item property changes | Multiple sparse updates | ✅ Tested |
| Partial: Insert + property update | Both operation types | ✅ Tested |
| Partial: Remove + Insert | Combined operations | ✅ Tested |
| Partial: Move + property update | Both operation types | ✅ Tested |
| Partial: Clear (all removed) | Remove operations for all | ✅ Tested |
| Partial: Populate from empty | Insert operations for all | ✅ Tested |
| Partial: Empty → Empty | No operations (no-op) | ✅ Tested |
| Apply: Insert | Item added at correct position | ✅ Tested |
| Apply: Remove | Item removed from correct position | ✅ Tested |
| Apply: Move | Item reordered correctly | ✅ Tested |
| Apply: Invalid index | Ignored gracefully | ✅ Tested |
| Apply: Negative index | Ignored gracefully | ✅ Tested |

### Dictionaries

| Scenario | Behavior | Status |
|----------|----------|--------|
| Complete | All entries with full data | ✅ Tested |
| Partial: Add key | Insert operation with key | ✅ Tested |
| Partial: Remove key | Remove operation with key | ✅ Tested |
| Partial: Item property change | Sparse update by key | ✅ Tested |
| Partial: Multiple item property changes | Multiple sparse updates | ✅ Tested |
| Partial: Add + Remove | Combined operations | ✅ Tested |
| Partial: Add + property update | Both types included | ✅ Tested |
| Partial: Replace value at same key | Remove + Insert | ✅ **Fixed & Tested** |
| Partial: Clear (all removed) | Remove operations for all | ✅ Tested |
| Partial: Populate from empty | Insert operations for all | ✅ Tested |
| Apply: Insert (add key) | Entry added | ✅ Tested |
| Apply: Remove (delete key) | Entry removed | ✅ Tested |