### PR TITLE
refactor: Improve handling of remove and move operations in subject updates

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateCollectionTests.WhenCollectionBecomesEmpty_ThenRemoveOperationsAreCreated.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateCollectionTests.WhenCollectionBecomesEmpty_ThenRemoveOperationsAreCreated.verified.txt
@@ -7,10 +7,10 @@
         Timestamp: DateTimeOffset_1,
         Operations: [
           {
-            Index: 0
+            Index: 1
           },
           {
-            Index: 1
+            Index: 0
           }
         ],
         Count: 0

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateTests.WhenGeneratingPartialSubjectDescription_ThenResultCollectionIsCorrect.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateTests.WhenGeneratingPartialSubjectDescription_ThenResultCollectionIsCorrect.verified.txt
@@ -7,10 +7,10 @@
         Timestamp: {Scrubbed},
         Operations: [
           {
-            Index: 0
+            Index: 1
           },
           {
-            Index: 1
+            Index: 0
           }
         ],
         Collection: [

--- a/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectCollectionUpdateApplier.cs
+++ b/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectCollectionUpdateApplier.cs
@@ -23,67 +23,57 @@ internal static class SubjectCollectionUpdateApplier
         var workingItems = (property.GetValue() as IEnumerable<IInterceptorSubject>)?.ToList() ?? [];
         var structureChanged = false;
 
-        // Apply structural operations
+        // Apply structural operations in two phases:
+        // Phase 1: Remove and Insert operations (applied sequentially)
+        // Phase 2: Move operations (applied atomically using snapshot)
         if (propertyUpdate.Operations is { Count: > 0 })
         {
-            // Move-only operations use original indices and must be applied atomically
-            if (propertyUpdate.Operations.All(op => op.Action == SubjectCollectionOperationType.Move))
+            // Phase 1: Apply Remove and Insert operations sequentially
+            // Removes should be in descending order so they don't affect each other's indices
+            foreach (var operation in propertyUpdate.Operations)
+            {
+                var index = ConvertIndexToInt(operation.Index);
+                switch (operation.Action)
+                {
+                    case SubjectCollectionOperationType.Remove:
+                        if (index >= 0 && index < workingItems.Count)
+                        {
+                            workingItems.RemoveAt(index);
+                            structureChanged = true;
+                        }
+                        break;
+
+                    case SubjectCollectionOperationType.Insert:
+                        if (operation.Id is not null && context.Subjects.TryGetValue(operation.Id, out var itemProps))
+                        {
+                            var newItem = CreateAndApplyItem(parent, property, index, operation.Id, itemProps, context);
+                            if (index >= workingItems.Count)
+                                workingItems.Add(newItem);
+                            else
+                                workingItems.Insert(index, newItem);
+                            structureChanged = true;
+                        }
+                        break;
+                }
+            }
+
+            // Phase 2: Apply Move operations atomically using snapshot
+            // Move indices reference the state after removes/inserts, and moves are applied simultaneously
+            var hasMoves = propertyUpdate.Operations.Any(op => op.Action == SubjectCollectionOperationType.Move);
+            if (hasMoves)
             {
                 var snapshot = workingItems.ToArray();
                 foreach (var operation in propertyUpdate.Operations)
                 {
-                    var toIndex = ConvertIndexToInt(operation.Index);
-                    var fromIndex = operation.FromIndex!.Value;
-                    if (fromIndex >= 0 && fromIndex < snapshot.Length && toIndex >= 0 && toIndex < workingItems.Count)
+                    if (operation.Action == SubjectCollectionOperationType.Move && operation.FromIndex.HasValue)
                     {
-                        workingItems[toIndex] = snapshot[fromIndex];
-                        structureChanged = true;
-                    }
-                }
-            }
-            else
-            {
-                foreach (var operation in propertyUpdate.Operations)
-                {
-                    var index = ConvertIndexToInt(operation.Index);
-                    switch (operation.Action)
-                    {
-                        case SubjectCollectionOperationType.Remove:
-                            if (index >= 0 && index < workingItems.Count)
-                            {
-                                workingItems.RemoveAt(index);
-                                structureChanged = true;
-                            }
-                            break;
-
-                        case SubjectCollectionOperationType.Insert:
-                            if (operation.Id is not null && context.Subjects.TryGetValue(operation.Id, out var itemProps))
-                            {
-                                var newItem = CreateAndApplyItem(parent, property, index, operation.Id, itemProps, context);
-                                if (index >= workingItems.Count)
-                                    workingItems.Add(newItem);
-                                else
-                                    workingItems.Insert(index, newItem);
-                                structureChanged = true;
-                            }
-                            break;
-
-                        case SubjectCollectionOperationType.Move:
-                            if (operation.FromIndex.HasValue)
-                            {
-                                var from = operation.FromIndex.Value;
-                                if (from >= 0 && from < workingItems.Count && index >= 0)
-                                {
-                                    var item = workingItems[from];
-                                    workingItems.RemoveAt(from);
-                                    if (index >= workingItems.Count)
-                                        workingItems.Add(item);
-                                    else
-                                        workingItems.Insert(index, item);
-                                    structureChanged = true;
-                                }
-                            }
-                            break;
+                        var toIndex = ConvertIndexToInt(operation.Index);
+                        var fromIndex = operation.FromIndex.Value;
+                        if (fromIndex >= 0 && fromIndex < snapshot.Length && toIndex >= 0 && toIndex < workingItems.Count)
+                        {
+                            workingItems[toIndex] = snapshot[fromIndex];
+                            structureChanged = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## refactor/improve-subject-update-code (current):

```

BenchmarkDotNet v0.15.5, macOS 26.2 (25C56) [Darwin 25.2.0]
Apple M4 Max, 1 CPU, 16 logical and 16 physical cores
.NET SDK 10.0.102
  [Host]     : .NET 9.0.10 (9.0.10, 9.0.1025.47515), Arm64 RyuJIT armv8.0-a
  DefaultJob : .NET 9.0.10 (9.0.10, 9.0.1025.47515), Arm64 RyuJIT armv8.0-a


```
| Method               | Mean     | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| CreateCompleteUpdate | 3.693 μs | 0.0172 μs | 0.0160 μs | 0.7057 | 0.0114 |   5.77 KB |
| CreatePartialUpdate  | 1.229 μs | 0.0071 μs | 0.0066 μs | 0.3166 | 0.0019 |   2.59 KB |



---

## master branch:

```

BenchmarkDotNet v0.15.5, macOS 26.2 (25C56) [Darwin 25.2.0]
Apple M4 Max, 1 CPU, 16 logical and 16 physical cores
.NET SDK 10.0.102
  [Host]     : .NET 9.0.10 (9.0.10, 9.0.1025.47515), Arm64 RyuJIT armv8.0-a
  DefaultJob : .NET 9.0.10 (9.0.10, 9.0.1025.47515), Arm64 RyuJIT armv8.0-a


```
| Method               | Mean     | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| CreateCompleteUpdate | 3.683 μs | 0.0152 μs | 0.0142 μs | 0.7057 | 0.0114 |   5.77 KB |
| CreatePartialUpdate  | 1.135 μs | 0.0051 μs | 0.0048 μs | 0.3166 | 0.0019 |   2.59 KB |


