### PR TITLE
Fix race condition in SubjectPropertyWriter replay loop

### DIFF
--- a/src/Namotion.Interceptor.Connectors/SubjectPropertyWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectPropertyWriter.cs
@@ -82,7 +82,6 @@ public sealed class SubjectPropertyWriter
                 return;
             }
 
-            _updates = null;
             foreach (var action in updates)
             {
                 try
@@ -94,6 +93,9 @@ public sealed class SubjectPropertyWriter
                     _logger.LogError(e, "Failed to apply subject update.");
                 }
             }
+
+            // Must be after replay: Write() reads _updates without lock on the fast path.
+            _updates = null;
         }
     }
 


### PR DESCRIPTION
## Problem

`SubjectPropertyWriter.Write()` reads `_updates` **without the lock** as a fast-path optimization (line 116). When `_updates` is `null`, it bypasses the lock entirely and applies the update directly.

In `LoadInitialStateAndResumeAsync()`, `_updates` was set to `null` **before** the buffered replay loop — while still inside the lock. This created a race condition:

1. **Thread A** (replay) holds the lock, sets `_updates = null`, starts iterating buffered actions
2. **Thread B** (`Write()`) reads `_updates` outside the lock → sees `null` → skips the lock entirely
3. **Thread B** calls `update(state)` directly, **concurrently with the replay loop** in Thread A
4. Both threads mutate the subject with no synchronization

## Before

```csharp
lock (_lock)
{
    applyAction?.Invoke();
    var updates = _updates;
    if (updates is null) { return; }

    _updates = null; // ← Set BEFORE replay — concurrent Write() sees null and races
    foreach (var action in updates)
    {
        action();
    }
}
```

## After

```csharp
lock (_lock)
{
    applyAction?.Invoke();
    var updates = _updates;
    if (updates is null) { return; }

    foreach (var action in updates)
    {
        action();
    }

    // Must be after replay: Write() reads _updates without lock on the fast path.
    _updates = null;
}
```

## Fix

Move `_updates = null` to **after** the replay loop completes. This ensures `_updates` remains non-null during replay, so any concurrent `Write()` call sees non-null on the fast path → enters the lock → blocks until replay finishes. No behavioral change otherwise — the entire block is inside the same lock.
