### PR TITLE
Throttle write retry queue flush failure warnings

### DIFF
--- a/src/Namotion.Interceptor.Connectors/WriteRetryQueue.cs
+++ b/src/Namotion.Interceptor.Connectors/WriteRetryQueue.cs
@@ -128,6 +128,7 @@ internal sealed class WriteRetryQueue : IDisposable
             }
 
             // Process in batches up to MaxBatchSize, looping until queue is empty
+            var totalFlushed = 0;
             while (true)
             {
                 // Dequeue up to buffer size
@@ -169,12 +170,13 @@ internal sealed class WriteRetryQueue : IDisposable
                     return false;
                 }
 
+                totalFlushed += count;
                 Array.Clear(_scratchBuffer, 0, count);
             }
 
             if (_hasFlushWarnings)
             {
-                _logger.LogInformation("Successfully flushed queued writes after retry.");
+                _logger.LogInformation("Successfully flushed {Count} queued writes after retry.", totalFlushed);
                 _hasFlushWarnings = false;
                 _lastFlushWarningTimestamp = 0;
             }


### PR DESCRIPTION
- Throttle flush-failure warnings in `WriteRetryQueue` to log at most once every 5 seconds (instead of on every failed attempt), preventing log spam during extended disconnections (e.g., OPC UA session not connected)
- Each throttled warning includes the current queue size for visibility
- Log an info message when queued writes are successfully flushed after retry

## Context

During OPC UA reconnection, every queued property change triggered a flush attempt, each logging a warning. This produced hundreds of identical warnings per second, making logs unusable.
