### PR TITLE
Add inheritance path tests for registry and connectors

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/Models/Employee.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Models/Employee.cs
@@ -1,0 +1,9 @@
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Connectors.Tests.Models;
+
+[InterceptorSubject]
+public partial class Employee : Person
+{
+    public partial string? Department { get; set; }
+}

--- a/src/Namotion.Interceptor.Connectors.Tests/Paths/InheritancePathTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Paths/InheritancePathTests.cs
@@ -1,0 +1,153 @@
+using Namotion.Interceptor.Connectors.Paths;
+using Namotion.Interceptor.Connectors.Tests.Models;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Paths;
+
+namespace Namotion.Interceptor.Connectors.Tests.Paths;
+
+public class InheritancePathTests
+{
+    [Fact]
+    public void WhenTryGetPropertyFromPath_InheritedPropertyOnDerivedSubject_ResolvesCorrectly()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var employee = new Employee(context) { FirstName = "Alice", Department = "Science" };
+
+        // Act — resolve inherited property by path
+        var (property, _) = employee
+            .TryGetPropertyFromPath("FirstName", DefaultPathProvider.Instance);
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal("FirstName", property.Name);
+    }
+
+    [Fact]
+    public void WhenTryGetPropertyFromPath_OwnPropertyOnDerivedSubject_ResolvesCorrectly()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var employee = new Employee(context) { FirstName = "Alice", Department = "Science" };
+
+        // Act — resolve own property by path
+        var (property, _) = employee
+            .TryGetPropertyFromPath("Department", DefaultPathProvider.Instance);
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal("Department", property.Name);
+    }
+
+    [Fact]
+    public void WhenTryGetPropertyFromPath_InheritedPropertyInCollection_ResolvesCorrectly()
+    {
+        // Arrange — matches reported scenario: Collection[0].InheritedProp where [0] is a derived type
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var employee = new Employee { FirstName = "Alice", Department = "Science" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children = [employee]
+        };
+
+        // Act — resolve inherited property through collection index
+        var (property, _) = person
+            .TryGetPropertyFromPath("Children[0].FirstName", DefaultPathProvider.Instance);
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal("FirstName", property.Name);
+        Assert.Equal(employee, property.Parent.Subject);
+    }
+
+    [Fact]
+    public void WhenTryGetPropertyFromPath_OwnPropertyInCollection_ResolvesCorrectly()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var employee = new Employee { FirstName = "Alice", Department = "Science" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children = [employee]
+        };
+
+        // Act — resolve derived-only property through collection index
+        var (property, _) = person
+            .TryGetPropertyFromPath("Children[0].Department", DefaultPathProvider.Instance);
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal("Department", property.Name);
+        Assert.Equal(employee, property.Parent.Subject);
+    }
+
+    [Fact]
+    public void WhenRoundTrip_InheritedPropertyInCollection_ResolvesBackToSameProperty()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var employee = new Employee { FirstName = "Alice", Department = "Science" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children = [employee]
+        };
+
+        // Act — round-trip: get path then resolve back
+        var originalProperty = employee.TryGetRegisteredProperty(e => e.FirstName)!;
+        var path = originalProperty.TryGetPath(DefaultPathProvider.Instance, null)!;
+        var (resolvedProperty, _) = person
+            .TryGetPropertyFromPath(path, DefaultPathProvider.Instance);
+
+        // Assert
+        Assert.Equal("Children[0].FirstName", path);
+        Assert.NotNull(resolvedProperty);
+        Assert.Equal(originalProperty.Name, resolvedProperty.Name);
+        Assert.Equal(originalProperty.Parent.Subject, resolvedProperty.Parent.Subject);
+    }
+
+    [Fact]
+    public void WhenRoundTrip_OwnPropertyInCollection_ResolvesBackToSameProperty()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var employee = new Employee { FirstName = "Alice", Department = "Science" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children = [employee]
+        };
+
+        // Act — round-trip for derived-only property
+        var originalProperty = employee.TryGetRegisteredProperty(e => e.Department)!;
+        var path = originalProperty.TryGetPath(DefaultPathProvider.Instance, null)!;
+        var (resolvedProperty, _) = person
+            .TryGetPropertyFromPath(path, DefaultPathProvider.Instance);
+
+        // Assert
+        Assert.Equal("Children[0].Department", path);
+        Assert.NotNull(resolvedProperty);
+        Assert.Equal(originalProperty.Name, resolvedProperty.Name);
+        Assert.Equal(originalProperty.Parent.Subject, resolvedProperty.Parent.Subject);
+    }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/InheritancePathTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/InheritancePathTests.cs
@@ -1,0 +1,170 @@
+using Namotion.Interceptor.Registry.Paths;
+using Namotion.Interceptor.Registry.Tests.Models;
+
+namespace Namotion.Interceptor.Registry.Tests;
+
+public class InheritancePathTests
+{
+    [Fact]
+    public void WhenTryGetPath_InheritedProperty_ReturnsPropertyName()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher(context) { FirstName = "Alice" };
+
+        // Act — FirstName is inherited from Person
+        var path = teacher
+            .TryGetRegisteredProperty(t => t.FirstName)?
+            .TryGetPath(DefaultPathProvider.Instance, null);
+
+        // Assert
+        Assert.Equal("FirstName", path);
+    }
+
+    [Fact]
+    public void WhenTryGetPath_OwnProperty_ReturnsPropertyName()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher(context) { MainCourse = "Math" };
+
+        // Act — MainCourse is declared on Teacher
+        var path = teacher
+            .TryGetRegisteredProperty(t => t.MainCourse)?
+            .TryGetPath(DefaultPathProvider.Instance, null);
+
+        // Assert
+        Assert.Equal("MainCourse", path);
+    }
+
+    [Fact]
+    public void WhenTryGetPath_NestedInheritedProperty_ReturnsFullPath()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher { FirstName = "Alice", MainCourse = "Math" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Mother = teacher
+        };
+
+        // Act — Mother is a Teacher, FirstName is inherited from Person
+        var path = teacher
+            .TryGetRegisteredProperty(t => t.FirstName)?
+            .TryGetPath(DefaultPathProvider.Instance, null);
+
+        // Assert
+        Assert.Equal("Mother.FirstName", path);
+    }
+
+    [Fact]
+    public void WhenTryGetPath_NestedOwnProperty_ReturnsFullPath()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher { FirstName = "Alice", MainCourse = "Math" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Mother = teacher
+        };
+
+        // Act — MainCourse is Teacher's own property
+        var path = teacher
+            .TryGetRegisteredProperty(t => t.MainCourse)?
+            .TryGetPath(DefaultPathProvider.Instance, null);
+
+        // Assert
+        Assert.Equal("Mother.MainCourse", path);
+    }
+
+    [Fact]
+    public void WhenTryGetPath_InheritedPropertyWithRootSubject_ReturnsRelativePath()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher { FirstName = "Alice", MainCourse = "Math" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Mother = teacher
+        };
+
+        // Act — get path relative to teacher itself
+        var path = teacher
+            .TryGetRegisteredProperty(t => t.FirstName)?
+            .TryGetPath(DefaultPathProvider.Instance, teacher);
+
+        // Assert
+        Assert.Equal("FirstName", path);
+    }
+
+    [Fact]
+    public void WhenGetAllProperties_OnInheritedSubject_IncludesBothBaseAndOwnProperties()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher(context) { FirstName = "Alice", MainCourse = "Math" };
+
+        // Act
+        var allPaths = teacher
+            .TryGetRegisteredSubject()?
+            .GetAllProperties()
+            .GetPaths(DefaultPathProvider.Instance, teacher)
+            .Select(p => p.path)
+            .Order()
+            .ToArray() ?? [];
+
+        // Assert
+        Assert.Contains("FirstName", allPaths);
+        Assert.Contains("MainCourse", allPaths);
+    }
+
+    [Fact]
+    public void WhenTeacherInCollection_ThenPathIncludesIndex()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var teacher = new Teacher { FirstName = "Alice", MainCourse = "Math" };
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children = [teacher]
+        };
+
+        // Act — inherited property through collection
+        var inheritedPath = teacher
+            .TryGetRegisteredProperty(t => t.FirstName)?
+            .TryGetPath(DefaultPathProvider.Instance, null);
+
+        var ownPath = teacher
+            .TryGetRegisteredProperty(t => t.MainCourse)?
+            .TryGetPath(DefaultPathProvider.Instance, null);
+
+        // Assert
+        Assert.Equal("Children[0].FirstName", inheritedPath);
+        Assert.Equal("Children[0].MainCourse", ownPath);
+    }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/Namotion.Interceptor.Registry.Tests.csproj
+++ b/src/Namotion.Interceptor.Registry.Tests/Namotion.Interceptor.Registry.Tests.csproj
@@ -27,7 +27,6 @@
         <ProjectReference Include="..\Namotion.Interceptor.AspNetCore\Namotion.Interceptor.AspNetCore.csproj" />
         <ProjectReference Include="..\Namotion.Interceptor.Generator\Namotion.Interceptor.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\Namotion.Interceptor.Testing\Namotion.Interceptor.Testing.csproj" />
-        <ProjectReference Include="..\Namotion.Interceptor.Connectors\Namotion.Interceptor.Connectors.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Add 7 registry-level tests verifying `TryGetPath` works with inherited properties on derived subjects (`Teacher : Person`)
- Add 6 connector-level tests verifying `TryGetPropertyFromPath` and round-trip path resolution with inheritance (`Employee : Person`)
- Add `Employee` test model in Connectors.Tests
- Remove stale Connectors project reference from Registry.Tests