### PR TITLE
fix: Use null fallback baseline in LifecycleInterceptor.WriteProperty

### DIFF
--- a/docs/design/tracking-lifecycle.md
+++ b/docs/design/tracking-lifecycle.md
@@ -63,7 +63,7 @@ _lastProcessedValues[(subject, "Collection")] = current collection reference
 _lastProcessedValues[(subject, "ObjectRef")]   = current child subject
 ```
 
-This establishes the initial baseline. Without seeding, the first `WriteProperty` would fall back to `context.CurrentValue`, which could be wrong if another thread wrote between attach and the first write.
+This establishes the initial baseline. Without seeding, the first `WriteProperty` would fall back to `null` (meaning "nothing was ever processed"), which triggers a full diff against the backing store — correct but slightly more work than diffing against a known baseline.
 
 ### 2. Updated on every structural write
 
@@ -81,10 +81,10 @@ On the next `WriteProperty` for the same property:
 
 ```csharp
 if (!_lastProcessedValues.TryGetValue(context.Property, out var lastProcessed))
-    lastProcessed = context.CurrentValue;  // fallback for edge cases
+    lastProcessed = null;  // nothing was ever processed for this property
 ```
 
-The fallback to `context.CurrentValue` handles the rare case where no entry exists (e.g., a write to a property whose entry was concurrently removed by a parent detach).
+The fallback to `null` handles the rare case where no entry exists (e.g., a write to a property whose entry was concurrently removed by a parent detach). Using `null` rather than `context.CurrentValue` is important: `context.CurrentValue` reflects what is *in the backing store*, not what the lifecycle *actually processed*. If the property already contains children that were never attached, `context.CurrentValue` would make them look "already processed", causing `ReferenceEquals` to skip re-discovery. `null` honestly represents "nothing was processed" and ensures the diff discovers all children in the backing store.
 
 ### 4. Read during detach (instead of backing store)
 
@@ -149,8 +149,8 @@ Thread X processes Thread Y's write; Thread Y becomes a no-op. Correct and effic
 1. Thread A: detaching parent → `_attachedSubjects.Remove(parent)`
 2. Thread B: `next()` wrote new child to backing store (before lock)
 3. Thread A: reads `_lastProcessedValues` → detaches old children → removes entries → releases lock
-4. Thread B: acquires lock → no `_lastProcessedValues` entry → falls back to `context.CurrentValue`
-   - Diffs, attaches new child, writes `_lastProcessedValues`
+4. Thread B: acquires lock → no `_lastProcessedValues` entry → falls back to `null`
+   - Diffs `null` vs backing store, attaches new child, writes `_lastProcessedValues`
    - Parent-dead check fires → undo (removes entry, detaches child)
 
 No leak.

--- a/src/Namotion.Interceptor.Tracking.Tests/Lifecycle/RecursiveAttachTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Lifecycle/RecursiveAttachTests.cs
@@ -1,0 +1,317 @@
+using Namotion.Interceptor.Tracking.Lifecycle;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests.Lifecycle;
+
+/// <summary>
+/// Tests that verify recursive discovery of descendants when subjects enter the graph.
+/// Discovery happens through ContextInheritanceHandler → AttachSubjectToContext, which
+/// seeds _lastProcessedValues and recursively attaches children.
+///
+/// WithLifecycle() alone does NOT discover grandchildren — subjects must have the
+/// context (via inheritance or manual assignment) for the lifecycle interceptor to
+/// observe their properties.
+/// </summary>
+public class RecursiveAttachTests
+{
+    // ──────────────────────────────────────────────
+    // Context inheritance discovers all descendants
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void WhenChildWithPrePopulatedGrandchildIsAttached_ThenGrandchildIsAlsoAttached()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+        var attached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var grandmother = new Person { FirstName = "Grandmother" };
+        var mother = new Person { FirstName = "Mother", Mother = grandmother };
+
+        // Act
+        parent.Mother = mother;
+
+        // Assert — both Mother and Grandmother must be attached
+        Assert.Contains(mother, attached);
+        Assert.Contains(grandmother, attached);
+    }
+
+    [Fact]
+    public void WhenChildWithPrePopulatedCollectionIsAttached_ThenCollectionChildrenAreAlsoAttached()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+        var attached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var grandchild1 = new Person { FirstName = "Grandchild1" };
+        var grandchild2 = new Person { FirstName = "Grandchild2" };
+        var mother = new Person { FirstName = "Mother", Children = [grandchild1, grandchild2] };
+
+        // Act
+        parent.Mother = mother;
+
+        // Assert
+        Assert.Contains(grandchild1, attached);
+        Assert.Contains(grandchild2, attached);
+    }
+
+    [Fact]
+    public void WhenDeepHierarchyIsAttached_ThenAllLevelsAreAttached()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+        var attached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var greatGrandmother = new Person { FirstName = "GreatGrandmother" };
+        var grandmother = new Person { FirstName = "Grandmother", Mother = greatGrandmother };
+        var mother = new Person { FirstName = "Mother", Mother = grandmother };
+
+        // Act
+        parent.Mother = mother;
+
+        // Assert — all three levels must be attached
+        Assert.Contains(mother, attached);
+        Assert.Contains(grandmother, attached);
+        Assert.Contains(greatGrandmother, attached);
+    }
+
+    // ──────────────────────────────────────────────
+    // Detach cascade cleans up discovered hierarchy
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void WhenParentOfDiscoveredHierarchyIsDetached_ThenAllLevelsAreDetached()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var grandmother = new Person { FirstName = "Grandmother" };
+        var mother = new Person { FirstName = "Mother", Mother = grandmother };
+        parent.Mother = mother;
+
+        var detached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectDetaching += change =>
+        {
+            if (change.IsContextDetach)
+                detached.Add(change.Subject);
+        };
+
+        // Act
+        parent.Mother = null;
+
+        // Assert — both Mother and Grandmother must be detached
+        Assert.Contains(mother, detached);
+        Assert.Contains(grandmother, detached);
+    }
+
+    [Fact]
+    public void WhenCollectionIsCleared_ThenDiscoveredGrandchildrenAreDetached()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var grandchild = new Person { FirstName = "Grandchild" };
+        var child = new Person { FirstName = "Child", Children = [grandchild] };
+        parent.Children = [child];
+
+        var detached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectDetaching += change =>
+        {
+            if (change.IsContextDetach)
+                detached.Add(change.Subject);
+        };
+
+        // Act
+        parent.Children = [];
+
+        // Assert
+        Assert.Contains(child, detached);
+        Assert.Contains(grandchild, detached);
+    }
+
+    // ──────────────────────────────────────────────
+    // Subsequent writes diff correctly against seeded baseline
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void WhenGrandchildIsReplacedAfterDiscovery_ThenOldIsDetachedAndNewIsAttached()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var grandmother = new Person { FirstName = "Grandmother" };
+        var mother = new Person { FirstName = "Mother", Mother = grandmother };
+        parent.Mother = mother;
+
+        var attached = new List<IInterceptorSubject>();
+        var detached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+        lifecycleInterceptor.SubjectDetaching += change =>
+        {
+            if (change.IsContextDetach)
+                detached.Add(change.Subject);
+        };
+
+        // Act — replace grandmother with a new one
+        var newGrandmother = new Person { FirstName = "NewGrandmother" };
+        mother.Mother = newGrandmother;
+
+        // Assert
+        Assert.Contains(grandmother, detached);
+        Assert.Contains(newGrandmother, attached);
+    }
+
+    // ──────────────────────────────────────────────
+    // Cycles must not cause infinite recursion
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void WhenCyclicGraphIsAttached_ThenAllSubjectsAreAttachedWithoutInfiniteRecursion()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithContextInheritance();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+        var attached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        // Create cycle: A.Mother = B, B.Mother = A
+        var nodeA = new Person { FirstName = "NodeA" };
+        var nodeB = new Person { FirstName = "NodeB" };
+        nodeA.Mother = nodeB;
+        nodeB.Mother = nodeA;
+
+        // Act — attach the cycle
+        parent.Mother = nodeA;
+
+        // Assert — both nodes attached, no stack overflow
+        Assert.Contains(nodeA, attached);
+        Assert.Contains(nodeB, attached);
+    }
+
+    // ──────────────────────────────────────────────
+    // WithLifecycle() alone: only direct children tracked
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void WhenUsingLifecycleWithoutContextInheritance_ThenOnlyDirectChildrenAreAttached()
+    {
+        // Arrange — WithLifecycle() alone, no context inheritance
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+        var attached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+
+        var parent = new Person(context) { FirstName = "Parent" };
+
+        var grandmother = new Person { FirstName = "Grandmother" };
+        var mother = new Person { FirstName = "Mother", Mother = grandmother };
+
+        // Act
+        parent.Mother = mother;
+
+        // Assert — only direct child is attached, grandchild is NOT
+        // (grandmother has no context, lifecycle can't observe her)
+        Assert.Contains(mother, attached);
+        Assert.DoesNotContain(grandmother, attached);
+    }
+
+    // ──────────────────────────────────────────────
+    // Null fallback: re-attached child without re-seeding
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void WhenReattachedChildWritesSameValue_ThenGrandchildIsRediscovered()
+    {
+        // Arrange — WithLifecycle() only (no context inheritance, no equality check).
+        // Child has context from constructor, so its property writes go through
+        // the lifecycle interceptor.
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle();
+
+        var lifecycleInterceptor = context.TryGetLifecycleInterceptor()!;
+
+        var parent = new Person(context) { FirstName = "Parent" };
+        var child = new Person(context) { FirstName = "Child" };
+        var grandmother = new Person(context) { FirstName = "Grandmother" };
+
+        // Build hierarchy: parent → child → grandmother
+        child.Mother = grandmother;
+        parent.Mother = child;
+
+        // Detach child → isLastDetach → _lastProcessedValues entries removed,
+        // grandmother detached via cascade
+        parent.Mother = null;
+
+        // Re-attach child — no ContextInheritanceHandler, so no AttachSubjectToContext,
+        // no re-seeding of _lastProcessedValues for child's properties
+        parent.Mother = child;
+
+        // At this point: child.Mother backing store = grandmother, but
+        // _lastProcessedValues[child.Mother] doesn't exist (removed during detach).
+        // grandmother was detached and is NOT currently tracked.
+
+        var attached = new List<IInterceptorSubject>();
+        lifecycleInterceptor.SubjectAttached += change => attached.Add(change.Subject);
+
+        // Act — re-write the same value to child.Mother (no equality interceptor to block it).
+        // This triggers WriteProperty with no _lastProcessedValues entry → fallback fires.
+        //
+        // With context.CurrentValue fallback: old = grandmother, new = grandmother
+        //   → ReferenceEquals → early return → grandmother NOT re-attached (BUG)
+        //
+        // With null fallback: old = null, new = grandmother
+        //   → diff → attach grandmother (CORRECT)
+        child.Mother = grandmother;
+
+        // Assert
+        Assert.Contains(grandmother, attached);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
@@ -298,7 +298,7 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
         lock (_attachedSubjects)
         {
             if (!_lastProcessedValues.TryGetValue(context.Property, out var lastProcessed))
-                lastProcessed = context.CurrentValue;
+                lastProcessed = null;
 
             // Read the actual backing store value to handle concurrent writes correctly.
             // context.NewValue may differ from the backing store if another thread


### PR DESCRIPTION
## Summary

- Fix incorrect fallback baseline in `WriteProperty` when `_lastProcessedValues` has no entry: use `null` instead of `context.CurrentValue`. The previous fallback treated unprocessed children as "already processed", causing `ReferenceEquals` to skip re-discovery after detach/re-attach cycles.
- Add 9 tests covering recursive attach behavior (context inheritance discovery, detach cascade, cycles, `WithLifecycle()` boundary, and the specific fallback bug scenario).
- Update `docs/design/tracking-lifecycle.md` to reflect the null fallback and explain why.

## Test plan

- [x] New test `WhenReattachedChildWritesSameValue_ThenGrandchildIsRediscovered` fails with `context.CurrentValue`, passes with `null`
- [x] All 9 RecursiveAttachTests pass
- [x] All 188 Tracking tests pass
- [x] All 109 Registry tests pass (including 7 concurrent structural write leak tests)
- [x] Full solution test suite green