### PR TITLE
fix: Prevent derived property from appearing in its own required properties

### DIFF
--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -227,9 +227,11 @@ public class RegisteredSubject
 
         var property = AddPropertyInternal(name, type, attributes);
 
-        // Trigger the initial change event with CurrentValue=null to indicate a new property.
-        // Using null (not readValue) ensures interceptors see a null→value transition,
-        // which is correct for lifecycle tracking of subjects in the initial value.
+        // Fires a null→value transition for lifecycle tracking of subject-valued initial values.
+        // TODO(perf): For derived-with-setter this re-enters RecalculateDerivedProperty (total
+        // 3 getter invocations: AttachProperty + invoke below + recalc), but AttachProperty has
+        // already seeded LastKnownValue. Consider a dedicated lifecycle notification for derived,
+        // or passing currentValue so PropertyValueEqualityCheckHandler short-circuits the write.
         property.Reference.SetPropertyValueWithInterception(getValue?.Invoke(Subject) ?? null,
             null, delegate { });
 

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRecorderTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRecorderTests.cs
@@ -7,14 +7,19 @@ public class DerivedPropertyRecorderTests
 {
     private static DerivedPropertyRecorder CreateRecorder() => new();
 
+    private static PropertyReference CreateSelf(IInterceptorSubject subject) =>
+        new(subject, "__SelfUnderTest");
+
     [Fact]
     public void StartRecording_SetsIsRecordingTrue()
     {
         // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
         var recorder = CreateRecorder();
 
         // Act
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
 
         // Assert
         Assert.True(recorder.IsRecording);
@@ -24,8 +29,10 @@ public class DerivedPropertyRecorderTests
     public void FinishRecording_SetsIsRecordingFalse()
     {
         // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
         var recorder = CreateRecorder();
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
 
         // Act
         _ = recorder.FinishRecording();
@@ -43,7 +50,7 @@ public class DerivedPropertyRecorderTests
         var recorder = CreateRecorder();
         var property = new PropertyReference(person, nameof(Person.FirstName));
 
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
 
         // Act
         recorder.TouchProperty(ref property);
@@ -63,7 +70,7 @@ public class DerivedPropertyRecorderTests
         var recorder = CreateRecorder();
         var property = new PropertyReference(person, nameof(Person.FirstName));
 
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
 
         // Act - touch same property multiple times
         recorder.TouchProperty(ref property);
@@ -85,7 +92,7 @@ public class DerivedPropertyRecorderTests
         var firstNameProperty = new PropertyReference(person, nameof(Person.FirstName));
         var lastNameProperty = new PropertyReference(person, nameof(Person.LastName));
 
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
 
         // Act
         recorder.TouchProperty(ref firstNameProperty);
@@ -96,6 +103,65 @@ public class DerivedPropertyRecorderTests
         Assert.Equal(2, recorded.Length);
         Assert.Contains(firstNameProperty, recorded.ToArray());
         Assert.Contains(lastNameProperty, recorded.ToArray());
+    }
+
+    [Fact]
+    public void TouchProperty_SkipsSelfReference()
+    {
+        // The derived property's outer interceptor-chain read fires ReadProperty on itself,
+        // which must not be recorded as a dependency.
+
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var recorder = CreateRecorder();
+        var selfProperty = new PropertyReference(person, nameof(Person.FullName));
+        var firstNameProperty = new PropertyReference(person, nameof(Person.FirstName));
+
+        recorder.StartRecording(selfProperty);
+
+        // Act - touch both the self-ref and a real dependency
+        recorder.TouchProperty(ref selfProperty);
+        recorder.TouchProperty(ref firstNameProperty);
+        var recorded = recorder.FinishRecording();
+
+        // Assert - only the real dependency is recorded
+        Assert.Single(recorded.ToArray());
+        Assert.Equal(firstNameProperty, recorded.ToArray()[0]);
+    }
+
+    [Fact]
+    public void NestedRecording_EachFrameSkipsOnlyItsOwnSelf()
+    {
+        // Nested recording: outer frame records inner's property; inner frame records its own deps.
+        // Each frame must exclude only its own self-ref, not the other's.
+
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var recorder = CreateRecorder();
+        var outerSelf = new PropertyReference(person, "OuterDerived");
+        var innerSelf = new PropertyReference(person, "InnerDerived");
+        var firstNameProperty = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act - outer frame touches inner's self-ref (legitimate dependency on the inner derived);
+        //       inner frame touches its own self-ref (must be filtered).
+        recorder.StartRecording(outerSelf);
+        recorder.TouchProperty(ref innerSelf);
+
+        recorder.StartRecording(innerSelf);
+        recorder.TouchProperty(ref innerSelf);       // filtered (inner's self)
+        recorder.TouchProperty(ref firstNameProperty);
+        var innerRecorded = recorder.FinishRecording();
+
+        var outerRecorded = recorder.FinishRecording();
+
+        // Assert
+        Assert.Single(innerRecorded.ToArray());
+        Assert.Equal(firstNameProperty, innerRecorded.ToArray()[0]);
+
+        Assert.Single(outerRecorded.ToArray());
+        Assert.Equal(innerSelf, outerRecorded.ToArray()[0]);
     }
 
     [Fact]
@@ -115,10 +181,10 @@ public class DerivedPropertyRecorderTests
         var fatherProperty = new PropertyReference(person, nameof(Person.Father));
 
         // Act - nested recording
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
         recorder.TouchProperty(ref firstNameProperty);
 
-        recorder.StartRecording(); // Nested
+        recorder.StartRecording(CreateSelf(person)); // Nested
         recorder.TouchProperty(ref lastNameProperty);
         recorder.TouchProperty(ref fatherProperty);
         var innerRecorded = recorder.FinishRecording();
@@ -142,7 +208,7 @@ public class DerivedPropertyRecorderTests
         var person = new Person(context);
         var recorder = CreateRecorder();
 
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
 
         // Act - add more properties than initial buffer size (8)
         var properties = new List<PropertyReference>();
@@ -174,7 +240,7 @@ public class DerivedPropertyRecorderTests
         // Act - multiple sessions
         for (var session = 0; session < 10; session++)
         {
-            recorder.StartRecording();
+            recorder.StartRecording(CreateSelf(person));
             for (var i = 0; i < 5; i++)
             {
                 var property = new PropertyReference(person, $"Prop{i}");
@@ -197,7 +263,7 @@ public class DerivedPropertyRecorderTests
         var recorder = CreateRecorder();
         var property = new PropertyReference(person, nameof(Person.FirstName));
 
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
         recorder.TouchProperty(ref property);
         _ = recorder.FinishRecording();
 
@@ -205,7 +271,7 @@ public class DerivedPropertyRecorderTests
         recorder.ClearLastRecording();
 
         // Assert - next recording session should start fresh
-        recorder.StartRecording();
+        recorder.StartRecording(CreateSelf(person));
         var recorded = recorder.FinishRecording();
         Assert.Equal(0, recorded.Length);
     }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
@@ -144,11 +144,40 @@ public class DerivedPropertyRequiredPropertiesTests
     }
 
     [Fact]
+    public void WhenDerivedAttributeIsEvaluated_ThenRequiredPropertiesDoesNotContainItself()
+    {
+        // AddDerivedAttribute routes through AddDerivedProperty with a "Name@Attr" property name,
+        // so self-ref filtering must apply transparently.
+
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+        var firstNameProperty = registered.TryGetProperty(nameof(Person.FirstName))!;
+
+        var derivedAttribute = firstNameProperty.AddDerivedAttribute(
+            "Upper",
+            typeof(string),
+            s => ((Person)s).FirstName?.ToUpperInvariant(),
+            setValue: null);
+
+        // Act
+        var deps = derivedAttribute.Reference.GetRequiredProperties().ToArray();
+
+        // Assert
+        Assert.DoesNotContain(derivedAttribute.Reference, deps);
+        Assert.Contains(new PropertyReference(person, nameof(Person.FirstName)), deps);
+    }
+
+    [Fact]
     public void WhenDynamicDerivedWithSetterShortCircuitsAtAttach_ThenSetterTriggeredRecalcDiscoversNewDependency()
     {
         // Pins the IsDerived guard in WriteProperty: a short-circuiting getter records zero deps
         // at attach, and the setter-triggered recalc must still run to surface new dependencies.
-        // Regressing the guard to HasRequiredProperties fails this test.
 
         // Arrange
         var context = InterceptorSubjectContext

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
@@ -46,12 +46,17 @@ public class DerivedPropertyRequiredPropertiesTests
 
         // Act
         var deps = dynamicDerived.Reference.GetRequiredProperties().ToArray();
+        var usedBy = dynamicDerived.Reference.GetUsedByProperties().Items.ToArray();
 
         // Assert
         Assert.DoesNotContain(dynamicDerived.Reference, deps);
         Assert.Contains(new PropertyReference(person, nameof(Person.FirstName)), deps);
         Assert.Contains(new PropertyReference(person, nameof(Person.LastName)), deps);
         Assert.Equal(2, deps.Length);
+
+        // Symmetric: the derived property must not appear in its own used-by list either
+        // (a self-ref in RequiredProperties would transitively register itself in UsedBy).
+        Assert.DoesNotContain(dynamicDerived.Reference, usedBy);
     }
 
     [Fact]
@@ -102,13 +107,15 @@ public class DerivedPropertyRequiredPropertiesTests
             "DoubledFirstName",
             s => ((Person)s).FirstName + ((Person)s).FirstName);
 
+        var firstNameReference = new PropertyReference(person, nameof(Person.FirstName));
+
         // Act
         var deps = dynamicDerived.Reference.GetRequiredProperties().ToArray();
 
         // Assert
         Assert.DoesNotContain(dynamicDerived.Reference, deps);
         Assert.Single(deps);
-        Assert.Equal(nameof(Person.FirstName), deps[0].Metadata.Name);
+        Assert.Equal(firstNameReference, deps[0]);
     }
 
     [Fact]
@@ -139,12 +146,9 @@ public class DerivedPropertyRequiredPropertiesTests
     [Fact]
     public void WhenDynamicDerivedWithSetterShortCircuitsAtAttach_ThenSetterTriggeredRecalcDiscoversNewDependency()
     {
-        // Pins the DerivedPropertyData.IsDerived guard in WriteProperty. Before that guard was
-        // introduced, the check used HasRequiredProperties — which was incorrectly true for dynamic
-        // derived properties only because self-reference pollution kept the deps list non-empty.
-        // Filtering self-refs made the short-circuit-at-attach case record zero deps, which would
-        // skip the setter-triggered recalc with the old guard and leave the getter permanently
-        // stale. Regressing the guard to HasRequiredProperties must fail this test.
+        // Pins the IsDerived guard in WriteProperty: a short-circuiting getter records zero deps
+        // at attach, and the setter-triggered recalc must still run to surface new dependencies.
+        // Regressing the guard to HasRequiredProperties fails this test.
 
         // Arrange
         var context = InterceptorSubjectContext
@@ -159,8 +163,7 @@ public class DerivedPropertyRequiredPropertiesTests
 
         var shortCircuitFlag = true;
 
-        // Getter short-circuits on shortCircuitFlag=true so FirstName is not read at attach →
-        // recorded deps are empty → IsDerived is the only correct guard for the setter recalc.
+        // shortCircuitFlag=true means FirstName is not read at attach → recorded deps are empty.
         var derived = registered.AddDerivedProperty<bool>(
             "ComputedFlag",
             _ => shortCircuitFlag || !string.IsNullOrEmpty(firstNameProperty.GetValue() as string),
@@ -168,15 +171,14 @@ public class DerivedPropertyRequiredPropertiesTests
 
         var derivedReference = derived.Reference;
 
-        // Sanity: attach left RequiredProperties empty (no FirstName dep recorded yet).
+        // Sanity: attach recorded zero deps.
         Assert.Empty(derivedReference.GetRequiredProperties().ToArray());
 
-        // Act — invoking the setter flips shortCircuitFlag=false, forcing a recalc that now reads
-        // FirstName. The IsDerived guard must allow this recalc despite empty prior deps.
+        // Act — setter flips the flag; the recalc now reads FirstName.
         derived.SetValue(false);
         var deps = derivedReference.GetRequiredProperties().ToArray();
 
-        // Assert — FirstName is now recorded as a dep; no self-ref present.
+        // Assert
         Assert.DoesNotContain(derivedReference, deps);
         Assert.Contains(firstNameReference, deps);
     }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
@@ -1,0 +1,183 @@
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+public class DerivedPropertyRequiredPropertiesTests
+{
+    [Fact]
+    public void WhenCompileTimeDerivedPropertyIsEvaluated_ThenRequiredPropertiesDoesNotContainItself()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+
+        var fullName = new PropertyReference(person, nameof(Person.FullName));
+        var fullNameWithPrefix = new PropertyReference(person, nameof(Person.FullNameWithPrefix));
+
+        // Act
+        _ = person.FullName;
+        _ = person.FullNameWithPrefix;
+
+        // Assert
+        Assert.DoesNotContain(fullName, fullName.GetRequiredProperties().ToArray());
+        Assert.DoesNotContain(fullNameWithPrefix, fullNameWithPrefix.GetRequiredProperties().ToArray());
+    }
+
+    [Fact]
+    public void WhenDynamicDerivedPropertyIsEvaluated_ThenRequiredPropertiesDoesNotContainItself()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+
+        var dynamicDerived = registered.AddDerivedProperty<string>(
+            "DynamicFull",
+            s => ((Person)s).FirstName + " " + ((Person)s).LastName);
+
+        // Act
+        var deps = dynamicDerived.Reference.GetRequiredProperties().ToArray();
+
+        // Assert
+        Assert.DoesNotContain(dynamicDerived.Reference, deps);
+        Assert.Contains(new PropertyReference(person, nameof(Person.FirstName)), deps);
+        Assert.Contains(new PropertyReference(person, nameof(Person.LastName)), deps);
+        Assert.Equal(2, deps.Length);
+    }
+
+    [Fact]
+    public void WhenNestedDynamicDerivedPropertiesAreEvaluated_ThenNeitherContainsItself()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+
+        var inner = registered.AddDerivedProperty<string>(
+            "DynamicFull",
+            s => ((Person)s).FirstName + " " + ((Person)s).LastName);
+
+        var outer = registered.AddDerivedProperty<string>(
+            "DynamicFullPrefixed",
+            s => "Mr. " + s.Properties["DynamicFull"].GetValue?.Invoke(s));
+
+        // Act
+        var innerDeps = inner.Reference.GetRequiredProperties().ToArray();
+        var outerDeps = outer.Reference.GetRequiredProperties().ToArray();
+
+        // Assert — inner must not contain itself; outer must not contain itself
+        Assert.DoesNotContain(inner.Reference, innerDeps);
+        Assert.DoesNotContain(outer.Reference, outerDeps);
+
+        // Outer should have recorded inner as a dependency (only the nested self-ref must be excluded)
+        Assert.Contains(inner.Reference, outerDeps);
+    }
+
+    [Fact]
+    public void WhenDynamicDerivedReadsSameDependencyTwice_ThenDedupedAndNoSelfRef()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+
+        var dynamicDerived = registered.AddDerivedProperty<string>(
+            "DoubledFirstName",
+            s => ((Person)s).FirstName + ((Person)s).FirstName);
+
+        // Act
+        var deps = dynamicDerived.Reference.GetRequiredProperties().ToArray();
+
+        // Assert
+        Assert.DoesNotContain(dynamicDerived.Reference, deps);
+        Assert.Single(deps);
+        Assert.Equal(nameof(Person.FirstName), deps[0].Metadata.Name);
+    }
+
+    [Fact]
+    public void WhenDynamicDerivedDependencyChanges_ThenRecalculationStillHasNoSelfRef()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+
+        var dynamicDerived = registered.AddDerivedProperty<string>(
+            "DynamicFull",
+            s => ((Person)s).FirstName + " " + ((Person)s).LastName);
+
+        // Act — mutate a dep to trigger recalculation and re-record
+        person.FirstName = "Changed";
+        var deps = dynamicDerived.Reference.GetRequiredProperties().ToArray();
+
+        // Assert
+        Assert.DoesNotContain(dynamicDerived.Reference, deps);
+        Assert.Equal(2, deps.Length);
+    }
+
+    [Fact]
+    public void WhenDynamicDerivedWithSetterShortCircuitsAtAttach_ThenSetterTriggeredRecalcDiscoversNewDependency()
+    {
+        // Pins the DerivedPropertyData.IsDerived guard in WriteProperty. Before that guard was
+        // introduced, the check used HasRequiredProperties — which was incorrectly true for dynamic
+        // derived properties only because self-reference pollution kept the deps list non-empty.
+        // Filtering self-refs made the short-circuit-at-attach case record zero deps, which would
+        // skip the setter-triggered recalc with the old guard and leave the getter permanently
+        // stale. Regressing the guard to HasRequiredProperties must fail this test.
+
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A" };
+        var registered = person.TryGetRegisteredSubject()!;
+        var firstNameProperty = registered.TryGetProperty(nameof(Person.FirstName))!;
+        var firstNameReference = new PropertyReference(person, nameof(Person.FirstName));
+
+        var shortCircuitFlag = true;
+
+        // Getter short-circuits on shortCircuitFlag=true so FirstName is not read at attach →
+        // recorded deps are empty → IsDerived is the only correct guard for the setter recalc.
+        var derived = registered.AddDerivedProperty<bool>(
+            "ComputedFlag",
+            _ => shortCircuitFlag || !string.IsNullOrEmpty(firstNameProperty.GetValue() as string),
+            (_, v) => shortCircuitFlag = v);
+
+        var derivedReference = derived.Reference;
+
+        // Sanity: attach left RequiredProperties empty (no FirstName dep recorded yet).
+        Assert.Empty(derivedReference.GetRequiredProperties().ToArray());
+
+        // Act — invoking the setter flips shortCircuitFlag=false, forcing a recalc that now reads
+        // FirstName. The IsDerived guard must allow this recalc despite empty prior deps.
+        derived.SetValue(false);
+        var deps = derivedReference.GetRequiredProperties().ToArray();
+
+        // Assert — FirstName is now recorded as a dep; no self-ref present.
+        Assert.DoesNotContain(derivedReference, deps);
+        Assert.Contains(firstNameReference, deps);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRequiredPropertiesTests.cs
@@ -82,6 +82,8 @@ public class DerivedPropertyRequiredPropertiesTests
         // Act
         var innerDeps = inner.Reference.GetRequiredProperties().ToArray();
         var outerDeps = outer.Reference.GetRequiredProperties().ToArray();
+        var innerUsedBy = inner.Reference.GetUsedByProperties().Items.ToArray();
+        var outerUsedBy = outer.Reference.GetUsedByProperties().Items.ToArray();
 
         // Assert — inner must not contain itself; outer must not contain itself
         Assert.DoesNotContain(inner.Reference, innerDeps);
@@ -89,6 +91,13 @@ public class DerivedPropertyRequiredPropertiesTests
 
         // Outer should have recorded inner as a dependency (only the nested self-ref must be excluded)
         Assert.Contains(inner.Reference, outerDeps);
+
+        // Symmetric: neither appears in its own used-by list.
+        Assert.DoesNotContain(inner.Reference, innerUsedBy);
+        Assert.DoesNotContain(outer.Reference, outerUsedBy);
+
+        // Outer should appear in inner's used-by list (consequence of outer depending on inner).
+        Assert.Contains(outer.Reference, innerUsedBy);
     }
 
     [Fact]
@@ -171,6 +180,63 @@ public class DerivedPropertyRequiredPropertiesTests
         // Assert
         Assert.DoesNotContain(derivedAttribute.Reference, deps);
         Assert.Contains(new PropertyReference(person, nameof(Person.FirstName)), deps);
+    }
+
+    [Fact]
+    public void WhenSourcePropertyHasDependents_ThenIsDerivedStaysFalse()
+    {
+        // A source property acquires DerivedPropertyData because a derived depends on it.
+        // Its IsDerived flag must stay false — otherwise WriteProperty would treat the source
+        // as derived-with-setter and trigger a spurious self-recalc on every write.
+
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+
+        registered.AddDerivedProperty<string>(
+            "DynamicFull",
+            s => ((Person)s).FirstName + " " + ((Person)s).LastName);
+
+        var firstNameReference = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var firstNameData = firstNameReference.TryGetDerivedPropertyData();
+
+        // Assert — data exists (created because DynamicFull depends on FirstName), but IsDerived is false.
+        Assert.NotNull(firstNameData);
+        Assert.False(firstNameData!.IsDerived);
+    }
+
+    [Fact]
+    public void WhenDerivedPropertyIsEvaluated_ThenIsDerivedIsTrue()
+    {
+        // Counterpart to the source-property test: ensure AttachProperty flips IsDerived
+        // for genuinely derived properties.
+
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithDerivedPropertyChangeDetection();
+
+        var person = new Person(context) { FirstName = "A", LastName = "B" };
+        var registered = person.TryGetRegisteredSubject()!;
+
+        var derived = registered.AddDerivedProperty<string>(
+            "DynamicFull",
+            s => ((Person)s).FirstName + " " + ((Person)s).LastName);
+
+        // Act
+        var derivedData = derived.Reference.TryGetDerivedPropertyData();
+
+        // Assert
+        Assert.NotNull(derivedData);
+        Assert.True(derivedData!.IsDerived);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -146,10 +146,9 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             return;
         }
 
-        // Derived-with-setter: Setter modifies state, but value comes from the getter → recalculate.
-        // Guard on data.IsDerived (not HasRequiredProperties): a getter that returns early without
-        // touching any tracked property records an empty dependency set at attach time and still
-        // needs recalculation once the setter runs — possibly surfacing new dependencies.
+        // Derived-with-setter: value comes from the getter, so setter changes require recalc.
+        // Guard on IsDerived (not HasRequiredProperties): a short-circuiting getter records zero
+        // deps at attach and still needs recalc to surface new dependencies.
         if (data.IsDerived && context.Property.Metadata.SetValue is not null)
         {
             var currentTimestampUtcTicks = SubjectChangeContext.Current.ChangedTimestampUtcTicks;
@@ -173,7 +172,9 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                 var dependent = usedByProperties[i];
                 if (dependent == context.Property)
                 {
-                    continue; // Skip self-references (rare edge case)
+                    // Defensive: DerivedPropertyRecorder filters self-refs, so this is unreachable
+                    // via the normal recorder path.
+                    continue;
                 }
 
                 RecalculateDerivedProperty(ref dependent, timestampUtcTicks);

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -62,7 +62,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             data.IsAttached = true;
             if (metadata.IsDerived)
             {
-                data.IsDerived = true;
+                Volatile.Write(ref data.IsDerived, true);
                 try
                 {
                     data.LastKnownValue = EvaluateAndStabilize(data, change.Property, callerHoldsLock: true);
@@ -146,10 +146,9 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             return;
         }
 
-        // Derived-with-setter: value comes from the getter, so setter changes require recalc.
-        // Guard on IsDerived (not HasRequiredProperties): a short-circuiting getter records zero
-        // deps at attach and still needs recalc to surface new dependencies.
-        if (data.IsDerived && context.Property.Metadata.SetValue is not null)
+        // Derived-with-setter: value comes from the getter, so setter changes require recalc
+        // even when the getter recorded zero deps (e.g. short-circuited at attach).
+        if (Volatile.Read(ref data.IsDerived) && context.Property.Metadata.SetValue is not null)
         {
             var currentTimestampUtcTicks = SubjectChangeContext.Current.ChangedTimestampUtcTicks;
             var property = context.Property;

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -62,6 +62,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             data.IsAttached = true;
             if (metadata.IsDerived)
             {
+                data.IsDerived = true;
                 try
                 {
                     data.LastKnownValue = EvaluateAndStabilize(data, change.Property, callerHoldsLock: true);
@@ -146,7 +147,10 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         }
 
         // Derived-with-setter: Setter modifies state, but value comes from the getter → recalculate.
-        if (data.HasRequiredProperties && context.Property.Metadata.SetValue is not null)
+        // Guard on data.IsDerived (not HasRequiredProperties): a getter that returns early without
+        // touching any tracked property records an empty dependency set at attach time and still
+        // needs recalculation once the setter runs — possibly surfacing new dependencies.
+        if (data.IsDerived && context.Property.Metadata.SetValue is not null)
         {
             var currentTimestampUtcTicks = SubjectChangeContext.Current.ChangedTimestampUtcTicks;
             var property = context.Property;
@@ -366,7 +370,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
 
         try
         {
-            StartRecordingTouchedProperties();
+            StartRecordingTouchedProperties(property);
             var result = property.Metadata.GetValue?.Invoke(property.Subject);
             var recordedDeps = _recorder!.FinishRecording();
 
@@ -397,7 +401,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             // Concurrent write detected while dependencies changed — stabilize.
             for (var iteration = 0; iteration < MaxStabilizationIterations; iteration++)
             {
-                StartRecordingTouchedProperties();
+                StartRecordingTouchedProperties(property);
                 result = property.Metadata.GetValue?.Invoke(property.Subject);
                 recordedDeps = _recorder.FinishRecording();
 
@@ -438,10 +442,10 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         }
     }
 
-    private static void StartRecordingTouchedProperties()
+    private static void StartRecordingTouchedProperties(in PropertyReference property)
     {
         _recorder ??= new DerivedPropertyRecorder();
-        _recorder.StartRecording();
+        _recorder.StartRecording(property);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyData.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyData.cs
@@ -68,18 +68,16 @@ internal sealed class DerivedPropertyData
     internal bool IsAttached = true;
 
     /// <summary>
-    /// True when this data belongs to a derived property; false for source properties
-    /// whose data exists only because a derived property depends on them.
-    /// Used by WriteProperty to identify derived-with-setter writes without re-reading
-    /// the property metadata in a hot path.
+    /// True if this data belongs to a derived property (vs. a source property whose data exists only
+    /// because a derived depends on it). Lets WriteProperty identify derived-with-setter writes
+    /// without touching metadata on the hot path.
     /// </summary>
     /// <remarks>
-    /// Write-once: set in AttachProperty under lock(this) when <c>metadata.IsDerived</c> is true,
-    /// never reset. Safe to read without a lock in WriteProperty: the full fence from
-    /// <c>Interlocked.Increment(ref _writeGeneration)</c> earlier in WriteProperty publishes
-    /// prior attach writes, and a stale <c>false</c> only skips a recalc that AttachProperty's
-    /// own initial EvaluateAndStabilize already performed. Metadata.IsDerived is immutable
-    /// per property, so there's nothing to reset on detach.
+    /// Write-once under lock(this) in AttachProperty; never reset (metadata.IsDerived is immutable).
+    /// Lock-free read in WriteProperty is safe: the <c>data</c> reference comes from
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, whose acquire
+    /// pairs with the <c>lock(data)</c> release in AttachProperty. A stale <c>false</c> in the narrow
+    /// pre-publish race only skips a recalc that AttachProperty's own EvaluateAndStabilize performs.
     /// </remarks>
     internal bool IsDerived;
 
@@ -93,7 +91,8 @@ internal sealed class DerivedPropertyData
     }
 
     /// <summary>
-    /// Whether this property has dependencies (has been evaluated as a derived property).
+    /// Whether any evaluation recorded dependencies. Do NOT use as an "is derived" proxy:
+    /// a short-circuiting derived getter legitimately records zero deps. Use <see cref="IsDerived"/> instead.
     /// </summary>
     internal bool HasRequiredProperties
     {

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyData.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyData.cs
@@ -73,11 +73,8 @@ internal sealed class DerivedPropertyData
     /// without touching metadata on the hot path.
     /// </summary>
     /// <remarks>
-    /// Write-once under lock(this) in AttachProperty; never reset (metadata.IsDerived is immutable).
-    /// Lock-free read in WriteProperty is safe: the <c>data</c> reference comes from
-    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, whose acquire
-    /// pairs with the <c>lock(data)</c> release in AttachProperty. A stale <c>false</c> in the narrow
-    /// pre-publish race only skips a recalc that AttachProperty's own EvaluateAndStabilize performs.
+    /// Written via <c>Volatile.Write</c> in AttachProperty, read via <c>Volatile.Read</c> in
+    /// WriteProperty. Write-once; never reset (metadata.IsDerived is immutable).
     /// </remarks>
     internal bool IsDerived;
 
@@ -88,16 +85,6 @@ internal sealed class DerivedPropertyData
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => Volatile.Read(ref _usedByProperties);
-    }
-
-    /// <summary>
-    /// Whether any evaluation recorded dependencies. Do NOT use as an "is derived" proxy:
-    /// a short-circuiting derived getter legitimately records zero deps. Use <see cref="IsDerived"/> instead.
-    /// </summary>
-    internal bool HasRequiredProperties
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _requiredProperties is not null;
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyData.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyData.cs
@@ -68,6 +68,22 @@ internal sealed class DerivedPropertyData
     internal bool IsAttached = true;
 
     /// <summary>
+    /// True when this data belongs to a derived property; false for source properties
+    /// whose data exists only because a derived property depends on them.
+    /// Used by WriteProperty to identify derived-with-setter writes without re-reading
+    /// the property metadata in a hot path.
+    /// </summary>
+    /// <remarks>
+    /// Write-once: set in AttachProperty under lock(this) when <c>metadata.IsDerived</c> is true,
+    /// never reset. Safe to read without a lock in WriteProperty: the full fence from
+    /// <c>Interlocked.Increment(ref _writeGeneration)</c> earlier in WriteProperty publishes
+    /// prior attach writes, and a stale <c>false</c> only skips a recalc that AttachProperty's
+    /// own initial EvaluateAndStabilize already performed. Metadata.IsDerived is immutable
+    /// per property, so there's nothing to reset on detach.
+    /// </remarks>
+    internal bool IsDerived;
+
+    /// <summary>
     /// Read-only access to used-by properties for public API.
     /// </summary>
     internal PropertyReferenceCollection? UsedByDependencies

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyRecorder.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyRecorder.cs
@@ -21,8 +21,9 @@ internal sealed class DerivedPropertyRecorder
     // Frame holds buffer and current count for one recording session
     private struct RecordingFrame
     {
-        public PropertyReference[]? Buffer; // Rented from pool, reused across sessions
-        public int Count;                   // Number of recorded items in this session
+        public PropertyReference Property;   // Property whose dependencies are being recorded (excluded from touches)
+        public PropertyReference[]? Buffer;  // Rented from pool, reused across sessions
+        public int Count;                    // Number of recorded items in this session
     }
 
     /// <summary>
@@ -33,7 +34,12 @@ internal sealed class DerivedPropertyRecorder
     /// <summary>
     /// Starts a new recording session. Reuses existing pooled buffer if available (allocation-free steady state).
     /// </summary>
-    public void StartRecording()
+    /// <param name="property">
+    /// The derived property being evaluated. Reads of this property via the outer interceptor chain
+    /// (e.g. <c>GetPropertyValue</c> wrapping on dynamic properties) are excluded from the recorded
+    /// dependency set so the property never depends on itself.
+    /// </param>
+    public void StartRecording(PropertyReference property)
     {
         // Grow frame stack if needed (rare - only happens on first use or deep nesting)
         if (_depth == _frames.Length)
@@ -42,6 +48,7 @@ internal sealed class DerivedPropertyRecorder
         // Get a frame for this depth level and reset count
         ref var frame = ref _frames[_depth++];
         frame.Count = 0;
+        frame.Property = property;
 
         // Rent pooled buffer if not already allocated (allocation-free on subsequent calls)
         frame.Buffer ??= _pool.Rent(8); // Typical derived property has < 8 dependencies
@@ -54,6 +61,16 @@ internal sealed class DerivedPropertyRecorder
     public void TouchProperty(ref PropertyReference property)
     {
         ref var frame = ref _frames[_depth - 1];
+
+        // Skip the self-read of the property being recorded. For dynamic derived properties,
+        // Metadata.GetValue is wrapped in GetPropertyValue(name, rawGetter), so invoking it from
+        // EvaluateAndStabilize re-enters the interceptor chain and fires ReadProperty for the
+        // derived property itself. Excluding it here keeps the property out of its own deps.
+        if (property == frame.Property)
+        {
+            return;
+        }
+
         var buffer = frame.Buffer!;
 
         // Deduplicate: Skip if already recorded in this session
@@ -103,5 +120,7 @@ internal sealed class DerivedPropertyRecorder
             Array.Clear(frame.Buffer!, 0, frame.Count);
             frame.Count = 0;
         }
+
+        frame.Property = default;
     }
 }

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyRecorder.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyRecorder.cs
@@ -32,14 +32,12 @@ internal sealed class DerivedPropertyRecorder
     public bool IsRecording => _depth > 0;
 
     /// <summary>
-    /// Starts a new recording session. Reuses existing pooled buffer if available (allocation-free steady state).
+    /// Starts a new recording session (reuses pooled buffer; allocation-free in steady state).
+    /// Reads of <paramref name="property"/> are filtered from the dependency set so a derived
+    /// property never depends on itself — needed because dynamic derived getters re-enter
+    /// <c>ReadProperty</c> via <c>GetPropertyValue</c> wrapping.
     /// </summary>
-    /// <param name="property">
-    /// The derived property being evaluated. Reads of this property via the outer interceptor chain
-    /// (e.g. <c>GetPropertyValue</c> wrapping on dynamic properties) are excluded from the recorded
-    /// dependency set so the property never depends on itself.
-    /// </param>
-    public void StartRecording(PropertyReference property)
+    public void StartRecording(in PropertyReference property)
     {
         // Grow frame stack if needed (rare - only happens on first use or deep nesting)
         if (_depth == _frames.Length)
@@ -62,10 +60,8 @@ internal sealed class DerivedPropertyRecorder
     {
         ref var frame = ref _frames[_depth - 1];
 
-        // Skip the self-read of the property being recorded. For dynamic derived properties,
-        // Metadata.GetValue is wrapped in GetPropertyValue(name, rawGetter), so invoking it from
-        // EvaluateAndStabilize re-enters the interceptor chain and fires ReadProperty for the
-        // derived property itself. Excluding it here keeps the property out of its own deps.
+        // Filter the self-read: dynamic derived getters re-enter ReadProperty for themselves via
+        // GetPropertyValue wrapping. See StartRecording.
         if (property == frame.Property)
         {
             return;


### PR DESCRIPTION
## Summary

- **Primary fix:** Dynamic derived properties (`AddDerivedProperty`) were listed in their own `GetRequiredProperties()` output. The recorder now tracks a per-frame "self" `PropertyReference` and filters self-reads in `TouchProperty`.
- **Latent fix surfaced by the primary fix:** The `WriteProperty` guard deciding whether to recalc a derived-with-setter after its setter runs used `HasRequiredProperties` as a proxy for "is derived." A getter that returns early without touching any tracked property recorded zero deps, so the old guard skipped the setter-triggered recalc and left the getter permanently stale. Replaced with a write-once `DerivedPropertyData.IsDerived` flag — same perf profile (no metadata lookup in hot path), correct semantics.

## Why this matters

**The self-ref was benign at runtime** — `WriteProperty` already skips `dependent == context.Property`. User-visible cost: one wasted array slot per dynamic derived, and a misleading public `GetRequiredProperties()` API (property appearing in its own deps list).

**The short-circuit bug was not benign** — e.g., `localFlag || SourceFlag` attached with `localFlag=true` never discovered `SourceFlag` after the setter flipped `localFlag=false`. The existing test `WhenDerivedPropertyWithSetterUsesShortCircuit_ThenDependenciesAreRerecordedOnSetValue` passed only because self-ref pollution kept `HasRequiredProperties` truthy.

## Changes

- `DerivedPropertyRecorder` — `RecordingFrame` now stores the property being recorded; `TouchProperty` filters touches matching it; filtering is per-frame so nested recordings each exclude only their own self-ref.
- `DerivedPropertyChangeHandler` — passes the property ref into `StartRecording` at both evaluation sites; write-path guard switched from `data.HasRequiredProperties` to `data.IsDerived`.
- `DerivedPropertyData` — new `internal bool IsDerived` field, write-once under lock in `AttachProperty`, lock-free-read-safe via the existing `_writeGeneration` full-fence.

## Tests

- `DerivedPropertyRequiredPropertiesTests` (new): 6 tests covering compile-time baseline, dynamic derived, nested dynamic derived, dedup, recalc-after-change, and a co-located test pinning the `IsDerived` guard against regression (verified fails when guard is reverted to `HasRequiredProperties`).
- `DerivedPropertyRecorderTests`: 2 new white-box tests for self-ref filtering in flat and nested recordings; all existing tests updated to pass the self ref.

## Test plan

- [x] `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"` — all 2000+ tests green
- [x] Manually regressed the `IsDerived` guard to `HasRequiredProperties` to confirm the new test fails, then restored