### PR TITLE
fix: abandon SDK-transferred OPC UA sessions after server restart [BLOCKED - investigating root cause]

### DIFF
--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaReconnectionTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaReconnectionTests.cs
@@ -129,6 +129,14 @@ public class OpcUaReconnectionTests
                     message: "Data should flow after restart");
                 logger.Log($"Client received: {client.Root.Name}");
 
+                // Wait for the manual reconnection to complete. The SDK reconnection
+                // is abandoned (transferred sessions are unreliable after server restart),
+                // and the health check triggers a fresh manual reconnection within ~5s.
+                await AsyncTestHelpers.WaitUntilAsync(
+                    () => client.Source!.Diagnostics.SuccessfulReconnections >= 1,
+                    timeout: TimeSpan.FromSeconds(30),
+                    message: "Manual reconnection should complete");
+
                 // Verify metrics
                 var finalAttempts = client.Source!.Diagnostics.TotalReconnectionAttempts;
                 var successfulReconnections = client.Source!.Diagnostics.SuccessfulReconnections;
@@ -145,14 +153,11 @@ public class OpcUaReconnectionTests
                 Assert.True(client.Source!.Diagnostics.IsConnected);
                 Assert.NotNull(client.Source.CurrentSession);
 
-                // Session swap visible to consumers. The reconnect cycle takes one of two paths
-                // depending on timing and server behavior:
-                //   A) SDK transfer succeeds → single (HadPrevious=true, HasCurrent=true) swap
-                //   B) SDK transfer fails / preserved session / stall reset →
-                //      (HadPrevious=true, HasCurrent=false) abandon + (HadPrevious=false, HasCurrent=true) recreate
-                // Either way, the consumer must see at least one transition releasing a previous
-                // session AND at least one transition with a current session — which together prove
-                // the connector raises events for both sides of the swap, including null transitions.
+                // Session swap visible to consumers. The SDK reconnection is always abandoned
+                // (transferred sessions are unreliable after server restart), so the cycle is:
+                //   (HadPrevious=true, HasCurrent=false) abandon + (HadPrevious=false, HasCurrent=true) recreate
+                // The consumer must see at least one transition releasing a previous session AND
+                // at least one transition with a current session.
                 lock (transitionsLock)
                 {
                     Assert.Contains(sessionTransitions, t => t.HadPrevious);

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
@@ -376,53 +376,21 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
 
                 if (!ReferenceEquals(oldSession, reconnectedSession))
                 {
+                    // New session object — the SDK created a fresh session (server restarted).
+                    // Transferred subscriptions on a restarted server are unreliable: the SDK's
+                    // response dispatcher can confuse PublishResponse with WriteResponse, causing
+                    // silent notification loss and write failures. Abandon the transferred session
+                    // and let the health check trigger a full manual reconnection with fresh
+                    // subscriptions that are guaranteed to work correctly.
                     _logger.LogInformation(
-                        "Reconnect created new OPC UA session (id={SessionId}, connected={Connected}).",
+                        "Reconnect created new OPC UA session (id={SessionId}, connected={Connected}). " +
+                        "Abandoning to trigger full reconnection with fresh subscriptions.",
                         reconnectedSession.SessionId,
                         reconnectedSession.Connected);
 
-                    // Check if subscriptions transferred BEFORE accepting the new session,
-                    // to avoid having two sessions that need disposal with only one pending slot.
-                    var transferredSubscriptions = reconnectedSession.Subscriptions.ToList();
-                    if (transferredSubscriptions.Count > 0)
-                    {
-                        // Transfer succeeded - accept new session, defer old session disposal
-                        if (oldSession is not null)
-                        {
-                            oldSession.KeepAlive -= OnKeepAlive;
-                            _sessionsToDispose.Enqueue(oldSession);
-                        }
-
-                        SetSession(reconnectedSession);
-                        ConfigureSession(reconnectedSession);
-
-                        SubscriptionManager.UpdateTransferredSubscriptions(transferredSubscriptions);
-
-                        // Signal the health check loop to perform a full state read.
-                        // We don't rely on subscription notifications alone because they can be
-                        // incomplete (notification queue overflow, timing gaps between address space
-                        // creation and ChangeQueueProcessor subscription on the server).
-                        Interlocked.Exchange(ref _needsFullStateSync, 1);
-
-                        _source.ReconnectionMetrics.RecordSuccess();
-                        _source.ClearLastError();
-
-                        _logger.LogInformation(
-                            "OPC UA session reconnected: Transferred {Count} subscriptions. Full state sync pending.",
-                            transferredSubscriptions.Count);
-                    }
-                    else
-                    {
-                        // Transfer failed - reject new session, abandon old session.
-                        // The reconnected session has a live TCP connection so it must be disposed.
-                        // The old session's connection is already dead (server restarted) and will be GC'd.
-                        _logger.LogWarning(
-                            "OPC UA session reconnected but subscription transfer failed (server restart). " +
-                            "Clearing session to trigger full reconnection via health check.");
-                        AbandonCurrentSession();
-                        reconnectedSession.KeepAlive -= OnKeepAlive;
-                        _sessionsToDispose.Enqueue(reconnectedSession);
-                    }
+                    AbandonCurrentSession();
+                    reconnectedSession.KeepAlive -= OnKeepAlive;
+                    _sessionsToDispose.Enqueue(reconnectedSession);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

- Always abandon SDK-transferred OPC UA sessions after server restart instead of trusting the transferred subscription
- The health check loop (5s interval) triggers a full manual reconnection with fresh subscriptions

## Problem

The OPC UA SDK's `SessionReconnectHandler` transfers subscriptions to a new session after server restart. Under concurrent write load (chaos testing), the transferred session's response dispatcher confuses `PublishResponse` with `WriteResponse`:

```
System.InvalidCastException: Unable to cast object of type 'Opc.Ua.PublishResponse' to type 'Opc.Ua.WriteResponse'.
   at Namotion.Interceptor.OpcUa.Client.OutboundWriter.WriteChangesAsync(...)
```

This causes:
1. **Write failures** — outbound writes get cast exceptions
2. **Silent notification loss** — publish responses are consumed by the wrong handler, subscription callbacks never fire

Clients appear connected but never receive updated values. Convergence fails after the full 5-minute timeout. Observed after 331 successful chaos cycles (server-only profile, ~0.3% failure rate).

## Investigation Status — BLOCKED

Investigating whether this is an OPC UA SDK regression in 1.5.378.134 vs 1.5.378.65.

### Possible causes

| Factor | 1000+ cycles (working) | 332 cycles (failing) |
|--------|----------------------|---------------------|
| OPC UA SDK | **1.5.378.65** | **1.5.378.134** |
| SubjectPropertyWriter race (PR #213) | Present (accidental mitigation) | Fixed |
| SDK reconnect handler | Old behavior | **PR #3471** changes `RecreateAsync` path |

### Key findings

**SDK version changed:** The 1000+ cycle runs used SDK **1.5.378.65**. Current code uses **1.5.378.134**. Between these versions, [OPCFoundation/UA-.NETStandard#3471](https://github.com/OPCFoundation/UA-.NETStandard/pull/3471) ("Fix session reconnect handler") changed the `RecreateAsync` call path. When `transportChannel` is null, it now calls `RecreateAsync(current)` without the transport channel, creating a brand new channel. This may introduce the response dispatcher confusion under concurrent writes.

**PR #213 race fix removed accidental mitigation:** Before PR #213, concurrent subscription notifications could interleave with the buffer replay, accidentally correcting stale values. The race fix blocks concurrent writes during replay, removing this accidental correction.

**SDK 1.5.378.65 has a memory leak** that's fixed in 1.5.378.134. We can't stay on the old SDK long-term.

### Verification steps

Chaos tester (`--launch-profile opcua-chaos --configuration Release`), clients at 500 mutations/sec.

| # | What | SDK version | Result |
|---|------|-------------|--------|
| 1 | Old SDK, 100/sec clients | 1.5.378.65 | 262 cycles passed, 0 failures (stopped) |
| 2 | Old SDK, 500/sec clients | 1.5.378.65 | **249 cycles passed, 0 failures** (stopped — memory leak in old SDK) |
| 3 | New SDK, 500/sec clients | 1.5.378.134 | ⏳ Running |
| 4 | This fix + new SDK | 1.5.378.134 | 39 cycles passed, stopped early |

**Combined old SDK results: 511 cycles, 0 failures.** If step 3 fails quickly, the SDK upgrade is confirmed as the cause.

### Next steps

- If step 3 confirms SDK regression → file issue on [OPCFoundation/UA-.NETStandard](https://github.com/OPCFoundation/UA-.NETStandard) with repro
- Consider whether to stay on this workaround (abandon transferred sessions) or fix the SDK interaction
- May need to use local SDK source reference (`UseLocalOpcUaProjects=true`) to patch the issue

## Test plan

- [x] All 4 `ServerRestart*` integration tests pass with fix
- [x] Full OPC UA test suite passes (240/240) with fix
- [ ] Confirm SDK regression with step 3
- [ ] Run final fix for 300+ cycles to validate