### PR TITLE
feature: Update OPC UA SDK package to upstream/master (post-1.5.378.134)

### DIFF
--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
@@ -173,7 +173,7 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
         var endpointConfiguration = EndpointConfiguration.Create(application.ApplicationConfiguration);
         var serverUri = new Uri(configuration.ServerUrl);
 
-        EndpointDescriptionCollection endpoints;
+        ArrayOf<EndpointDescription> endpoints;
         try
         {
             using var discoveryClient = await DiscoveryClient.CreateAsync(
@@ -181,7 +181,7 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
                 serverUri,
                 endpointConfiguration, ct: cancellationToken).ConfigureAwait(false);
 
-            endpoints = await discoveryClient.GetEndpointsAsync(null, cancellationToken).ConfigureAwait(false);
+            endpoints = await discoveryClient.GetEndpointsAsync(default, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -212,7 +212,7 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
             identity: configuration.CreateUserIdentity != null
                 ? await configuration.CreateUserIdentity(cancellationToken).ConfigureAwait(false)
                 : new UserIdentity(),
-            preferredLocales: null,
+            preferredLocales: default,
             cancellationToken).ConfigureAwait(false);
 
         var newSession = sessionResult as Session

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -149,7 +149,7 @@ internal class SubscriptionManager : IAsyncDisposable
         }
     }
 
-    private void OnFastDataChange(Subscription subscription, DataChangeNotification notification, IList<string> stringTable)
+    private void OnFastDataChange(Subscription subscription, DataChangeNotification notification, ArrayOf<string> stringTable)
     {
         if (_shuttingDown)
         {
@@ -175,8 +175,8 @@ internal class SubscriptionManager : IAsyncDisposable
                     changes.Add(new PropertyUpdate
                     {
                         Property = property,
-                        Value = _configuration.ValueConverter.ConvertToPropertyValue(item.Value.Value, property),
-                        Timestamp = item.Value.SourceTimestamp
+                        Value = _configuration.ValueConverter.ConvertToPropertyValue(item.Value.WrappedValue.AsBoxedObject(), property),
+                        Timestamp = item.Value.SourceTimestamp.ToDateTimeOffset()
                     });
                 }
             }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
@@ -361,7 +361,7 @@ public class OpcUaClientConfiguration
         var host = System.Net.Dns.GetHostName();
         var applicationUri = $"urn:{host}:Namotion.Interceptor:{ApplicationName}";
 
-        var config = new ApplicationConfiguration
+        var config = new ApplicationConfiguration(TelemetryContext)
         {
             ApplicationName = ApplicationName,
             ApplicationType = ApplicationType.Client,

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -26,7 +26,7 @@ public class OpcUaClientDiagnostics
     /// <summary>
     /// Gets the current session identifier, or null if not connected.
     /// </summary>
-    public string? SessionId => _source.SessionManager?.CurrentSession?.SessionId?.ToString();
+    public string? SessionId => _source.SessionManager?.CurrentSession?.SessionId.ToString();
 
     /// <summary>
     /// Gets the number of active OPC UA subscriptions.

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
@@ -184,16 +184,18 @@ internal sealed class OpcUaSubjectClientSource : BackgroundService, IOpcUaSubjec
         for (var offset = 0; offset < itemCount; offset += batchSize)
         {
             var take = Math.Min(batchSize, itemCount - offset);
-            var readValues = new ReadValueIdCollection(take);
+            var readValuesList = new List<ReadValueId>(take);
 
             for (var i = 0; i < take; i++)
             {
-                readValues.Add(new ReadValueId
+                readValuesList.Add(new ReadValueId
                 {
                     NodeId = ownedProperties[offset + i].NodeId,
                     AttributeId = Opc.Ua.Attributes.Value
                 });
             }
+
+            var readValues = readValuesList.ToArrayOf();
 
             var readResponse = await session.ReadAsync(
                 requestHeader: null,
@@ -218,8 +220,8 @@ internal sealed class OpcUaSubjectClientSource : BackgroundService, IOpcUaSubjec
         {
             foreach (var (property, dataValue) in result)
             {
-                var value = _configuration.ValueConverter.ConvertToPropertyValue(dataValue.Value, property);
-                property.SetValueFromSource(this, dataValue.SourceTimestamp, null, value);
+                var value = _configuration.ValueConverter.ConvertToPropertyValue(dataValue.WrappedValue.AsBoxedObject(), property);
+                property.SetValueFromSource(this, dataValue.SourceTimestamp.ToDateTimeOffset(), null, value);
             }
 
             _logger.LogInformation("Updated {Count} properties with OPC UA node values.", itemCount);
@@ -504,7 +506,14 @@ internal sealed class OpcUaSubjectClientSource : BackgroundService, IOpcUaSubjec
         if (_configuration.RootName is not null)
         {
             var references = await BrowseNodeAsync(session, ObjectIds.ObjectsFolder, cancellationToken).ConfigureAwait(false);
-            return references.FirstOrDefault(reference => reference.BrowseName.Name == _configuration.RootName);
+            foreach (var reference in references)
+            {
+                if (reference.BrowseName.Name == _configuration.RootName)
+                {
+                    return reference;
+                }
+            }
+            return null;
         }
 
         return new ReferenceDescription
@@ -618,7 +627,7 @@ internal sealed class OpcUaSubjectClientSource : BackgroundService, IOpcUaSubjec
         }
     }
 
-    private async Task<ReferenceDescriptionCollection> BrowseNodeAsync(
+    private async Task<ArrayOf<ReferenceDescription>> BrowseNodeAsync(
         Session session,
         NodeId nodeId,
         CancellationToken cancellationToken)

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectLoader.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectLoader.cs
@@ -395,13 +395,13 @@ internal class OpcUaSubjectLoader
         }
     }
 
-    private async Task<ReferenceDescriptionCollection> BrowseNodeAsync(
+    private async Task<List<ReferenceDescription>> BrowseNodeAsync(
         NodeId nodeId,
         ISession session,
         CancellationToken cancellationToken)
     {
-        var browseDescriptions = new BrowseDescriptionCollection
-        {
+        ArrayOf<BrowseDescription> browseDescriptions =
+        [
             new BrowseDescription
             {
                 NodeId = nodeId,
@@ -411,9 +411,9 @@ internal class OpcUaSubjectLoader
                 NodeClassMask = NodeClassMask,
                 ResultMask = (uint)BrowseResultMask.All
             }
-        };
+        ];
 
-        var results = new ReferenceDescriptionCollection();
+        var results = new List<ReferenceDescription>();
 
         var response = await session.BrowseAsync(
             null,
@@ -424,7 +424,10 @@ internal class OpcUaSubjectLoader
 
         if (response.Results.Count > 0 && StatusCode.IsGood(response.Results[0].StatusCode))
         {
-            results.AddRange(response.Results[0].References);
+            foreach (var reference in response.Results[0].References)
+            {
+                results.Add(reference);
+            }
 
             var continuationPoint = response.Results[0].ContinuationPoint;
             while (continuationPoint is { Length: > 0 })
@@ -436,9 +439,9 @@ internal class OpcUaSubjectLoader
                 if (nextResponse.Results.Count > 0 && StatusCode.IsGood(nextResponse.Results[0].StatusCode))
                 {
                     var r0 = nextResponse.Results[0];
-                    if (r0.References is { Count: > 0 } nextReferences)
+                    if (r0.References.Count > 0)
                     {
-                        foreach (var reference in nextReferences)
+                        foreach (var reference in r0.References)
                         {
                             results.Add(reference);
                         }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
@@ -24,7 +24,7 @@ public class OpcUaTypeResolver
         [
             new OpcUaNodeAttribute(reference.BrowseName.Name, namespaceUri)
             {
-                NodeIdentifier = reference.NodeId.Identifier.ToString(),
+                NodeIdentifier = reference.NodeId.IdentifierAsString,
                 NodeNamespaceUri = namespaceUri
             }
         ];
@@ -33,7 +33,7 @@ public class OpcUaTypeResolver
     public virtual async Task<Type?> TryGetTypeForNodeAsync(ISession session, ReferenceDescription reference, CancellationToken cancellationToken)
     {
         // Check cache first
-        var cacheKey = (reference.NodeId.NamespaceUri ?? session.NamespaceUris.GetString(reference.NodeId.NamespaceIndex), reference.NodeId.Identifier);
+        var cacheKey = (reference.NodeId.NamespaceUri ?? session.NamespaceUris.GetString(reference.NodeId.NamespaceIndex), reference.NodeId.IdentifierAsString);
         if (_typeCache.TryGetValue(cacheKey, out var cachedType))
         {
             return cachedType;
@@ -50,18 +50,18 @@ public class OpcUaTypeResolver
 
         if (reference.NodeClass != NodeClass.Variable)
         {
-            var browseDescriptions = new BrowseDescriptionCollection
-            {
+            ArrayOf<BrowseDescription> browseDescriptions =
+            [
                 new BrowseDescription
                 {
-                    NodeId = nodeId!,
+                    NodeId = nodeId,
                     BrowseDirection = BrowseDirection.Forward,
                     ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
                     IncludeSubtypes = true,
                     NodeClassMask = (uint)NodeClass.Variable | (uint)NodeClass.Object,
                     ResultMask = (uint)BrowseResultMask.All
                 }
-            };
+            ];
 
             var response = await session.BrowseAsync(
                 null,
@@ -70,9 +70,15 @@ public class OpcUaTypeResolver
                 browseDescriptions,
                 cancellationToken);
 
-            if (response.Results.Count > 0 && response.Results[0].References.Any(n => n.NodeClass == NodeClass.Variable))
+            if (response.Results.Count > 0)
             {
-                return typeof(DynamicSubject);
+                foreach (var r in response.Results[0].References)
+                {
+                    if (r.NodeClass == NodeClass.Variable)
+                    {
+                        return typeof(DynamicSubject);
+                    }
+                }
             }
 
             return typeof(DynamicSubject[]);
@@ -80,29 +86,28 @@ public class OpcUaTypeResolver
 
         try
         {
-            if (nodeId is null)
+            if (nodeId.IsNull)
             {
                 return null;
             }
 
-            var nodesToRead = new ReadValueIdCollection(2)
-            {
+            ArrayOf<ReadValueId> nodesToRead =
+            [
                 new ReadValueId { NodeId = nodeId, AttributeId = Opc.Ua.Attributes.DataType },
                 new ReadValueId { NodeId = nodeId, AttributeId = Opc.Ua.Attributes.ValueRank }
-            };
+            ];
 
             var response = await session.ReadAsync(null, 0, TimestampsToReturn.Neither, nodesToRead, cancellationToken);
             if (response.Results.Count >= 2 && StatusCode.IsGood(response.Results[0].StatusCode))
             {
-                var dataTypeId = response.Results[0].Value as NodeId;
-                if (dataTypeId != null)
+                if (response.Results[0].WrappedValue.TryGetValue(out NodeId dataTypeId) && !dataTypeId.IsNull)
                 {
                     var builtIn = TypeInfo.GetBuiltInType(dataTypeId);
                     var elementType = TryMapBuiltInType(builtIn);
                     if (elementType is not null)
                     {
                         // If ValueRank >= 0 we treat it as (at least) an array - simplification for multi-dim arrays.
-                        var valueRank = response.Results[1].Value is int vr ? vr : -1; // -1 => scalar
+                        var valueRank = response.Results[1].WrappedValue.TryGetValue(out int vr) ? vr : -1; // -1 => scalar
                         if (valueRank >= 0)
                         {
                             return elementType.MakeArrayType();

--- a/src/Namotion.Interceptor.OpcUa/Client/OutboundWriter.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OutboundWriter.cs
@@ -79,7 +79,7 @@ internal sealed class OutboundWriter
         return StatusCode.IsBad(statusCode);
     }
 
-    private WriteResult ProcessWriteResults(StatusCodeCollection results, ReadOnlyMemory<SubjectPropertyChange> allChanges)
+    private WriteResult ProcessWriteResults(ArrayOf<StatusCode> results, ReadOnlyMemory<SubjectPropertyChange> allChanges)
     {
         var failureCount = 0;
         for (var i = 0; i < results.Count; i++)
@@ -129,7 +129,7 @@ internal sealed class OutboundWriter
 
     private bool TryGetWritableNodeId(SubjectPropertyChange change, out NodeId nodeId, out RegisteredSubjectProperty registeredProperty)
     {
-        nodeId = null!;
+        nodeId = default;
         registeredProperty = null!;
 
         if (!change.Property.TryGetPropertyData(_opcUaNodeIdKey, out var value) || value is not NodeId id)
@@ -147,10 +147,10 @@ internal sealed class OutboundWriter
         return true;
     }
 
-    private WriteValueCollection CreateWriteValuesCollection(ReadOnlyMemory<SubjectPropertyChange> changes)
+    private ArrayOf<WriteValue> CreateWriteValuesCollection(ReadOnlyMemory<SubjectPropertyChange> changes)
     {
         var span = changes.Span;
-        var writeValues = new WriteValueCollection(span.Length);
+        var writeValues = new List<WriteValue>(span.Length);
 
         for (var i = 0; i < span.Length; i++)
         {
@@ -171,14 +171,16 @@ internal sealed class OutboundWriter
                 AttributeId = Opc.Ua.Attributes.Value,
                 Value = new DataValue
                 {
-                    Value = convertedValue,
+#pragma warning disable CS0618 // Variant(object) is obsolete but required for dynamic typing
+                    WrappedValue = new Variant(convertedValue),
+#pragma warning restore CS0618
                     StatusCode = StatusCodes.Good,
                     SourceTimestamp = change.ChangedTimestamp.UtcDateTime
                 }
             });
         }
 
-        return writeValues;
+        return writeValues.ToArrayOf();
     }
 
     private void NotifyPropertiesWritten(ReadOnlyMemory<SubjectPropertyChange> changes)

--- a/src/Namotion.Interceptor.OpcUa/Client/Polling/PollingManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Polling/PollingManager.cs
@@ -326,15 +326,16 @@ internal sealed class PollingManager : IAsyncDisposable
         try
         {
             // Build read request - pre-size to avoid resizing
-            var nodesToRead = new ReadValueIdCollection(batch.Count);
+            var nodesToReadList = new List<ReadValueId>(batch.Count);
             foreach (var item in batch)
             {
-                nodesToRead.Add(new ReadValueId
+                nodesToReadList.Add(new ReadValueId
                 {
                     NodeId = item.NodeId,
                     AttributeId = Opc.Ua.Attributes.Value
                 });
             }
+            var nodesToRead = nodesToReadList.ToArrayOf();
 
             // Execute read
             var response = await session.ReadAsync(
@@ -378,7 +379,7 @@ internal sealed class PollingManager : IAsyncDisposable
 
     private void ProcessValueChange(PollingItem pollingItem, DataValue dataValue, DateTimeOffset receivedTimestamp)
     {
-        var newValue = dataValue.Value;
+        var newValue = dataValue.WrappedValue.AsBoxedObject();
         var oldValue = pollingItem.LastValue;
 
         // Only notify on actual change (same as subscription behavior)
@@ -401,7 +402,7 @@ internal sealed class PollingManager : IAsyncDisposable
             {
                 Property = pollingItem.Property,
                 Value = newValue,
-                Timestamp = dataValue.SourceTimestamp
+                Timestamp = dataValue.SourceTimestamp.ToDateTimeOffset()
             };
 
             // Queue update using same pattern as subscriptions

--- a/src/Namotion.Interceptor.OpcUa/Client/ReadAfterWrite/ReadAfterWriteManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/ReadAfterWrite/ReadAfterWriteManager.cs
@@ -296,15 +296,16 @@ internal sealed class ReadAfterWriteManager : IAsyncDisposable
 
         try
         {
-            var readValues = new ReadValueIdCollection(dueCount);
+            var readValuesList = new List<ReadValueId>(dueCount);
             for (var i = 0; i < dueCount; i++)
             {
-                readValues.Add(new ReadValueId
+                readValuesList.Add(new ReadValueId
                 {
                     NodeId = _dueReadsList[i].NodeId,
                     AttributeId = Opc.Ua.Attributes.Value
                 });
             }
+            var readValues = readValuesList.ToArrayOf();
 
             var response = await session.ReadAsync(
                 requestHeader: null,
@@ -326,7 +327,7 @@ internal sealed class ReadAfterWriteManager : IAsyncDisposable
                 }
 
                 var (_, property) = _dueReadsList[i];
-                var sourceTimestamp = (DateTimeOffset)result.SourceTimestamp;
+                var sourceTimestamp = result.SourceTimestamp.ToDateTimeOffset();
 
                 // Skip if property already has a newer value from subscription notification
                 var currentWriteTimestamp = property.Reference.TryGetWriteTimestamp();
@@ -336,7 +337,7 @@ internal sealed class ReadAfterWriteManager : IAsyncDisposable
                     continue;
                 }
 
-                var value = _configuration.ValueConverter.ConvertToPropertyValue(result.Value, property);
+                var value = _configuration.ValueConverter.ConvertToPropertyValue(result.WrappedValue.AsBoxedObject(), property);
                 property.SetValueFromSource(_source, sourceTimestamp, receivedTimestamp, value);
                 successCount++;
             }

--- a/src/Namotion.Interceptor.OpcUa/Mapping/AttributeOpcUaNodeMapper.cs
+++ b/src/Namotion.Interceptor.OpcUa/Mapping/AttributeOpcUaNodeMapper.cs
@@ -101,7 +101,7 @@ public class AttributeOpcUaNodeMapper : IOpcUaNodeMapper
         ISession session,
         CancellationToken cancellationToken)
     {
-        var nodeIdString = nodeReference.NodeId.Identifier.ToString();
+        var nodeIdString = nodeReference.NodeId.IdentifierAsString;
         var nodeNamespaceUri = nodeReference.NodeId.NamespaceUri
             ?? session.NamespaceUris.GetString(nodeReference.NodeId.NamespaceIndex);
 

--- a/src/Namotion.Interceptor.OpcUa/Namotion.Interceptor.OpcUa.csproj
+++ b/src/Namotion.Interceptor.OpcUa/Namotion.Interceptor.OpcUa.csproj
@@ -4,8 +4,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <!-- Set to true to use local OPC UA project references (development), false for NuGet packages (production) -->
-    <UseLocalOpcUaProjects>false</UseLocalOpcUaProjects>
+    <UseLocalOpcUaProjects>true</UseLocalOpcUaProjects>
   </PropertyGroup>
 
   <!-- Define compiler constant when using local OPC UA projects -->

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
@@ -43,7 +43,10 @@ internal class CustomNodeManager : CustomNodeManager2
     // Expose protected members for OpcUaNodeFactory
     internal ISystemContext GetSystemContext() => SystemContext;
     internal NodeIdDictionary<NodeState> GetPredefinedNodes() => PredefinedNodes;
-    internal NodeState FindNode(NodeId nodeId) => FindNodeInAddressSpace(nodeId);
+    internal NodeState FindNode(NodeId nodeId) =>
+#pragma warning disable CS0618 // Type or member is obsolete
+        FindNodeInAddressSpace(nodeId);
+#pragma warning restore CS0618 // Type or member is obsolete
     internal void AddNode(NodeState node) => AddPredefinedNode(SystemContext, node);
 
     protected override NodeStateCollection LoadPredefinedNodes(ISystemContext context)
@@ -366,13 +369,14 @@ internal class CustomNodeManager : CustomNodeManager2
         // Set array dimensions (works for 1D and multi-D)
         if (value is Array arrayValue)
         {
-            variableNode.ArrayDimensions = new ReadOnlyList<uint>(
-                Enumerable.Range(0, arrayValue.Rank)
-                    .Select(i => (uint)arrayValue.GetLength(i))
-                    .ToArray());
+            variableNode.ArrayDimensions = Enumerable.Range(0, arrayValue.Rank)
+                .Select(i => (uint)arrayValue.GetLength(i))
+                .ToArrayOf();
         }
 
-        variableNode.Value = value;
+#pragma warning disable CS0618 // Variant(object) is obsolete but required for dynamic typing
+        variableNode.Value = new Variant(value);
+#pragma warning restore CS0618
 
         var writeTimestamp = property.Reference.TryGetWriteTimestamp();
         if (writeTimestamp.HasValue)
@@ -386,7 +390,7 @@ internal class CustomNodeManager : CustomNodeManager2
             {
                 // No lock needed: StateChanged fires from ClearChangeMasks which is always
                 // called under NodeManager.Lock (from WriteChangesAsync or SDK write handling).
-                _serverService.UpdateProperty(property.Reference, variableNode.Timestamp, variableNode.Value);
+                _serverService.UpdateProperty(property.Reference, variableNode.Timestamp.ToDateTimeOffset(), variableNode.Value.AsBoxedObject());
             }
         };
 
@@ -439,7 +443,9 @@ internal class CustomNodeManager : CustomNodeManager2
         if (_subjects.TryGetValue(registeredSubject, out var existingNode))
         {
             // Subject already created, add reference to existing node
+#pragma warning disable CS0618 // Type or member is obsolete
             var parentNode = FindNodeInAddressSpace(parentNodeId);
+#pragma warning restore CS0618 // Type or member is obsolete
             parentNode.AddReference(referenceTypeId ?? ReferenceTypeIds.HasComponent, false, existingNode.NodeId);
         }
         else

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManagerFactory.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManagerFactory.cs
@@ -11,7 +11,7 @@ internal class CustomNodeManagerFactory : INodeManagerFactory
     private readonly OpcUaServerConfiguration _configuration;
     private readonly ILogger _logger;
 
-    public StringCollection NamespacesUris => new(_configuration.GetNamespaceUris());
+    public ArrayOf<string> NamespacesUris => _configuration.GetNamespaceUris().ToArrayOf();
 
     public CustomNodeManager? NodeManager { get; private set; }
 

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaNodeFactory.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaNodeFactory.cs
@@ -134,7 +134,7 @@ internal sealed class OpcUaNodeFactory
             DisplayName = new LocalizedText(nodeConfiguration?.DisplayName ?? browseName.Name),
             Description = nodeConfiguration?.Description is not null
                 ? new LocalizedText(nodeConfiguration.Description)
-                : null,
+                : default,
             TypeDefinitionId = typeDefinition ?? ObjectTypeIds.FolderType,
             WriteMask = AttributeWriteMask.None,
             UserWriteMask = AttributeWriteMask.None,
@@ -167,7 +167,7 @@ internal sealed class OpcUaNodeFactory
             DisplayName = new LocalizedText(nodeConfiguration?.DisplayName ?? browseName.Name),
             Description = nodeConfiguration?.Description is not null
                 ? new LocalizedText(nodeConfiguration.Description)
-                : null,
+                : default,
             TypeDefinitionId = typeDefinition ?? ObjectTypeIds.BaseObjectType,
             WriteMask = AttributeWriteMask.None,
             UserWriteMask = AttributeWriteMask.None,
@@ -203,7 +203,7 @@ internal sealed class OpcUaNodeFactory
             DisplayName = new LocalizedText(nodeConfiguration?.DisplayName ?? browseName.Name),
             Description = nodeConfiguration?.Description is not null
                 ? new LocalizedText(nodeConfiguration.Description)
-                : null,
+                : default,
 
             TypeDefinitionId = VariableTypeIds.BaseDataVariableType,
             DataType = dataTypeOverride ?? Opc.Ua.TypeInfo.GetDataTypeId(dataType),
@@ -253,7 +253,7 @@ internal sealed class OpcUaNodeFactory
                 ? NodeId.Create(reference.TargetNodeId, reference.TargetNamespaceUri, manager.GetSystemContext().NamespaceUris)
                 : new NodeId(reference.TargetNodeId, namespaceIndex);
 
-            node.AddReference(referenceTypeId, reference.IsForward, targetNodeId);
+            node.AddReference(referenceTypeId.Value, reference.IsForward, targetNodeId);
         }
     }
 
@@ -265,13 +265,13 @@ internal sealed class OpcUaNodeFactory
         }
 
         var modellingRuleNodeId = GetModellingRuleNodeId(nodeConfiguration.ModellingRule.Value);
-        if (modellingRuleNodeId is not null)
+        if (!modellingRuleNodeId.IsNull)
         {
             node.AddReference(ReferenceTypeIds.HasModellingRule, false, modellingRuleNodeId);
         }
     }
 
-    private static NodeId? GetModellingRuleNodeId(ModellingRule modellingRule)
+    private static NodeId GetModellingRuleNodeId(ModellingRule modellingRule)
     {
         return modellingRule switch
         {
@@ -280,7 +280,7 @@ internal sealed class OpcUaNodeFactory
             ModellingRule.MandatoryPlaceholder => ObjectIds.ModellingRule_MandatoryPlaceholder,
             ModellingRule.OptionalPlaceholder => ObjectIds.ModellingRule_OptionalPlaceholder,
             ModellingRule.ExposesItsArray => ObjectIds.ModellingRule_ExposesItsArray,
-            _ => null
+            _ => NodeId.Null
         };
     }
 }

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaNodeIdResolver.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaNodeIdResolver.cs
@@ -91,8 +91,9 @@ internal sealed class OpcUaNodeIdResolver
         if (ExpandedNodeId.TryParse(identifier, out var expandedNodeId) &&
             !string.IsNullOrEmpty(expandedNodeId.NamespaceUri))
         {
-            var namespaceIndex = context.NamespaceUris.GetIndexOrAppend(expandedNodeId.NamespaceUri);
-            return new NodeId(expandedNodeId.Identifier, namespaceIndex);
+            context.NamespaceUris.GetIndexOrAppend(expandedNodeId.NamespaceUri);
+            var resolved = ExpandedNodeId.ToNodeId(expandedNodeId, context.NamespaceUris, updateNamespaceTable: true);
+            return !resolved.IsNull ? resolved : (NodeId?)null;
         }
 
         // Strategy 4: Standard type lookup by category

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerConfiguration.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerConfiguration.cs
@@ -95,7 +95,7 @@ public class OpcUaServerConfiguration
         var host = System.Net.Dns.GetHostName();
         var applicationUri = $"urn:{host}:Namotion.Interceptor:{ApplicationName}";
 
-        var config = new ApplicationConfiguration
+        var config = new ApplicationConfiguration(TelemetryContext)
         {
             ApplicationName = ApplicationName,
             ApplicationType = ApplicationType.Server,
@@ -144,7 +144,7 @@ public class OpcUaServerConfiguration
             ServerConfiguration = new ServerConfiguration
             {
                 // Base addresses kept minimal (tcp only). Add https if required later.
-                BaseAddresses = { BaseAddress },
+                BaseAddresses = [BaseAddress],
                 SecurityPolicies =
                 [
                     new ServerSecurityPolicy { SecurityMode = MessageSecurityMode.Sign, SecurityPolicyUri = SecurityPolicies.Basic256Sha256 },

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
@@ -15,6 +15,7 @@ internal class OpcUaSubjectServer : StandardServer
     private List<ITransportListener>? _savedTransportListeners;
 
     public OpcUaSubjectServer(IInterceptorSubject subject, OpcUaSubjectServerBackgroundService source, OpcUaServerConfiguration configuration, ILogger logger)
+        : base(configuration.TelemetryContext)
     {
         _logger = logger;
         _nodeManagerFactory = new CustomNodeManagerFactory(subject, source, configuration, logger);

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServerBackgroundService.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServerBackgroundService.cs
@@ -142,7 +142,9 @@ internal class OpcUaSubjectServerBackgroundService : BackgroundService, IOpcUaSu
                     var convertedValue = _configuration.ValueConverter
                         .ConvertToNodeValue(value, registeredProperty);
 
-                    node.Value = convertedValue;
+#pragma warning disable CS0618 // Variant(object) is obsolete but required for dynamic typing
+                    node.Value = new Variant(convertedValue);
+#pragma warning restore CS0618
                     node.Timestamp = change.ChangedTimestamp.UtcDateTime;
                     node.ClearChangeMasks(currentInstance.DefaultSystemContext, false);
                 }
@@ -315,7 +317,7 @@ internal class OpcUaSubjectServerBackgroundService : BackgroundService, IOpcUaSu
                     var sessions = sessionManager.GetSessions();
                     foreach (var session in sessions)
                     {
-                        try { session.Close(); } catch (Exception ex) { _logger.LogDebug(ex, "Error closing session during shutdown."); }
+                        try { session.CloseAsync().AsTask().GetAwaiter().GetResult(); } catch (Exception ex) { _logger.LogDebug(ex, "Error closing session during shutdown."); }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Adapt to breaking API changes in OPCFoundation/UA-.NETStandard master (ahead of 1.5.378.134)
- Originally proposed as the way to deliver the `#3734` notification-loss fix; this is now obsolete because `#331` ships the same fix on the release line without API churn.
- Uses UseLocalOpcUaProjects=true for now; will switch to NuGet when next SDK version is published

## Relationship to #331

`#331` bumps the release-line NuGet to `1.5.378.145`, which already contains the `#3734` fix and is API-compatible. `#331` supersedes this PR as the way to deliver `#3734` to users. This PR remains as the tracker for the larger move to master's newer API (`NodeId` struct, removed collection types, C# 14 extension syntax, `WrappedValue.AsBoxedObject`, `TelemetryContext` constructor). It stays blocked on #290 and on the underlying notification-loss family also seen in #285.

## Known Issue

Chaos testing on upstream/master (OPCFoundation/UA-.NETStandard@2806e35c) found a regression: tiny notification loss (1-3 properties, 25ms) at mutate/converge boundaries. Reproduced at cycle 133 and again at cycle 717 (see #290). The same scenario did not reproduce on NuGet 1.5.378.134 in 1050+ cycles. The release-line `1.5.378.145` soak gating `#331` did reproduce a broader #285-style failure once at cycle 698, but with flat heap throughout, so the master-only heap drift hypothesis still holds for #290's specific tiny-divergence variant.

## Key Changes

- Replace removed collection types with ArrayOf<T> and List<T> + .ToArrayOf()
- Use WrappedValue.AsBoxedObject() instead of DataValue.Value
- Convert SourceTimestamp with .ToDateTimeOffset()
- Pass TelemetryContext to ApplicationConfiguration constructor (prevents null ref on discovery)
- Handle NodeId as struct (.IsNull, default instead of null)
- Add LangVersion=preview for C# 14 extension syntax from SDK

## Test plan

Build / API surface:
- [x] Build succeeds with local SDK reference
- [ ] Re-verify build against a released SDK version (post-1.5.378.145) that contains the master changes
- [ ] Drop `UseLocalOpcUaProjects=true` and switch to a NuGet reference
- [ ] Drop `LangVersion=preview` if the SDK ships with stable C# language features

Chaos soak on the master-line SDK (run via `dotnet run --project src/Namotion.Interceptor.ConnectorTester --launch-profile opcua-chaos --configuration Release`; the `opcua-chaos` profile rotates through client-only, server-only, and full-chaos sub-profiles so a single run exercises all three regressions below):

- [ ] **#290** does not reproduce. This is the merge blocker for this PR. Prior repros at cycles 133 and 717. Target a clean run comparable to the 1050+ cycle baseline cleared by 1.5.378.134.
- [ ] **#285** does not reproduce at a rate worse than the release line. The release-line baseline is currently 2 known repros across 1.5.378.134 (cycle 318) and 1.5.378.145 (cycle 698); master must not be worse. Note: `#3734` was originally believed to fix #285 but does not (see #285 / #331).
- [ ] **#287** does not reproduce under the server-only sub-profile (subscription silent death after server-restart session transfer; observed once in 2200+ cycles, treat as a stability check rather than a blocker).
- [ ] HeapMB in `cycles.csv` does not drift upward across cycles. Master showed 88 MB to 216 MB over 717 cycles; release line is flat at 98.8 MB. Sustained growth is a merge blocker because it likely causes #290.
