### PR TITLE
feature: Improve OPC UA dynamic property discovery

### DIFF
--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -601,6 +601,34 @@ if (dynamicProperty != null)
 }
 ```
 
+#### Type Resolution
+
+The `OpcUaTypeResolver` maps OPC UA nodes to CLR types during dynamic discovery:
+
+- **Object nodes** become `DynamicSubject` (named sub-properties on the parent subject).
+- **Object nodes with `[index]` convention** become `DynamicSubject[]` collections. This convention is used by this library's OPC UA server when exposing C# collections (e.g., `People[0]`, `People[1]`). Standard OPC UA servers typically use named children and are always treated as single subjects.
+- **Variable nodes** are mapped to CLR types based on their OPC UA DataType. The resolver uses `session.TypeTree` to walk the type hierarchy, so custom DataType subtypes (e.g., a server-specific `LocalizedText` variant) are correctly resolved to their base built-in type.
+
+| OPC UA BuiltInType | CLR Type | Notes |
+|---|---|---|
+| Boolean, SByte, Byte, Int16, ... | bool, sbyte, byte, short, ... | Direct mapping |
+| String | string | |
+| DateTime | DateTime | |
+| LocalizedText | LocalizedText | |
+| Enumeration | int | Mapped to underlying Int32 |
+| Number | double | Abstract numeric base type |
+| Integer | long | Abstract signed integer |
+| UInteger | ulong | Abstract unsigned integer |
+| ExtensionObject | ExtensionObject | Complex structured types |
+| XmlElement | string | |
+| Variant, Null | (skipped) | Type cannot be determined |
+
+Override `TryGetTypeForNodeAsync` on `OpcUaTypeResolver` to customize type mapping for specific nodes.
+
+#### Subject Deduplication
+
+When the same OPC UA node appears at multiple paths in the address space (e.g., `Identification` referenced from both `MyMachine` and `MachineryBuildingBlocks`), the client reuses the same subject instance. Both parent properties point to the same `DynamicSubject`, which receives a single set of monitored items. The subject's canonical path resolves to the shallowest location in the tree.
+
 ## Write Error Handling
 
 When a batch write to the OPC UA server partially fails, the client throws an `OpcUaWriteException`. The exception distinguishes between transient failures (connectivity issues, timeouts that may succeed on retry) and permanent failures (invalid nodes, access denied; should not be retried). The write retry queue (see [Resilience](#write-retry-queue-during-disconnection)) handles transient failures automatically during disconnection, but writes that fail while connected surface this exception.

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -627,7 +627,7 @@ Override `TryGetTypeForNodeAsync` on `OpcUaTypeResolver` to customize type mappi
 
 #### Subject Deduplication
 
-When the same OPC UA node appears at multiple paths in the address space (e.g., `Identification` referenced from both `MyMachine` and `MachineryBuildingBlocks`), the client reuses the same subject instance. Both parent properties point to the same `DynamicSubject`, which receives a single set of monitored items. The subject's canonical path resolves to the shallowest location in the tree.
+When the same OPC UA node appears at multiple paths in the address space (e.g., `Identification` referenced from both `MyMachine` and `MachineryBuildingBlocks`), the client reuses the same subject instance. Both parent properties point to the same `DynamicSubject`, which receives a single set of monitored items.
 
 ## Write Error Handling
 

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -606,7 +606,10 @@ if (dynamicProperty != null)
 The `OpcUaTypeResolver` maps OPC UA nodes to CLR types during dynamic discovery:
 
 - **Object nodes** become `DynamicSubject` (named sub-properties on the parent subject).
-- **Object nodes with `[index]` convention** become `DynamicSubject[]` collections. This convention is used by this library's OPC UA server when exposing C# collections (e.g., `People[0]`, `People[1]`). Standard OPC UA servers typically use named children and are always treated as single subjects.
+- **Object nodes with `[numeric]` convention** (e.g., `People[0]`, `People[1]`) become `DynamicSubject[]` collections.
+- **Object nodes with `[string]` convention** (e.g., `Devices[SensorA]`) become `IReadOnlyDictionary<string, DynamicSubject>` dictionaries.
+
+The bracket convention is produced by this library's OPC UA server when exposing C# collections and dictionaries. Standard OPC UA servers typically use named children and are always treated as single subjects.
 - **Variable nodes** are mapped to CLR types based on their OPC UA DataType. The resolver uses `session.TypeTree` to walk the type hierarchy, so custom DataType subtypes (e.g., a server-specific `LocalizedText` variant) are correctly resolved to their base built-in type.
 
 | OPC UA BuiltInType | CLR Type | Notes |

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -627,7 +627,7 @@ Override `TryGetTypeForNodeAsync` on `OpcUaTypeResolver` to customize type mappi
 
 #### Subject Deduplication
 
-When the same OPC UA node appears at multiple paths in the address space (e.g., `Identification` referenced from both `MyMachine` and `MachineryBuildingBlocks`), the client reuses the same subject instance. Both parent properties point to the same `DynamicSubject`, which receives a single set of monitored items.
+When the same OPC UA node appears at multiple paths in the address space (e.g., `Identification` referenced from both `MyMachine` and `MachineryBuildingBlocks`), the client reuses the same subject instance. Reuse applies to single references as well as collection and dictionary elements: any property that resolves to the same `NodeId` during a load is bound to the existing subject, which receives a single set of monitored items.
 
 ## Write Error Handling
 

--- a/src/HomeBlaze/HomeBlaze.AI.Tests/Mcp/HomeBlazeMcpSubjectEnricherTests.cs
+++ b/src/HomeBlaze/HomeBlaze.AI.Tests/Mcp/HomeBlazeMcpSubjectEnricherTests.cs
@@ -210,7 +210,7 @@ public class HomeBlazeMcpSubjectEnricherTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
     }

--- a/src/HomeBlaze/HomeBlaze.AI.Tests/Mcp/HomeBlazeMcpToolProviderTests.cs
+++ b/src/HomeBlaze/HomeBlaze.AI.Tests/Mcp/HomeBlazeMcpToolProviderTests.cs
@@ -206,7 +206,7 @@ public class HomeBlazeMcpToolProviderTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
 

--- a/src/HomeBlaze/HomeBlaze.AI.Tests/Mcp/StateAttributePathProviderTests.cs
+++ b/src/HomeBlaze/HomeBlaze.AI.Tests/Mcp/StateAttributePathProviderTests.cs
@@ -159,7 +159,7 @@ public class StateAttributePathProviderTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
     }

--- a/src/HomeBlaze/HomeBlaze.Host/Components/Browser/SubjectPropertyPanel.razor
+++ b/src/HomeBlaze/HomeBlaze.Host/Components/Browser/SubjectPropertyPanel.razor
@@ -262,7 +262,7 @@
             return [];
 
         return _registeredSubject.Properties
-            .Where(p => p.GetStateMetadata() != null && !p.CanContainSubjects
+            .Where(p => p.GetStateMetadata() != null && !p.IsAttribute && !p.CanContainSubjects
                      && p.GetConfigurationMetadata()?.IsSecret != true)
             .OrderBy(p => p.GetDisplayPosition());
     }

--- a/src/HomeBlaze/HomeBlaze.OpcUa/HomeBlazeOpcUaSubjectFactory.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/HomeBlazeOpcUaSubjectFactory.cs
@@ -1,0 +1,29 @@
+using Namotion.Interceptor;
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.OpcUa;
+using Namotion.Interceptor.Registry.Abstractions;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace HomeBlaze.OpcUa;
+
+public class HomeBlazeOpcUaSubjectFactory : OpcUaSubjectFactory
+{
+    public HomeBlazeOpcUaSubjectFactory() : base(DefaultSubjectFactory.Instance)
+    {
+    }
+
+    public override Task<IInterceptorSubject> CreateSubjectAsync(
+        RegisteredSubjectProperty property, ReferenceDescription node,
+        ISession session, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IInterceptorSubject>(new OpcUaDynamicSubject(node.BrowseName.Name));
+    }
+
+    public override Task<IInterceptorSubject> CreateCollectionSubjectAsync(
+        RegisteredSubjectProperty collectionProperty, ReferenceDescription node, object? index,
+        ISession session, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IInterceptorSubject>(new OpcUaDynamicSubject(node.BrowseName.Name));
+    }
+}

--- a/src/HomeBlaze/HomeBlaze.OpcUa/HomeBlazeOpcUaSubjectFactory.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/HomeBlazeOpcUaSubjectFactory.cs
@@ -17,13 +17,13 @@ public class HomeBlazeOpcUaSubjectFactory : OpcUaSubjectFactory
         RegisteredSubjectProperty property, ReferenceDescription node,
         ISession session, CancellationToken cancellationToken)
     {
-        return Task.FromResult<IInterceptorSubject>(new OpcUaDynamicSubject(node.BrowseName.Name));
+        return Task.FromResult<IInterceptorSubject>(new OpcUaDynamicSubject(node.BrowseName?.Name));
     }
 
     public override Task<IInterceptorSubject> CreateCollectionSubjectAsync(
         RegisteredSubjectProperty collectionProperty, ReferenceDescription node, object? index,
         ISession session, CancellationToken cancellationToken)
     {
-        return Task.FromResult<IInterceptorSubject>(new OpcUaDynamicSubject(node.BrowseName.Name));
+        return Task.FromResult<IInterceptorSubject>(new OpcUaDynamicSubject(node.BrowseName?.Name));
     }
 }

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Namotion.Interceptor.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Namotion.Interceptor;
-using Namotion.Interceptor.Connectors;
 using Namotion.Interceptor.Dynamic;
 using Namotion.Interceptor.Hosting;
 using Namotion.Interceptor.OpcUa;
@@ -146,21 +145,15 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
         if (IsEnabled)
         {
             await StartClientAsync(stoppingToken);
+            UpdateDiagnostics();
         }
 
         try
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (_clientSource is { } source)
-                {
-                    var diagnostics = source.Diagnostics;
-                    IsConnected = diagnostics.IsConnected;
-                    IncomingChangesPerSecond = diagnostics.IncomingChangesPerSecond;
-                    OutgoingChangesPerSecond = diagnostics.OutgoingChangesPerSecond;
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(60), stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+                UpdateDiagnostics();
             }
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -174,6 +167,17 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     {
         await StopClientAsync(cancellationToken);
         await StartClientAsync(cancellationToken);
+    }
+
+    private void UpdateDiagnostics()
+    {
+        if (_clientSource is { } source)
+        {
+            var diagnostics = source.Diagnostics;
+            IsConnected = diagnostics.IsConnected;
+            IncomingChangesPerSecond = diagnostics.IncomingChangesPerSecond;
+            OutgoingChangesPerSecond = diagnostics.OutgoingChangesPerSecond;
+        }
     }
 
     private async Task StartClientAsync(CancellationToken cancellationToken)
@@ -190,7 +194,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
                 return;
             }
 
-            var root = new DynamicSubject(((IInterceptorSubject)this).Context);
+            var root = new OpcUaDynamicSubject(RootName ?? "Root");
             Root = root;
 
             var configuration = new OpcUaClientConfiguration
@@ -199,7 +203,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
                 RootName = RootName,
                 TypeResolver = new HomeBlazeOpcUaTypeResolver(_logger),
                 ValueConverter = new OpcUaValueConverter(),
-                SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),
+                SubjectFactory = new HomeBlazeOpcUaSubjectFactory(),
             };
 
             _clientSource = root.CreateOpcUaClientSource(configuration, _logger);

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaDynamicSubject.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaDynamicSubject.cs
@@ -1,0 +1,14 @@
+using HomeBlaze.Abstractions;
+using Namotion.Interceptor.Dynamic;
+
+namespace HomeBlaze.OpcUa;
+
+public class OpcUaDynamicSubject : DynamicSubject, ITitleProvider
+{
+    public string? Title { get; }
+
+    public OpcUaDynamicSubject(string? title)
+    {
+        Title = title;
+    }
+}

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Attributes/ConfigurationAttributeInitializerTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Attributes/ConfigurationAttributeInitializerTests.cs
@@ -18,7 +18,7 @@ public class ConfigurationAttributeInitializerTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
     }

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Attributes/StateAttributeInitializerTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Attributes/StateAttributeInitializerTests.cs
@@ -18,7 +18,7 @@ public class StateAttributeInitializerTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
     }

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Integration/RegistryAttributeMigrationIntegrationTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Integration/RegistryAttributeMigrationIntegrationTests.cs
@@ -22,7 +22,7 @@ public class RegistryAttributeMigrationIntegrationTests
             .WithService<ILifecycleHandler>(
                 () => new MethodPropertyInitializer(),
                 handler => handler is MethodPropertyInitializer)
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
     }

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurableSubjectSerializerTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurableSubjectSerializerTests.cs
@@ -427,7 +427,7 @@ public class ConfigurableSubjectSerializerTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
         var subject = new TestSubject(context) { ConfigProperty = "original" };
@@ -448,7 +448,7 @@ public class ConfigurableSubjectSerializerTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
         var subject = new TestSubject(context) { ConfigProperty = "original" };
@@ -470,7 +470,7 @@ public class ConfigurableSubjectSerializerTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
         var subject = new SubjectWithMixedProperties(context)

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurationJsonTypeInfoResolverTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurationJsonTypeInfoResolverTests.cs
@@ -227,7 +227,7 @@ public class ConfigurationJsonTypeInfoResolverTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
         var subject = new TestSubject(context)

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverGetPathTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverGetPathTests.cs
@@ -267,6 +267,27 @@ public class SubjectPathResolverGetPathTests : SubjectPathResolverTestBase
         Assert.Equal("/Notes", path);
     }
 
+    [Fact]
+    public void WhenSubjectHasMultipleParents_ThenShortestPathIsReturnedFirst()
+    {
+        // Arrange
+        var shared = new TestContainer(Context) { Name = "Shared" };
+        var intermediate = new TestContainer(Context) { Name = "Intermediate", Child = shared };
+        var root = new TestContainer(Context) { Name = "Root", Child = intermediate };
+        root.Children = new Dictionary<string, TestContainer> { ["Shortcut"] = shared };
+        RootManager.Root = root;
+
+        // Act
+        var firstPath = Resolver.GetPath(shared, PathStyle.Canonical);
+        var allPaths = Resolver.GetPaths(shared, PathStyle.Canonical);
+
+        // Assert
+        Assert.Equal(2, allPaths.Count);
+        Assert.Equal("/Children[Shortcut]", allPaths[0]);
+        Assert.Equal("/Child/Child", allPaths[1]);
+        Assert.Equal("/Children[Shortcut]", firstPath);
+    }
+
     #endregion
 
     #region CanonicalToRoute conversion

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectRegistryExtensionsTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectRegistryExtensionsTests.cs
@@ -18,7 +18,7 @@ public class SubjectRegistryExtensionsTests
             .WithFullPropertyTracking()
             .WithRegistry()
             .WithLifecycle()
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer);
     }

--- a/src/HomeBlaze/HomeBlaze.Services/Lifecycle/PropertyAttributeInitializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/Lifecycle/PropertyAttributeInitializer.cs
@@ -1,7 +1,9 @@
 using HomeBlaze.Abstractions;
 using HomeBlaze.Abstractions.Attributes;
 using HomeBlaze.Abstractions.Metadata;
+using Namotion.Interceptor;
 using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Abstractions;
 using Namotion.Interceptor.Tracking.Lifecycle;
 
 namespace HomeBlaze.Services.Lifecycle;
@@ -10,55 +12,66 @@ namespace HomeBlaze.Services.Lifecycle;
 /// Lifecycle handler that registers State and Configuration registry attributes
 /// from [State] and [Configuration] C# attributes on first attach.
 /// </summary>
-public class PropertyAttributeInitializer : ILifecycleHandler
+public class PropertyAttributeInitializer : IPropertyLifecycleHandler
 {
-    public void HandleLifecycleChange(SubjectLifecycleChange change)
+    public void AttachProperty(SubjectPropertyLifecycleChange change)
     {
-        if (!change.IsContextAttach)
-            return;
-
-        var registeredSubject = change.Subject.TryGetRegisteredSubject()
-            ?? throw new InvalidOperationException("Subject not registered");
-
-        foreach (var property in registeredSubject.Properties)
+        var property = change.Subject.TryGetRegisteredProperty(change.Property.Name);
+        if (property is not null)
         {
-            var hasState = false;
-            ConfigurationAttribute? configurationAttribute = null;
+            InitializePropertyAttributes(property);
+        }
+    }
 
-            // Merge fields: first explicitly-set value wins (class attributes come first)
-            string? title = null;
-            StateUnit? unit = null;
-            int? position = null;
-            bool? isCumulative = null;
-            bool? isDiscrete = null;
-            bool? isEstimated = null;
+    public void DetachProperty(SubjectPropertyLifecycleChange change)
+    {
+    }
 
-            foreach (var reflectionAttribute in property.ReflectionAttributes)
+    public void RefreshCollectionProperty(PropertyReference property, object? value)
+    {
+    }
+
+    private static void InitializePropertyAttributes(RegisteredSubjectProperty property)
+    {
+        var hasState = false;
+        ConfigurationAttribute? configurationAttribute = null;
+
+        // Merge fields: first explicitly-set value wins (class attributes come first)
+        string? title = null;
+        StateUnit? unit = null;
+        int? position = null;
+        bool? isCumulative = null;
+        bool? isDiscrete = null;
+        bool? isEstimated = null;
+
+        foreach (var reflectionAttribute in property.ReflectionAttributes)
+        {
+            if (reflectionAttribute is StateAttribute stateAttribute)
             {
-                if (reflectionAttribute is StateAttribute stateAttribute)
+                hasState = true;
+
+                title ??= stateAttribute.Title;
+
+                if (unit == null && stateAttribute.IsUnitSet)
+                    unit = stateAttribute.Unit;
+
+                if (position == null && stateAttribute.IsPositionSet)
+                    position = stateAttribute.Position;
+
+                if (isCumulative == null && stateAttribute.IsCumulativeSet)
+                    isCumulative = stateAttribute.IsCumulative;
+
+                if (isDiscrete == null && stateAttribute.IsDiscreteSet)
+                    isDiscrete = stateAttribute.IsDiscrete;
+
+                if (isEstimated == null && stateAttribute.IsEstimatedSet)
+                    isEstimated = stateAttribute.IsEstimated;
+            }
+            else if (reflectionAttribute is ConfigurationAttribute configAttribute)
+            {
+                configurationAttribute = configAttribute;
+                if (property.TryGetAttribute(KnownAttributes.Configuration) is null)
                 {
-                    hasState = true;
-
-                    title ??= stateAttribute.Title;
-
-                    if (unit == null && stateAttribute.IsUnitSet)
-                        unit = stateAttribute.Unit;
-
-                    if (position == null && stateAttribute.IsPositionSet)
-                        position = stateAttribute.Position;
-
-                    if (isCumulative == null && stateAttribute.IsCumulativeSet)
-                        isCumulative = stateAttribute.IsCumulative;
-
-                    if (isDiscrete == null && stateAttribute.IsDiscreteSet)
-                        isDiscrete = stateAttribute.IsDiscrete;
-
-                    if (isEstimated == null && stateAttribute.IsEstimatedSet)
-                        isEstimated = stateAttribute.IsEstimated;
-                }
-                else if (reflectionAttribute is ConfigurationAttribute configAttribute)
-                {
-                    configurationAttribute = configAttribute;
                     var metadata = new ConfigurationMetadata
                     {
                         IsSecret = configAttribute.IsSecret
@@ -67,29 +80,29 @@ public class PropertyAttributeInitializer : ILifecycleHandler
                         _ => metadata, null);
                 }
             }
+        }
 
-            if (hasState)
+        if (hasState && property.TryGetAttribute(KnownAttributes.State) is null)
+        {
+            var stateMetadata = new StateMetadata
             {
-                var stateMetadata = new StateMetadata
-                {
-                    Title = title,
-                    Unit = unit ?? StateUnit.Default,
-                    Position = position ?? int.MaxValue,
-                    IsCumulative = isCumulative ?? false,
-                    IsDiscrete = isDiscrete ?? false,
-                    IsEstimated = isEstimated ?? false,
-                };
-                property.AddAttribute(KnownAttributes.State, typeof(StateMetadata),
-                    _ => stateMetadata, null);
-            }
+                Title = title,
+                Unit = unit ?? StateUnit.Default,
+                Position = position ?? int.MaxValue,
+                IsCumulative = isCumulative ?? false,
+                IsDiscrete = isDiscrete ?? false,
+                IsEstimated = isEstimated ?? false,
+            };
+            property.AddAttribute(KnownAttributes.State, typeof(StateMetadata),
+                _ => stateMetadata, null);
+        }
 
-            if (hasState && configurationAttribute is { IsSecret: true })
-            {
-                throw new InvalidOperationException(
-                    $"Property '{property.Name}' on '{registeredSubject.Subject.GetType().Name}' " +
-                    $"has both [State] and [Configuration(IsSecret = true)]. " +
-                    $"Secret configuration properties must not be exposed as state.");
-            }
+        if (hasState && configurationAttribute is { IsSecret: true })
+        {
+            throw new InvalidOperationException(
+                $"Property '{property.Name}' on '{property.Parent.Subject.GetType().Name}' " +
+                $"has both [State] and [Configuration(IsSecret = true)]. " +
+                $"Secret configuration properties must not be exposed as state.");
         }
     }
 }

--- a/src/HomeBlaze/HomeBlaze.Services/SubjectContextFactory.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/SubjectContextFactory.cs
@@ -31,7 +31,7 @@ public static class SubjectContextFactory
             .WithService<ILifecycleHandler>(
                 () => new MethodPropertyInitializer(),
                 handler => handler is MethodPropertyInitializer)
-            .WithService<ILifecycleHandler>(
+            .WithService<IPropertyLifecycleHandler>(
                 () => new PropertyAttributeInitializer(),
                 handler => handler is PropertyAttributeInitializer)
             .WithDataAnnotationValidation()

--- a/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
@@ -344,22 +344,19 @@ public class SubjectPathResolver : ILifecycleHandler
         if (paths.Count > 1)
         {
             // Order by path depth (number of '/' separators) so the shallowest path is first.
-            // Precompute the depth per path to avoid recounting on every comparison.
-            var depths = new int[paths.Count];
-            for (var i = 0; i < paths.Count; i++)
-            {
-                var path = paths[i];
-                var depth = 0;
-                foreach (var t in path)
+            // OrderBy is a documented stable sort: keys are computed once per element, and equal
+            // keys preserve insertion order so paths at the same depth stay deterministic.
+            paths = paths
+                .OrderBy(static path =>
                 {
-                    if (t == '/') depth++;
-                }
-                depths[i] = depth;
-            }
-
-            var pathArray = paths.ToArray();
-            Array.Sort(depths, pathArray);
-            paths = new List<string>(pathArray);
+                    var depth = 0;
+                    foreach (var ch in path)
+                    {
+                        if (ch == '/') depth++;
+                    }
+                    return depth;
+                })
+                .ToList();
         }
 
         return paths.Count > 0 ? paths : Array.Empty<string>();

--- a/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
@@ -173,9 +173,8 @@ public class SubjectPathResolver : ILifecycleHandler
             return canonicalPath;
 
         var sb = new StringBuilder(canonicalPath.Length);
-        for (var i = 0; i < canonicalPath.Length; i++)
+        foreach (var ch in canonicalPath)
         {
-            var ch = canonicalPath[i];
             if (ch == '[')
                 sb.Append('/');
             else if (ch != ']')
@@ -342,7 +341,27 @@ public class SubjectPathResolver : ILifecycleHandler
             }
         }
 
-        paths.Sort(static (a, b) => a.Count(c => c == '/').CompareTo(b.Count(c => c == '/')));
+        if (paths.Count > 1)
+        {
+            // Order by path depth (number of '/' separators) so the shallowest path is first.
+            // Precompute the depth per path to avoid recounting on every comparison.
+            var depths = new int[paths.Count];
+            for (var i = 0; i < paths.Count; i++)
+            {
+                var path = paths[i];
+                var depth = 0;
+                foreach (var t in path)
+                {
+                    if (t == '/') depth++;
+                }
+                depths[i] = depth;
+            }
+
+            var pathArray = paths.ToArray();
+            Array.Sort(depths, pathArray);
+            paths = new List<string>(pathArray);
+        }
+
         return paths.Count > 0 ? paths : Array.Empty<string>();
     }
 
@@ -367,16 +386,10 @@ public class SubjectPathResolver : ILifecycleHandler
             string segment;
             if (parent.Index != null)
             {
-                if (isInlinePathsProperty)
-                {
-                    // InlinePaths: just the key (dots are fine with / separator)
-                    segment = parent.Index.ToString()!;
-                }
-                else
-                {
+                // InlinePaths: just the key (dots are fine with / separator)
+                segment = isInlinePathsProperty ? parent.Index.ToString()! :
                     // Regular collection/dict: PropertyName[index]
-                    segment = $"{parent.Property.Name}[{parent.Index}]";
-                }
+                    $"{parent.Property.Name}[{parent.Index}]";
             }
             else
             {

--- a/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
@@ -342,6 +342,7 @@ public class SubjectPathResolver : ILifecycleHandler
             }
         }
 
+        paths.Sort(static (a, b) => a.Count(c => c == '/').CompareTo(b.Count(c => c == '/')));
         return paths.Count > 0 ? paths : Array.Empty<string>();
     }
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectFactoryTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectFactoryTests.cs
@@ -1,0 +1,53 @@
+using Moq;
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Dynamic;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Abstractions;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+public class OpcUaSubjectFactoryTests
+{
+    [Fact]
+    public async Task WhenCreateCollectionSubjectAsync_ThenDelegatesToSubjectFactory()
+    {
+        // Arrange
+        var expectedSubject = new DynamicSubject(InterceptorSubjectContext.Create().WithRegistry());
+        var mockSubjectFactory = new Mock<ISubjectFactory>();
+        mockSubjectFactory
+            .Setup(f => f.CreateSubject(It.IsAny<Type>(), It.IsAny<IServiceProvider?>()))
+            .Returns(expectedSubject);
+
+        var opcUaSubjectFactory = new OpcUaSubjectFactory(mockSubjectFactory.Object);
+
+        var context = InterceptorSubjectContext.Create().WithRegistry();
+        var parentSubject = new DynamicSubject(context);
+        var registeredSubject = parentSubject.TryGetRegisteredSubject()!;
+        var collectionProperty = registeredSubject.AddProperty(
+            "Items",
+            typeof(DynamicSubject[]),
+            _ => null,
+            (_, _) => { });
+
+        var nodeReference = new ReferenceDescription
+        {
+            BrowseName = new QualifiedName("Item"),
+            NodeId = new ExpandedNodeId(new NodeId(100, 2)),
+            NodeClass = NodeClass.Object
+        };
+
+        var mockSession = new Mock<ISession>();
+
+        // Act
+        var result = await opcUaSubjectFactory.CreateCollectionSubjectAsync(
+            collectionProperty, nodeReference, 0, mockSession.Object, CancellationToken.None);
+
+        // Assert
+        Assert.Same(expectedSubject, result);
+        mockSubjectFactory.Verify(
+            f => f.CreateSubject(It.IsAny<Type>(), It.IsAny<IServiceProvider?>()),
+            Times.Once);
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectLoaderTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectLoaderTests.cs
@@ -398,7 +398,6 @@ public class OpcUaSubjectLoaderTests
         };
 
         var mockSession = CreateMockSession();
-        var callCount = 0;
         mockSession
             .Setup(s => s.BrowseAsync(
                 It.IsAny<RequestHeader>(),
@@ -420,7 +419,6 @@ public class OpcUaSubjectLoaderTests
                 else
                     children = [];
 
-                callCount++;
                 var collection = new ReferenceDescriptionCollection();
                 collection.AddRange(children);
                 return new BrowseResponse

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectLoaderTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectLoaderTests.cs
@@ -461,6 +461,112 @@ public class OpcUaSubjectLoaderTests
         Assert.Same(sharedFromParent1, sharedFromParent2);
     }
 
+    [Fact]
+    public async Task WhenSameNodeAppearsInCollectionsFromMultipleParents_ThenSubjectIsReused()
+    {
+        // Arrange: type resolver returns DynamicSubject[] for "Collection*" nodes, DynamicSubject for other Objects.
+        var mockTypeResolver = new Mock<OpcUaTypeResolver>(NullLogger<OpcUaSubjectClientSource>.Instance);
+        mockTypeResolver
+            .Setup(t => t.TryGetTypeForNodeAsync(It.IsAny<ISession>(), It.IsAny<ReferenceDescription>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISession _, ReferenceDescription reference, CancellationToken _) =>
+            {
+                if (reference.BrowseName.Name?.StartsWith("Collection") == true)
+                    return typeof(DynamicSubject[]);
+                if (reference.NodeClass == NodeClass.Object)
+                    return typeof(DynamicSubject);
+                return typeof(double);
+            });
+        mockTypeResolver
+            .Setup(t => t.GetDynamicPropertyAttributes(It.IsAny<ReferenceDescription>(), It.IsAny<ISession>()))
+            .Returns((ReferenceDescription reference, ISession session) =>
+            {
+                var namespaceUri = reference.NodeId.NamespaceUri ?? session.NamespaceUris.GetString(reference.NodeId.NamespaceIndex);
+                return
+                [
+                    new OpcUaNodeAttribute(reference.BrowseName.Name, namespaceUri)
+                    {
+                        NodeIdentifier = reference.NodeId.Identifier.ToString(),
+                        NodeNamespaceUri = namespaceUri
+                    }
+                ];
+            });
+
+        var sharedNodeId = new NodeId(8888, 2);
+        var collection1NodeId = new NodeId(2001, 2);
+        var collection2NodeId = new NodeId(2002, 2);
+
+        // Both collections contain a "SharedItem[0]" element with the same NodeId.
+        var collection1Children = new ReferenceDescription[]
+        {
+            CreateObjectReferenceDescription("SharedItem[0]", new ExpandedNodeId(sharedNodeId))
+        };
+        var collection2Children = new ReferenceDescription[]
+        {
+            CreateObjectReferenceDescription("SharedItem[0]", new ExpandedNodeId(sharedNodeId))
+        };
+
+        var rootChildren = new ReferenceDescription[]
+        {
+            CreateObjectReferenceDescription("Collection1", new ExpandedNodeId(collection1NodeId)),
+            CreateObjectReferenceDescription("Collection2", new ExpandedNodeId(collection2NodeId))
+        };
+
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, ViewDescription _, uint _, BrowseDescriptionCollection browseDescriptions, CancellationToken _) =>
+            {
+                var nodeId = browseDescriptions[0].NodeId;
+                ReferenceDescription[] children;
+
+                if (nodeId == new NodeId(1, 0))
+                    children = rootChildren;
+                else if (nodeId == collection1NodeId)
+                    children = collection1Children;
+                else if (nodeId == collection2NodeId)
+                    children = collection2Children;
+                else
+                    children = [];
+
+                var collection = new ReferenceDescriptionCollection();
+                collection.AddRange(children);
+                return new BrowseResponse
+                {
+                    Results = [new BrowseResult { References = collection }],
+                    DiagnosticInfos = []
+                };
+            });
+
+        var (loader, _) = CreateLoader(
+            shouldAddDynamicProperties: (_, _) => Task.FromResult(true),
+            typeResolver: mockTypeResolver.Object);
+
+        var subject = CreateTestSubject();
+        var rootNode = CreateTestReferenceDescription("Root", new NodeId(1, 0));
+
+        // Act
+        await loader.LoadSubjectAsync(subject, rootNode, mockSession.Object, CancellationToken.None);
+
+        // Assert
+        var registeredSubject = subject.TryGetRegisteredSubject()!;
+        var collection1Property = registeredSubject.Properties.Single(p => p.Name == "Collection1");
+        var collection2Property = registeredSubject.Properties.Single(p => p.Name == "Collection2");
+
+        var collection1Value = collection1Property.GetValue() as System.Collections.IEnumerable;
+        var collection2Value = collection2Property.GetValue() as System.Collections.IEnumerable;
+        Assert.NotNull(collection1Value);
+        Assert.NotNull(collection2Value);
+
+        var sharedFromCollection1 = collection1Value!.Cast<IInterceptorSubject>().Single();
+        var sharedFromCollection2 = collection2Value!.Cast<IInterceptorSubject>().Single();
+        Assert.Same(sharedFromCollection1, sharedFromCollection2);
+    }
+
     private static ReferenceDescription CreateObjectReferenceDescription(string name, ExpandedNodeId nodeId)
     {
         return new ReferenceDescription

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectLoaderTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubjectLoaderTests.cs
@@ -292,6 +292,185 @@ public class OpcUaSubjectLoaderTests
         return mockSession;
     }
 
+    [Fact]
+    public async Task WhenDynamicPropertyHasNumberDataType_ThenPropertyTypeIsDouble()
+    {
+        // Arrange
+        var mockTypeResolver = new Mock<OpcUaTypeResolver>(NullLogger<OpcUaSubjectClientSource>.Instance);
+        mockTypeResolver
+            .Setup(t => t.TryGetTypeForNodeAsync(It.IsAny<ISession>(), It.IsAny<ReferenceDescription>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(typeof(double));
+
+        var (loader, _) = CreateLoader(
+            shouldAddDynamicProperties: (_, _) => Task.FromResult(true),
+            typeResolver: mockTypeResolver.Object);
+
+        var subject = CreateTestSubject();
+        var rootNode = CreateTestReferenceDescription("Root", new NodeId(1, 0));
+        var mockSession = CreateMockSessionWithChildren(
+        [
+            CreateTestReferenceDescription("NumericValue", new NodeId(3001, 2))
+        ]);
+
+        // Act
+        await loader.LoadSubjectAsync(subject, rootNode, mockSession.Object, CancellationToken.None);
+
+        // Assert
+        var registeredSubject = subject.TryGetRegisteredSubject()!;
+        var property = registeredSubject.Properties.Single(p => p.Name == "NumericValue");
+        Assert.Equal(typeof(double), property.Type);
+    }
+
+    [Fact]
+    public async Task WhenDynamicPropertyHasExtensionObjectDataType_ThenPropertyTypeIsExtensionObject()
+    {
+        // Arrange
+        var mockTypeResolver = new Mock<OpcUaTypeResolver>(NullLogger<OpcUaSubjectClientSource>.Instance);
+        mockTypeResolver
+            .Setup(t => t.TryGetTypeForNodeAsync(It.IsAny<ISession>(), It.IsAny<ReferenceDescription>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(typeof(ExtensionObject));
+
+        var (loader, _) = CreateLoader(
+            shouldAddDynamicProperties: (_, _) => Task.FromResult(true),
+            typeResolver: mockTypeResolver.Object);
+
+        var subject = CreateTestSubject();
+        var rootNode = CreateTestReferenceDescription("Root", new NodeId(1, 0));
+        var mockSession = CreateMockSessionWithChildren(
+        [
+            CreateTestReferenceDescription("ComplexValue", new NodeId(3002, 2))
+        ]);
+
+        // Act
+        await loader.LoadSubjectAsync(subject, rootNode, mockSession.Object, CancellationToken.None);
+
+        // Assert
+        var registeredSubject = subject.TryGetRegisteredSubject()!;
+        var property = registeredSubject.Properties.Single(p => p.Name == "ComplexValue");
+        Assert.Equal(typeof(ExtensionObject), property.Type);
+    }
+
+    [Fact]
+    public async Task WhenSameNodeAppearsAtMultiplePaths_ThenSubjectIsReused()
+    {
+        // Arrange: create a type resolver that returns DynamicSubject for Object nodes
+        var mockTypeResolver = new Mock<OpcUaTypeResolver>(NullLogger<OpcUaSubjectClientSource>.Instance);
+        mockTypeResolver
+            .Setup(t => t.TryGetTypeForNodeAsync(It.IsAny<ISession>(), It.IsAny<ReferenceDescription>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISession _, ReferenceDescription reference, CancellationToken _) =>
+            {
+                if (reference.NodeClass == NodeClass.Object)
+                    return typeof(DynamicSubject);
+                return typeof(double);
+            });
+        mockTypeResolver
+            .Setup(t => t.GetDynamicPropertyAttributes(It.IsAny<ReferenceDescription>(), It.IsAny<ISession>()))
+            .Returns((ReferenceDescription reference, ISession session) =>
+            {
+                var namespaceUri = reference.NodeId.NamespaceUri ?? session.NamespaceUris.GetString(reference.NodeId.NamespaceIndex);
+                return
+                [
+                    new OpcUaNodeAttribute(reference.BrowseName.Name, namespaceUri)
+                    {
+                        NodeIdentifier = reference.NodeId.Identifier.ToString(),
+                        NodeNamespaceUri = namespaceUri
+                    }
+                ];
+            });
+
+        var sharedNodeId = new NodeId(9999, 2);
+
+        // Parent1 has child "SharedChild" -> sharedNodeId
+        // Parent2 has child "SharedChild" -> sharedNodeId (same NodeId)
+        var parent1Children = new ReferenceDescription[]
+        {
+            CreateObjectReferenceDescription("SharedChild", new ExpandedNodeId(sharedNodeId))
+        };
+        var parent2Children = new ReferenceDescription[]
+        {
+            CreateObjectReferenceDescription("SharedChild", new ExpandedNodeId(sharedNodeId))
+        };
+
+        var rootChildren = new ReferenceDescription[]
+        {
+            CreateObjectReferenceDescription("Parent1", new ExpandedNodeId(new NodeId(1001, 2))),
+            CreateObjectReferenceDescription("Parent2", new ExpandedNodeId(new NodeId(1002, 2)))
+        };
+
+        var mockSession = CreateMockSession();
+        var callCount = 0;
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, ViewDescription _, uint _, BrowseDescriptionCollection browseDescriptions, CancellationToken _) =>
+            {
+                var nodeId = browseDescriptions[0].NodeId;
+                ReferenceDescription[] children;
+
+                if (nodeId == new NodeId(1, 0))
+                    children = rootChildren;
+                else if (nodeId == new NodeId(1001, 2))
+                    children = parent1Children;
+                else if (nodeId == new NodeId(1002, 2))
+                    children = parent2Children;
+                else
+                    children = [];
+
+                callCount++;
+                var collection = new ReferenceDescriptionCollection();
+                collection.AddRange(children);
+                return new BrowseResponse
+                {
+                    Results = [new BrowseResult { References = collection }],
+                    DiagnosticInfos = []
+                };
+            });
+
+        var (loader, _) = CreateLoader(
+            shouldAddDynamicProperties: (_, _) => Task.FromResult(true),
+            typeResolver: mockTypeResolver.Object);
+
+        var subject = CreateTestSubject();
+        var rootNode = CreateTestReferenceDescription("Root", new NodeId(1, 0));
+
+        // Act
+        await loader.LoadSubjectAsync(subject, rootNode, mockSession.Object, CancellationToken.None);
+
+        // Assert
+        var registeredSubject = subject.TryGetRegisteredSubject()!;
+        var parent1Property = registeredSubject.Properties.Single(p => p.Name == "Parent1");
+        var parent2Property = registeredSubject.Properties.Single(p => p.Name == "Parent2");
+
+        var parent1Subject = parent1Property.GetValue() as IInterceptorSubject;
+        var parent2Subject = parent2Property.GetValue() as IInterceptorSubject;
+        Assert.NotNull(parent1Subject);
+        Assert.NotNull(parent2Subject);
+
+        var parent1Registered = parent1Subject.TryGetRegisteredSubject()!;
+        var parent2Registered = parent2Subject.TryGetRegisteredSubject()!;
+
+        var sharedFromParent1 = parent1Registered.Properties.SingleOrDefault(p => p.Name == "SharedChild")?.GetValue() as IInterceptorSubject;
+        var sharedFromParent2 = parent2Registered.Properties.SingleOrDefault(p => p.Name == "SharedChild")?.GetValue() as IInterceptorSubject;
+
+        Assert.NotNull(sharedFromParent1);
+        Assert.NotNull(sharedFromParent2);
+        Assert.Same(sharedFromParent1, sharedFromParent2);
+    }
+
+    private static ReferenceDescription CreateObjectReferenceDescription(string name, ExpandedNodeId nodeId)
+    {
+        return new ReferenceDescription
+        {
+            BrowseName = new QualifiedName(name),
+            NodeId = nodeId,
+            NodeClass = NodeClass.Object
+        };
+    }
+
     private Mock<ISession> CreateMockSessionWithChildren(ReferenceDescription[] children)
     {
         var mockSession = CreateMockSession();
@@ -307,7 +486,7 @@ public class OpcUaSubjectLoaderTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BrowseResponse
             {
-                Results = 
+                Results =
                 [
                     new BrowseResult { References = childCollection }
                 ],

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
@@ -153,6 +153,57 @@ public class OpcUaTypeResolverTests
         Assert.Equal(typeof(DynamicSubject), result);
     }
 
+    [Fact]
+    public async Task WhenVariableHasCustomDataTypeSubtype_ThenWalksTypeTreeToBuiltInType()
+    {
+        // Arrange: a Variable whose DataType is a custom NodeId outside the built-in range.
+        // The session's TypeTree walks the custom DataType up to the well-known Double DataType.
+        // This locks in the fix that uses session.TypeTree instead of the static (no-walk) overload.
+        var customDataTypeId = new NodeId(5001, 2);
+        var variableNodeId = new NodeId(2001, 2);
+
+        var mockTypeTable = new Mock<ITypeTable>();
+        mockTypeTable
+            .Setup(t => t.FindSuperTypeAsync(customDataTypeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DataTypeIds.Double);
+
+        var mockSession = CreateMockSession();
+        mockSession.SetupGet(s => s.TypeTree).Returns(mockTypeTable.Object);
+        mockSession
+            .Setup(s => s.ReadAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<double>(),
+                It.IsAny<TimestampsToReturn>(),
+                It.IsAny<ReadValueIdCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReadResponse
+            {
+                ResponseHeader = new ResponseHeader(),
+                Results =
+                [
+                    new DataValue { Value = customDataTypeId, StatusCode = StatusCodes.Good },
+                    new DataValue { Value = -1, StatusCode = StatusCodes.Good }
+                ],
+                DiagnosticInfos = []
+            });
+
+        var variableReference = new ReferenceDescription
+        {
+            BrowseName = new QualifiedName("Temperature"),
+            NodeId = new ExpandedNodeId(variableNodeId),
+            NodeClass = NodeClass.Variable
+        };
+
+        // Act
+        var result = await _resolver.TryGetTypeForNodeAsync(mockSession.Object, variableReference, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(typeof(double), result);
+        mockTypeTable.Verify(
+            t => t.FindSuperTypeAsync(customDataTypeId, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
     private static Mock<ISession> CreateMockSession()
     {
         var mockSession = new Mock<ISession>();

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
@@ -154,6 +154,51 @@ public class OpcUaTypeResolverTests
     }
 
     [Fact]
+    public async Task WhenObjectNodeChildrenHaveNonNumericBracketNames_ThenTypeIsReadOnlyDictionary()
+    {
+        // Arrange
+        var objectReference = new ReferenceDescription
+        {
+            BrowseName = new QualifiedName("Devices"),
+            NodeId = new ExpandedNodeId(new NodeId(4000, 2)),
+            NodeClass = NodeClass.Object
+        };
+
+        var mockSession = CreateMockSession();
+        var childCollection = new ReferenceDescriptionCollection
+        {
+            new ReferenceDescription
+            {
+                BrowseName = new QualifiedName("Device[SensorA]"),
+                NodeId = new ExpandedNodeId(new NodeId(4001, 2)),
+                NodeClass = NodeClass.Object
+            }
+        };
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult { References = childCollection }
+                ],
+                DiagnosticInfos = []
+            });
+
+        // Act
+        var result = await _resolver.TryGetTypeForNodeAsync(mockSession.Object, objectReference, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(typeof(IReadOnlyDictionary<string, DynamicSubject>), result);
+    }
+
+    [Fact]
     public async Task WhenVariableHasCustomDataTypeSubtype_ThenWalksTypeTreeToBuiltInType()
     {
         // Arrange: a Variable whose DataType is a custom NodeId outside the built-in range.

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Namotion.Interceptor.Dynamic;
+using Namotion.Interceptor.OpcUa.Client;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+public class OpcUaTypeResolverTests
+{
+    private readonly OpcUaTypeResolver _resolver;
+
+    public OpcUaTypeResolverTests()
+    {
+        _resolver = new OpcUaTypeResolver(NullLogger<OpcUaTypeResolver>.Instance);
+    }
+
+    [Fact]
+    public async Task WhenObjectNodeChildrenHaveBracketNames_ThenTypeIsDynamicSubjectArray()
+    {
+        // Arrange
+        var objectReference = new ReferenceDescription
+        {
+            BrowseName = new QualifiedName("Items"),
+            NodeId = new ExpandedNodeId(new NodeId(1000, 2)),
+            NodeClass = NodeClass.Object
+        };
+
+        var mockSession = CreateMockSession();
+        var childCollection = new ReferenceDescriptionCollection
+        {
+            new ReferenceDescription
+            {
+                BrowseName = new QualifiedName("Item[0]"),
+                NodeId = new ExpandedNodeId(new NodeId(1001, 2)),
+                NodeClass = NodeClass.Object
+            },
+            new ReferenceDescription
+            {
+                BrowseName = new QualifiedName("Item[1]"),
+                NodeId = new ExpandedNodeId(new NodeId(1002, 2)),
+                NodeClass = NodeClass.Object
+            }
+        };
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult { References = childCollection }
+                ],
+                DiagnosticInfos = []
+            });
+
+        // Act
+        var result = await _resolver.TryGetTypeForNodeAsync(mockSession.Object, objectReference, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(typeof(DynamicSubject[]), result);
+    }
+
+    [Fact]
+    public async Task WhenObjectNodeChildrenHaveRegularNames_ThenTypeIsDynamicSubject()
+    {
+        // Arrange
+        var objectReference = new ReferenceDescription
+        {
+            BrowseName = new QualifiedName("Sensor"),
+            NodeId = new ExpandedNodeId(new NodeId(2000, 2)),
+            NodeClass = NodeClass.Object
+        };
+
+        var mockSession = CreateMockSession();
+        var childCollection = new ReferenceDescriptionCollection
+        {
+            new ReferenceDescription
+            {
+                BrowseName = new QualifiedName("Temperature"),
+                NodeId = new ExpandedNodeId(new NodeId(2001, 2)),
+                NodeClass = NodeClass.Variable
+            },
+            new ReferenceDescription
+            {
+                BrowseName = new QualifiedName("Pressure"),
+                NodeId = new ExpandedNodeId(new NodeId(2002, 2)),
+                NodeClass = NodeClass.Variable
+            }
+        };
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult { References = childCollection }
+                ],
+                DiagnosticInfos = []
+            });
+
+        // Act
+        var result = await _resolver.TryGetTypeForNodeAsync(mockSession.Object, objectReference, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(typeof(DynamicSubject), result);
+    }
+
+    private static Mock<ISession> CreateMockSession()
+    {
+        var mockSession = new Mock<ISession>();
+        mockSession.SetupGet(s => s.NamespaceUris).Returns(new NamespaceTable());
+        return mockSession;
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaTypeResolverTests.cs
@@ -118,6 +118,41 @@ public class OpcUaTypeResolverTests
         Assert.Equal(typeof(DynamicSubject), result);
     }
 
+    [Fact]
+    public async Task WhenObjectNodeHasNoChildren_ThenTypeIsDynamicSubject()
+    {
+        // Arrange
+        var objectReference = new ReferenceDescription
+        {
+            BrowseName = new QualifiedName("Empty"),
+            NodeId = new ExpandedNodeId(new NodeId(3000, 2)),
+            NodeClass = NodeClass.Object
+        };
+
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult { References = new ReferenceDescriptionCollection() }
+                ],
+                DiagnosticInfos = []
+            });
+
+        // Act
+        var result = await _resolver.TryGetTypeForNodeAsync(mockSession.Object, objectReference, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(typeof(DynamicSubject), result);
+    }
+
     private static Mock<ISession> CreateMockSession()
     {
         var mockSession = new Mock<ISession>();

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -320,6 +320,7 @@ namespace Namotion.Interceptor.OpcUa
     public class OpcUaSubjectFactory
     {
         public OpcUaSubjectFactory(Namotion.Interceptor.Connectors.ISubjectFactory subjectFactory) { }
+        public virtual System.Threading.Tasks.Task<Namotion.Interceptor.IInterceptorSubject> CreateCollectionSubjectAsync(Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty collectionProperty, Opc.Ua.ReferenceDescription node, object? index, Opc.Ua.Client.ISession session, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task<Namotion.Interceptor.IInterceptorSubject> CreateSubjectAsync(Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty property, Opc.Ua.ReferenceDescription node, Opc.Ua.Client.ISession session, System.Threading.CancellationToken cancellationToken) { }
     }
     public class OpcUaValueConverter

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectLoader.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectLoader.cs
@@ -292,8 +292,20 @@ internal class OpcUaSubjectLoader
         {
             var childNode = childNodes[i];
             var childSubject = i < existingChildren.Length ? existingChildren[i].Subject : null;
+            var nodeId = ExpandedNodeId.ToNodeId(childNode.NodeId, session.NamespaceUris);
+
+            if (childSubject is null && nodeId is not null)
+            {
+                subjectsByNodeId.TryGetValue(nodeId, out childSubject);
+            }
+
             childSubject ??= await _configuration.SubjectFactory.CreateCollectionSubjectAsync(
                 property, childNode, i, session, cancellationToken).ConfigureAwait(false);
+
+            if (nodeId is not null)
+            {
+                subjectsByNodeId.TryAdd(nodeId, childSubject);
+            }
 
             children.Add((childNode, childSubject));
         }
@@ -328,9 +340,22 @@ internal class OpcUaSubjectLoader
         foreach (var childNode in childNodes)
         {
             var key = childNode.BrowseName.Name; // Use BrowseName as dictionary key
-            var childSubject = existingChildren.GetValueOrDefault(key)
-                ?? await _configuration.SubjectFactory.CreateCollectionSubjectAsync(
-                    property, childNode, key, session, cancellationToken).ConfigureAwait(false);
+            var childSubject = existingChildren.GetValueOrDefault(key);
+            var nodeId = ExpandedNodeId.ToNodeId(childNode.NodeId, session.NamespaceUris);
+
+            if (childSubject is null && nodeId is not null)
+            {
+                subjectsByNodeId.TryGetValue(nodeId, out childSubject);
+            }
+
+            childSubject ??= await _configuration.SubjectFactory.CreateCollectionSubjectAsync(
+                property, childNode, key, session, cancellationToken).ConfigureAwait(false);
+
+            if (nodeId is not null)
+            {
+                subjectsByNodeId.TryAdd(nodeId, childSubject);
+            }
+
             entries[key] = childSubject;
             nodesByKey[key] = childNode;
         }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectLoader.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectLoader.cs
@@ -36,7 +36,8 @@ internal class OpcUaSubjectLoader
     {
         var monitoredItems = new List<MonitoredItem>();
         var loadedSubjects = new HashSet<IInterceptorSubject>();
-        await LoadSubjectAsync(subject, node, session, monitoredItems, loadedSubjects, cancellationToken).ConfigureAwait(false);
+        var subjectsByNodeId = new Dictionary<NodeId, IInterceptorSubject>();
+        await LoadSubjectAsync(subject, node, session, monitoredItems, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
         return monitoredItems;
     }
 
@@ -45,6 +46,7 @@ internal class OpcUaSubjectLoader
         ISession session,
         List<MonitoredItem> monitoredItems,
         HashSet<IInterceptorSubject> loadedSubjects,
+        Dictionary<NodeId, IInterceptorSubject> subjectsByNodeId,
         CancellationToken cancellationToken)
     {
         if (!loadedSubjects.Add(subject))
@@ -127,16 +129,16 @@ internal class OpcUaSubjectLoader
                     }
                     else
                     {
-                        await LoadSubjectReferenceAsync(property, nodeReference, subject, session, monitoredItems, loadedSubjects, cancellationToken).ConfigureAwait(false);
+                        await LoadSubjectReferenceAsync(property, nodeReference, subject, session, monitoredItems, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
                     }
                 }
                 else if (property.IsSubjectCollection)
                 {
-                    await LoadSubjectCollectionAsync(property, childNodeId, monitoredItems, session, loadedSubjects, cancellationToken).ConfigureAwait(false);
+                    await LoadSubjectCollectionAsync(property, childNodeId, monitoredItems, session, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
                 }
                 else if (property.IsSubjectDictionary)
                 {
-                    await LoadSubjectDictionaryAsync(property, childNodeId, monitoredItems, session, loadedSubjects, cancellationToken).ConfigureAwait(false);
+                    await LoadSubjectDictionaryAsync(property, childNodeId, monitoredItems, session, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -240,20 +242,34 @@ internal class OpcUaSubjectLoader
         ISession session,
         List<MonitoredItem> monitoredItems,
         HashSet<IInterceptorSubject> loadedSubjects,
+        Dictionary<NodeId, IInterceptorSubject> subjectsByNodeId,
         CancellationToken cancellationToken)
     {
         var existingSubject = property.Children.SingleOrDefault();
         if (existingSubject.Subject is not null)
         {
-            await LoadSubjectAsync(existingSubject.Subject, nodeReference, session, monitoredItems, loadedSubjects, cancellationToken).ConfigureAwait(false);
+            await LoadSubjectAsync(existingSubject.Subject, nodeReference, session, monitoredItems, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            // Create new subject instance
-            var newSubject = await _configuration.SubjectFactory.CreateSubjectAsync(property, nodeReference, session, cancellationToken).ConfigureAwait(false);
-            newSubject.Context.AddFallbackContext(subject.Context);
-            await LoadSubjectAsync(newSubject, nodeReference, session, monitoredItems, loadedSubjects, cancellationToken).ConfigureAwait(false);
-            property.SetValueFromSource(_source, null, null, newSubject);
+            var nodeId = ExpandedNodeId.ToNodeId(nodeReference.NodeId, session.NamespaceUris);
+            if (nodeId is not null && subjectsByNodeId.TryGetValue(nodeId, out var reusedSubject))
+            {
+                property.SetValueFromSource(_source, null, null, reusedSubject);
+            }
+            else
+            {
+                var newSubject = await _configuration.SubjectFactory.CreateSubjectAsync(property, nodeReference, session, cancellationToken).ConfigureAwait(false);
+                newSubject.Context.AddFallbackContext(subject.Context);
+
+                if (nodeId is not null)
+                {
+                    subjectsByNodeId[nodeId] = newSubject;
+                }
+
+                await LoadSubjectAsync(newSubject, nodeReference, session, monitoredItems, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
+                property.SetValueFromSource(_source, null, null, newSubject);
+            }
         }
     }
 
@@ -262,20 +278,22 @@ internal class OpcUaSubjectLoader
         List<MonitoredItem> monitoredItems,
         ISession session,
         HashSet<IInterceptorSubject> loadedSubjects,
+        Dictionary<NodeId, IInterceptorSubject> subjectsByNodeId,
         CancellationToken cancellationToken)
     {
         var childNodes = await BrowseNodeAsync(childNodeId, session, cancellationToken).ConfigureAwait(false);
         var childCount = childNodes.Count;
         var children = new List<(ReferenceDescription Node, IInterceptorSubject Subject)>(childCount);
-        
+
         // Convert to array once to avoid multiple enumerations
         var existingChildren = property.Children.ToArray();
-        
+
         for (var i = 0; i < childCount; i++)
         {
             var childNode = childNodes[i];
             var childSubject = i < existingChildren.Length ? existingChildren[i].Subject : null;
-            childSubject ??= DefaultSubjectFactory.Instance.CreateCollectionSubject(property, i);
+            childSubject ??= await _configuration.SubjectFactory.CreateCollectionSubjectAsync(
+                property, childNode, i, session, cancellationToken).ConfigureAwait(false);
 
             children.Add((childNode, childSubject));
         }
@@ -289,7 +307,7 @@ internal class OpcUaSubjectLoader
         // Requires making monitoredItems and loadedSubjects thread-safe (e.g., ConcurrentBag, ConcurrentHashSet).
         foreach (var child in children)
         {
-            await LoadSubjectAsync(child.Subject, child.Node, session, monitoredItems, loadedSubjects, cancellationToken).ConfigureAwait(false);
+            await LoadSubjectAsync(child.Subject, child.Node, session, monitoredItems, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -299,6 +317,7 @@ internal class OpcUaSubjectLoader
         List<MonitoredItem> monitoredItems,
         ISession session,
         HashSet<IInterceptorSubject> loadedSubjects,
+        Dictionary<NodeId, IInterceptorSubject> subjectsByNodeId,
         CancellationToken cancellationToken)
     {
         var childNodes = await BrowseNodeAsync(childNodeId, session, cancellationToken).ConfigureAwait(false);
@@ -310,7 +329,8 @@ internal class OpcUaSubjectLoader
         {
             var key = childNode.BrowseName.Name; // Use BrowseName as dictionary key
             var childSubject = existingChildren.GetValueOrDefault(key)
-                ?? DefaultSubjectFactory.Instance.CreateCollectionSubject(property, key);
+                ?? await _configuration.SubjectFactory.CreateCollectionSubjectAsync(
+                    property, childNode, key, session, cancellationToken).ConfigureAwait(false);
             entries[key] = childSubject;
             nodesByKey[key] = childNode;
         }
@@ -321,7 +341,7 @@ internal class OpcUaSubjectLoader
         foreach (var entry in entries)
         {
             var childNode = nodesByKey[entry.Key];
-            await LoadSubjectAsync(entry.Value, childNode, session, monitoredItems, loadedSubjects, cancellationToken).ConfigureAwait(false);
+            await LoadSubjectAsync(entry.Value, childNode, session, monitoredItems, loadedSubjects, subjectsByNodeId, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
@@ -63,11 +63,13 @@ public class OpcUaTypeResolver
                 }
             };
 
+            // Browse only the first child: the [index] convention requires every collection
+            // element to follow the pattern, so the first reference is enough to classify the parent.
             var response = await session.BrowseAsync(null, null, 1u, browseDescriptions, cancellationToken);
             if (response.Results.Count > 0 &&
                 response.Results[0].References.Count > 0 &&
                 response.Results[0].References[0].NodeClass == NodeClass.Object &&
-                response.Results[0].References[0].BrowseName.Name.Contains('['))
+                response.Results[0].References[0].BrowseName?.Name?.Contains('[') == true)
             {
                 return typeof(DynamicSubject[]);
             }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
@@ -59,23 +59,20 @@ public class OpcUaTypeResolver
                     ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
                     IncludeSubtypes = true,
                     NodeClassMask = (uint)NodeClass.Variable | (uint)NodeClass.Object,
-                    ResultMask = (uint)BrowseResultMask.All
+                    ResultMask = (uint)(BrowseResultMask.BrowseName | BrowseResultMask.NodeClass)
                 }
             };
 
-            var response = await session.BrowseAsync(
-                null,
-                null,
-                0u,
-                browseDescriptions,
-                cancellationToken);
-
-            if (response.Results.Count > 0 && response.Results[0].References.Any(n => n.NodeClass == NodeClass.Variable))
+            var response = await session.BrowseAsync(null, null, 1u, browseDescriptions, cancellationToken);
+            if (response.Results.Count > 0 &&
+                response.Results[0].References.Count > 0 &&
+                response.Results[0].References[0].NodeClass == NodeClass.Object &&
+                response.Results[0].References[0].BrowseName.Name.Contains('['))
             {
-                return typeof(DynamicSubject);
+                return typeof(DynamicSubject[]);
             }
 
-            return typeof(DynamicSubject[]);
+            return typeof(DynamicSubject);
         }
 
         try
@@ -97,7 +94,7 @@ public class OpcUaTypeResolver
                 var dataTypeId = response.Results[0].Value as NodeId;
                 if (dataTypeId != null)
                 {
-                    var builtIn = TypeInfo.GetBuiltInType(dataTypeId);
+                    var builtIn = await TypeInfo.GetBuiltInTypeAsync(dataTypeId, session.TypeTree, cancellationToken);
                     var elementType = TryMapBuiltInType(builtIn);
                     if (elementType is not null)
                     {
@@ -138,14 +135,21 @@ public class OpcUaTypeResolver
         BuiltInType.DateTime => typeof(DateTime),
         BuiltInType.Guid => typeof(Guid),
         BuiltInType.ByteString => typeof(byte[]),
+        BuiltInType.XmlElement => typeof(string),
         BuiltInType.NodeId => typeof(NodeId),
         BuiltInType.ExpandedNodeId => typeof(ExpandedNodeId),
         BuiltInType.StatusCode => typeof(StatusCode),
         BuiltInType.QualifiedName => typeof(QualifiedName),
         BuiltInType.LocalizedText => typeof(LocalizedText),
         BuiltInType.DiagnosticInfo => typeof(DiagnosticInfo),
+        BuiltInType.ExtensionObject => typeof(ExtensionObject),
         BuiltInType.DataValue => typeof(DataValue),
-        BuiltInType.Enumeration => typeof(int), // map enum to underlying Int32
+        BuiltInType.Enumeration => typeof(int),
+        BuiltInType.Number => typeof(double),
+        BuiltInType.Integer => typeof(long),
+        BuiltInType.UInteger => typeof(ulong),
+        BuiltInType.Variant => null,
+        BuiltInType.Null => null,
         _ => null
     };
 }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaTypeResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Namotion.Interceptor.Dynamic;
 using Namotion.Interceptor.OpcUa.Attributes;
@@ -63,15 +64,28 @@ public class OpcUaTypeResolver
                 }
             };
 
-            // Browse only the first child: the [index] convention requires every collection
+            // Browse only the first child: the [index] convention requires every collection/dictionary
             // element to follow the pattern, so the first reference is enough to classify the parent.
             var response = await session.BrowseAsync(null, null, 1u, browseDescriptions, cancellationToken);
             if (response.Results.Count > 0 &&
                 response.Results[0].References.Count > 0 &&
-                response.Results[0].References[0].NodeClass == NodeClass.Object &&
-                response.Results[0].References[0].BrowseName?.Name?.Contains('[') == true)
+                response.Results[0].References[0].NodeClass == NodeClass.Object)
             {
-                return typeof(DynamicSubject[]);
+                var name = response.Results[0].References[0].BrowseName?.Name;
+                if (name is not null)
+                {
+                    var bracketStart = name.LastIndexOf('[');
+                    if (bracketStart >= 0 && name.EndsWith("]"))
+                    {
+                        var content = name.AsSpan(bracketStart + 1, name.Length - bracketStart - 2);
+                        if (int.TryParse(content, out _))
+                        {
+                            return typeof(DynamicSubject[]);
+                        }
+
+                        return typeof(IReadOnlyDictionary<string, DynamicSubject>);
+                    }
+                }
             }
 
             return typeof(DynamicSubject);

--- a/src/Namotion.Interceptor.OpcUa/OpcUaSubjectFactory.cs
+++ b/src/Namotion.Interceptor.OpcUa/OpcUaSubjectFactory.cs
@@ -20,4 +20,11 @@ public class OpcUaSubjectFactory
     {
         return Task.FromResult(_subjectFactory.CreateSubject(property));
     }
+
+    public virtual Task<IInterceptorSubject> CreateCollectionSubjectAsync(
+        RegisteredSubjectProperty collectionProperty, ReferenceDescription node, object? index,
+        ISession session, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_subjectFactory.CreateCollectionSubject(collectionProperty, index));
+    }
 }

--- a/src/Namotion.Interceptor.OpcUa/OpcUaSubjectFactory.cs
+++ b/src/Namotion.Interceptor.OpcUa/OpcUaSubjectFactory.cs
@@ -1,10 +1,16 @@
-﻿using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Connectors;
 using Namotion.Interceptor.Registry.Abstractions;
 using Opc.Ua;
 using Opc.Ua.Client;
 
 namespace Namotion.Interceptor.OpcUa;
 
+/// <summary>
+/// Factory for materializing subjects discovered via OPC UA browse during dynamic discovery.
+/// Subclasses that override <see cref="CreateSubjectAsync"/> should usually also override
+/// <see cref="CreateCollectionSubjectAsync"/>; otherwise collection elements fall back to the
+/// default factory and skip the subclass customizations.
+/// </summary>
 public class OpcUaSubjectFactory
 {
     private readonly ISubjectFactory _subjectFactory;
@@ -14,6 +20,9 @@ public class OpcUaSubjectFactory
         _subjectFactory = subjectFactory;
     }
 
+    /// <summary>
+    /// Creates a subject for a single (non-collection) reference property.
+    /// </summary>
     public virtual Task<IInterceptorSubject> CreateSubjectAsync(
         RegisteredSubjectProperty property, ReferenceDescription node,
         ISession session, CancellationToken cancellationToken)
@@ -21,6 +30,10 @@ public class OpcUaSubjectFactory
         return Task.FromResult(_subjectFactory.CreateSubject(property));
     }
 
+    /// <summary>
+    /// Creates a subject for an element of a collection or dictionary property.
+    /// <paramref name="index"/> is the integer index for collections or the string key for dictionaries.
+    /// </summary>
     public virtual Task<IInterceptorSubject> CreateCollectionSubjectAsync(
         RegisteredSubjectProperty collectionProperty, ReferenceDescription node, object? index,
         ISession session, CancellationToken cancellationToken)


### PR DESCRIPTION
## OPC UA library (`Namotion.Interceptor.OpcUa`)

- Fix type resolver to use `session.TypeTree` for custom DataType resolution
- Add missing BuiltInType mappings (Number, Integer, UInteger, XmlElement, ExtensionObject); skip Variant/Null
- Detect collections via `[index]` BrowseName convention instead of the prior Variable-child heuristic
- Browse only the first child for collection classification (narrower result mask, MaxResultsToReturn=1)
- Null-guard `BrowseName.Name` in collection convention check
- Add `CreateCollectionSubjectAsync` extension point on `OpcUaSubjectFactory`; route collection/dictionary child creation through it
- Document `OpcUaSubjectFactory` virtual methods and the dual-override expectation
- NodeId-based subject deduplication across single references, collection elements, and dictionary entries: any property resolving to the same NodeId during a load shares one subject instance and one set of monitored items
- Tests for type resolver (bracket/regular/empty), Number and ExtensionObject mappings, and shared-node reuse for both single-reference and collection paths

## HomeBlaze (`HomeBlaze.OpcUa` + `HomeBlaze.Services`)

- Add `OpcUaDynamicSubject` (extends `DynamicSubject`, implements `ITitleProvider`) and `HomeBlazeOpcUaSubjectFactory`
- Use the new factory for both single and collection subjects so dynamic OPC UA nodes render with proper titles
- Reduce diagnostics polling interval to 10s and refresh once immediately after connect
- Migrate `PropertyAttributeInitializer` from `ILifecycleHandler` to `IPropertyLifecycleHandler` so dynamically added properties also get `[State]` / `[Configuration]` metadata
- Guard re-initialization with `TryGetAttribute(...) is null` to avoid duplicate metadata
- `SubjectPathResolver` orders multi-parent paths by depth (shallowest first) using a precomputed depth key
- `SubjectPropertyPanel` filters out `IsAttribute` properties from the primitive list
- Test for shortest-path-first behavior on shared subjects

## Docs

- New "Type Resolution" and "Subject Deduplication" sections in `connectors-opcua-client.md`