### PR TITLE
feature: Add RecalculateDerivedProperty()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ The library has specialized support for:
 
 - **Naming**: `When<Condition>_Then<ExpectedBehavior>` (e.g., `WhenDepthIsZero_ThenReturnsNoChildren`)
 - **Structure**: Explicit `// Arrange`, `// Act`, `// Assert` comments separating each phase (use `// Act & Assert` for exception tests)
+- **No hardcoded waits**: Use `AsyncTestHelpers.WaitUntilAsync(() => condition)` or event-based synchronization (`ManualResetEventSlim`, `CountdownEvent`) instead of `Task.Delay`/`Thread.Sleep`. Hardcoded delays are either too long (slow CI) or too short (flaky CI).
 
 ## Public API Tracking
 

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -187,7 +187,7 @@ person.LastName = "Doe";
 - When a dependency changes, the derived property is recalculated
 - If the derived value changes, a change event is triggered with `Source = null` (indicating local calculation)
 
-### Manual Recalculation for External Data
+### Manual Recalculation
 
 When a derived property's getter depends on data outside the interceptor system (external APIs, services, static state, etc.), automatic dependency tracking cannot detect changes. Use `RecalculateDerivedProperty()` to manually trigger recalculation:
 

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -187,6 +187,28 @@ person.LastName = "Doe";
 - When a dependency changes, the derived property is recalculated
 - If the derived value changes, a change event is triggered with `Source = null` (indicating local calculation)
 
+### Manual Recalculation for External Data
+
+When a derived property's getter depends on data outside the interceptor system (external APIs, services, static state, etc.), automatic dependency tracking cannot detect changes. Use `RecalculateDerivedProperty()` to manually trigger recalculation:
+
+```csharp
+[InterceptorSubject]
+public partial class Sensor
+{
+    public partial string? Label { get; set; }
+
+    [Derived]
+    public double CalibratedTemperature => _externalService.GetCalibratedTemperature();
+}
+
+// When external data changes, trigger recalculation:
+var property = new PropertyReference(sensor, nameof(Sensor.CalibratedTemperature));
+property.RecalculateDerivedProperty();
+// Getter is re-evaluated; if the value changed, change notifications fire
+```
+
+This goes through the same pipeline as automatic recalculation: the getter is re-evaluated, dependencies are updated, and all notifications (observable, queue, `INotifyPropertyChanged`) fire if the value changed. It is fully thread-safe and can be called concurrently with property writes.
+
 > **Internal design:** For details on the dependency graph, concurrency model, and correctness guarantees, see [Derived Property Design](design/tracking-derived-properties.md).
 
 ## Context Inheritance

--- a/src/Namotion.Interceptor.Connectors.Tests/BackgroundTaskLifetimeTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/BackgroundTaskLifetimeTests.cs
@@ -72,7 +72,7 @@ public class BackgroundTaskLifetimeTests
             NullLogger.Instance,
             _ => throw new InvalidOperationException("monitor failed"));
 
-        await Task.Delay(50);
+        await Task.Yield();
 
         // Act & Assert
         await lifetime.DisposeAsync();
@@ -144,7 +144,7 @@ public class BackgroundTaskLifetimeTests
             NullLogger.Instance,
             _ => Task.CompletedTask);
 
-        await Task.Delay(50);
+        await Task.Yield();
 
         // Act & Assert
         await lifetime.DisposeAsync();

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionAsyncTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionAsyncTests.cs
@@ -1,5 +1,6 @@
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Connectors.Tests.Models;
+using Namotion.Interceptor.Testing;
 using Namotion.Interceptor.Tracking;
 using Namotion.Interceptor.Tracking.Transactions;
 
@@ -21,6 +22,7 @@ public class SubjectTransactionAsyncTests
 
         Task<SubjectTransaction> tx2Task;
         var tx2AcquiredTcs = new TaskCompletionSource<bool>();
+        var tx2Started = new TaskCompletionSource<bool>();
 
         // Act
         using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
@@ -31,17 +33,17 @@ public class SubjectTransactionAsyncTests
             {
                 tx2Task = Task.Run(async () =>
                 {
+                    tx2Started.SetResult(true);
                     var tx = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
                     tx2AcquiredTcs.SetResult(true);
                     return tx;
                 });
             }
 
-            // Wait a bit
-            await Task.Delay(100);
-
             // Assert
-            // tx2 should be waiting because tx1 has not been disposed
+            // Wait for tx2 to start, then verify it hasn't acquired the lock
+            await tx2Started.Task;
+            await Task.Yield();
             Assert.False(tx2AcquiredTcs.Task.IsCompleted, "tx2 should be waiting for lock");
         }
 
@@ -105,11 +107,10 @@ public class SubjectTransactionAsyncTests
 
         // Act
         // Give tx2 time to start
-        while (!tx2Started)
-            await Task.Delay(1);
+        await AsyncTestHelpers.WaitUntilAsync(() => tx2Started);
 
         // tx2 should be waiting for lock (not yet completed)
-        await Task.Delay(100);
+        await Task.Yield();
 
         // Assert
         Assert.False(tx2Acquired, "tx2 should not have acquired lock yet");

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionOptimisticLockingTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionOptimisticLockingTests.cs
@@ -107,7 +107,8 @@ public class SubjectTransactionOptimisticLockingTests
         var person = new Person(context);
 
         var tx1Acquired = new TaskCompletionSource<bool>();
-        var tx1Complete = new TaskCompletionSource<bool>();
+        var tx1CanCommit = new TaskCompletionSource<bool>();
+        var tx2Started = new TaskCompletionSource<bool>();
 
         Task tx1Task;
         using (ExecutionContext.SuppressFlow())
@@ -121,11 +122,9 @@ public class SubjectTransactionOptimisticLockingTests
 
                 person.FirstName = "Tx1";
 
-                // Hold the lock for a bit
-                await Task.Delay(500);
+                await tx1CanCommit.Task;
 
                 await tx.CommitAsync(CancellationToken.None);
-                tx1Complete.SetResult(true);
             });
         }
 
@@ -135,9 +134,9 @@ public class SubjectTransactionOptimisticLockingTests
         Task<SubjectTransaction> tx2Task;
         using (ExecutionContext.SuppressFlow())
         {
-            // Try to start tx2 - should block until tx1 completes
             tx2Task = Task.Run(async () =>
             {
+                tx2Started.SetResult(true);
                 return await context.BeginTransactionAsync(
                     TransactionFailureHandling.BestEffort,
                     TransactionLocking.Exclusive);
@@ -145,12 +144,13 @@ public class SubjectTransactionOptimisticLockingTests
         }
 
         // Act
-        // Wait a bit - tx2 should still be waiting
-        await Task.Delay(100);
+        await tx2Started.Task;
+        await Task.Yield();
         Assert.False(tx2Task.IsCompleted, "tx2 should wait for tx1 to complete");
 
-        // Wait for tx1 to complete
-        await tx1Complete.Task;
+        // Release tx1 to commit
+        tx1CanCommit.SetResult(true);
+        await tx1Task;
 
         // Now tx2 should complete
         using var tx2 = await tx2Task;
@@ -347,7 +347,6 @@ public class SubjectTransactionOptimisticLockingTests
 
                 // Wait for optimistic to signal it's trying to commit
                 await optimisticCommitStarted.Task;
-                await Task.Delay(100);
 
                 await tx.CommitAsync(CancellationToken.None);
                 exclusiveComplete.SetResult(true);

--- a/src/Namotion.Interceptor.Connectors.Tests/WriteRetryQueueTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/WriteRetryQueueTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Namotion.Interceptor.Testing;
 using Namotion.Interceptor.Tracking.Change;
 
 namespace Namotion.Interceptor.Connectors.Tests;
@@ -215,7 +216,7 @@ public class WriteRetryQueueTests
         var flush1 = queue.FlushAsync(sourceMock.Object, CancellationToken.None);
         var flush2 = queue.FlushAsync(sourceMock.Object, CancellationToken.None);
 
-        await Task.Delay(100); // Let them start
+        await AsyncTestHelpers.WaitUntilAsync(() => callCount >= 1);
 
         // Assert - only one should be running
         Assert.Equal(1, callCount);

--- a/src/Namotion.Interceptor.Hosting.Tests/HostedServiceHandlerTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/HostedServiceHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Namotion.Interceptor.Hosting.Tests.Models;
+using Namotion.Interceptor.Testing;
 using Namotion.Interceptor.Tracking;
 
 namespace Namotion.Interceptor.Hosting.Tests;
@@ -16,14 +17,14 @@ public class HostedServiceHandlerTests
         await RunWithAppLifecycleAsync(async context =>
         {
             person = new PersonWithBackgroundService(context);
-            await Task.Delay(100);
-            
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
+
             // Assert
             Assert.Equal("John", person.FirstName);
             Assert.Equal("Doe", person.LastName);
         });
-        
-        await Task.Delay(100);
+
+        await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "Disposed");
         Assert.Equal("Disposed", person.FirstName);
     }
     
@@ -40,14 +41,14 @@ public class HostedServiceHandlerTests
             var hostedService = new PersonBackgroundService(person);
             person.AttachHostedService(hostedService);
 
-            await Task.Delay(100);
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
 
             // Assert
             Assert.Equal("John", person.FirstName);
             Assert.Equal("Doe", person.LastName);
         });
-        
-        await Task.Delay(100);
+
+        await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "Disposed");
         Assert.Equal("Disposed", person.FirstName);
     }
     
@@ -63,9 +64,9 @@ public class HostedServiceHandlerTests
             var hostedService = new PersonBackgroundService(person);
             person.AttachHostedService(hostedService);
             var attachedHostedServices = person.GetAttachedHostedServices();
-            
-            await Task.Delay(100);
-            
+
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
+
             Assert.Equal("John", person.FirstName);
             Assert.Equal("Doe", person.LastName);
             Assert.Single(attachedHostedServices);
@@ -75,7 +76,7 @@ public class HostedServiceHandlerTests
             attachedHostedServices = person.GetAttachedHostedServices();
 
             // Assert
-            await Task.Delay(100);
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "Disposed");
             Assert.Equal("Disposed", person.FirstName);
             Assert.Empty(attachedHostedServices);
         });
@@ -94,7 +95,7 @@ public class HostedServiceHandlerTests
             person.AttachHostedService(hostedService);
             var attachedHostedServices = person.GetAttachedHostedServices();
 
-            await Task.Delay(100);
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
             Assert.Single(attachedHostedServices);
 
             // Act
@@ -102,7 +103,7 @@ public class HostedServiceHandlerTests
             attachedHostedServices = person.GetAttachedHostedServices();
 
             // Assert
-            await Task.Delay(100);
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "Disposed");
             Assert.Equal("Disposed", person.FirstName);
             Assert.Empty(attachedHostedServices); // the service has been stopped and
                                                    // removed from list (not allowed to restart again anyway)
@@ -128,7 +129,7 @@ public class HostedServiceHandlerTests
             Assert.Single(person.GetAttachedHostedServices());
         });
 
-        await Task.Delay(100);
+        await AsyncTestHelpers.WaitUntilAsync(() => person!.FirstName == "Disposed");
         Assert.Equal("Disposed", person!.FirstName);
     }
 

--- a/src/Namotion.Interceptor.Hosting.Tests/Namotion.Interceptor.Hosting.Tests.csproj
+++ b/src/Namotion.Interceptor.Hosting.Tests/Namotion.Interceptor.Hosting.Tests.csproj
@@ -29,6 +29,7 @@
       <ProjectReference Include="..\Namotion.Interceptor.Generator\Namotion.Interceptor.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
       <ProjectReference Include="..\Namotion.Interceptor.Hosting\Namotion.Interceptor.Hosting.csproj" />
       <ProjectReference Include="..\Namotion.Interceptor.Tracking\Namotion.Interceptor.Tracking.csproj" />
+      <ProjectReference Include="..\Namotion.Interceptor.Testing\Namotion.Interceptor.Testing.csproj" />
       <ProjectReference Include="..\Namotion.Interceptor\Namotion.Interceptor.csproj" />
     </ItemGroup>
 

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeQueueTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeQueueTests.cs
@@ -239,7 +239,7 @@ public class PropertyChangeQueueTests
 
         // Assert
         var dequeued = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (subscription.TryDequeue(out _, cts.Token))
         {
             dequeued++;

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeQueueTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeQueueTests.cs
@@ -1,0 +1,252 @@
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+public class PropertyChangeQueueTests
+{
+    [Fact]
+    public void WhenPropertyChanged_ThenChangeIsEnqueued()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+        var cts = new CancellationTokenSource();
+
+        // Act
+        person.FirstName = "John";
+        cts.Cancel();
+
+        // Assert
+        Assert.True(subscription.TryDequeue(out var change, CancellationToken.None));
+        Assert.Equal(nameof(Person.FirstName), change.Property.Name);
+        Assert.Null(change.GetOldValue<string?>());
+        Assert.Equal("John", change.GetNewValue<string?>());
+    }
+
+    [Fact]
+    public void WhenMultiplePropertiesChanged_ThenAllChangesAreEnqueuedInOrder()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+
+        // Act
+        person.FirstName = "John";
+        person.LastName = "Doe";
+
+        // Assert
+        Assert.True(subscription.TryDequeue(out var change1, CancellationToken.None));
+        Assert.Equal(nameof(Person.FirstName), change1.Property.Name);
+
+        Assert.True(subscription.TryDequeue(out var change2, CancellationToken.None));
+        Assert.Equal(nameof(Person.LastName), change2.Property.Name);
+    }
+
+    [Fact]
+    public void WhenMultipleSubscriptionsExist_ThenAllReceiveChanges()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription1 = context.CreatePropertyChangeQueueSubscription();
+        using var subscription2 = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+
+        // Act
+        person.FirstName = "John";
+
+        // Assert
+        Assert.True(subscription1.TryDequeue(out var change1, CancellationToken.None));
+        Assert.Equal("John", change1.GetNewValue<string?>());
+
+        Assert.True(subscription2.TryDequeue(out var change2, CancellationToken.None));
+        Assert.Equal("John", change2.GetNewValue<string?>());
+    }
+
+    [Fact]
+    public void WhenSubscriptionDisposed_ThenTryDequeueReturnsFalse()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        var subscription = context.CreatePropertyChangeQueueSubscription();
+
+        // Act
+        subscription.Dispose();
+
+        // Assert
+        Assert.False(subscription.TryDequeue(out _, CancellationToken.None));
+    }
+
+    [Fact]
+    public void WhenCancellationRequested_ThenTryDequeueReturnsFalse()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription = context.CreatePropertyChangeQueueSubscription();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var result = subscription.TryDequeue(out _, cts.Token);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task WhenNoChanges_ThenTryDequeueBlocksUntilChange()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+        SubjectPropertyChange? received = null;
+
+        // Act
+        var consumer = Task.Run(() =>
+        {
+            if (subscription.TryDequeue(out var change, CancellationToken.None))
+            {
+                received = change;
+            }
+        });
+
+        person.FirstName = "John";
+        await AsyncTestHelpers.WaitUntilAsync(() => consumer.IsCompleted, message: "Consumer should have received change");
+
+        // Assert
+        Assert.NotNull(received);
+        Assert.Equal("John", received.Value.GetNewValue<string?>());
+    }
+
+    [Fact]
+    public async Task WhenSubscriptionDisposedWhileWaiting_ThenConsumerWakes()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        var subscription = context.CreatePropertyChangeQueueSubscription();
+        bool? result = null;
+
+        // Act
+        var consumer = Task.Run(() =>
+        {
+            result = subscription.TryDequeue(out _, CancellationToken.None);
+        });
+
+        subscription.Dispose();
+        await AsyncTestHelpers.WaitUntilAsync(() => consumer.IsCompleted, message: "Consumer should wake on dispose");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void WhenUnsubscribed_ThenNoMoreChangesReceived()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        var subscription = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+
+        person.FirstName = "Before";
+        Assert.True(subscription.TryDequeue(out _, CancellationToken.None));
+
+        // Act
+        subscription.Dispose();
+        person.FirstName = "After";
+
+        // Assert
+        Assert.False(subscription.TryDequeue(out _, CancellationToken.None));
+    }
+
+    [Fact]
+    public void WhenSetValueFromSourceCalled_ThenSourceAndTimestampsAreAvailable()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+        var source = new object();
+        var changedTimestamp = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        var receivedTimestamp = new DateTimeOffset(2026, 1, 15, 10, 30, 1, TimeSpan.Zero);
+
+        // Act
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+        property.SetValueFromSource(source, changedTimestamp, receivedTimestamp, "FromSource");
+
+        // Assert
+        Assert.True(subscription.TryDequeue(out var change, CancellationToken.None));
+        Assert.Equal("FromSource", change.GetNewValue<string?>());
+        Assert.Same(source, change.Source);
+        Assert.Equal(changedTimestamp, change.ChangedTimestamp);
+        Assert.Equal(receivedTimestamp, change.ReceivedTimestamp);
+    }
+
+    [Fact]
+    public void WhenQueueDisposed_ThenAllSubscriptionsDisposed()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        var queue = context.GetService<PropertyChangeQueue>();
+        var subscription1 = queue.Subscribe();
+        var subscription2 = queue.Subscribe();
+
+        // Act
+        queue.Dispose();
+
+        // Assert
+        Assert.False(subscription1.TryDequeue(out _, CancellationToken.None));
+        Assert.False(subscription2.TryDequeue(out _, CancellationToken.None));
+    }
+
+    [Fact]
+    public void WhenConcurrentProducers_ThenAllChangesAreDequeued()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithPropertyChangeQueue();
+
+        using var subscription = context.CreatePropertyChangeQueueSubscription();
+        var person = new Person(context);
+        var changeCount = 100;
+
+        // Act
+        Parallel.For(0, changeCount, i =>
+        {
+            person.FirstName = $"Name{i}";
+        });
+
+        // Assert
+        var dequeued = 0;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (subscription.TryDequeue(out _, cts.Token))
+        {
+            dequeued++;
+        }
+
+        Assert.Equal(changeCount, dequeued);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeQueueTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeQueueTests.cs
@@ -15,11 +15,9 @@ public class PropertyChangeQueueTests
 
         using var subscription = context.CreatePropertyChangeQueueSubscription();
         var person = new Person(context);
-        var cts = new CancellationTokenSource();
 
         // Act
         person.FirstName = "John";
-        cts.Cancel();
 
         // Assert
         Assert.True(subscription.TryDequeue(out var change, CancellationToken.None));
@@ -241,7 +239,7 @@ public class PropertyChangeQueueTests
 
         // Assert
         var dequeued = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
         while (subscription.TryDequeue(out _, cts.Token))
         {
             dequeued++;

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -112,6 +112,10 @@ public class RecalculateDerivedPropertyTests
         });
 
         // Assert
+        // Thread-safety contract: concurrent calls must not deadlock, notifications must
+        // arrive in order (no stale value after a newer one), and the final settled value
+        // must be correct. The count is non-deterministic because IsRecalculating coalesces
+        // concurrent calls, so fewer than 100 getter evaluations occur.
         lock (changes)
         {
             Assert.True(changes.Count > 0, "At least some recalculations should produce change notifications");
@@ -123,6 +127,9 @@ public class RecalculateDerivedPropertyTests
                 Assert.True(current > previous,
                     $"Notifications must be monotonically increasing but got {previous} -> {current} at index {i}");
             }
+
+            var finalNotifiedValue = changes[^1].GetNewValue<double>();
+            Assert.Equal((double)callCount, finalNotifiedValue);
         }
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -1,0 +1,82 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+public class RecalculateDerivedPropertyTests
+{
+    [Fact]
+    public void WhenRecalculateCalled_ThenGetterIsReEvaluatedAndNotificationFired()
+    {
+        // Arrange
+        var externalValue = 10.0;
+        var changes = new List<SubjectPropertyChange>();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(changes.Add);
+
+        var sensor = new ExternalSensor(context);
+        sensor.ExternalValueProvider = () => externalValue;
+        var property = new PropertyReference(sensor, nameof(ExternalSensor.CalibratedTemperature));
+        property.RecalculateDerivedProperty();
+        changes.Clear();
+
+        // Act
+        externalValue = 42.0;
+        property.RecalculateDerivedProperty();
+
+        // Assert
+        Assert.Single(changes);
+        Assert.Equal(nameof(ExternalSensor.CalibratedTemperature), changes[0].Property.Name);
+        Assert.Equal(10.0, changes[0].GetOldValue<double>());
+        Assert.Equal(42.0, changes[0].GetNewValue<double>());
+    }
+
+    [Fact]
+    public void WhenRecalculateCalledAndValueUnchanged_ThenNoNotificationFired()
+    {
+        // Arrange
+        var externalValue = 10.0;
+        var changes = new List<SubjectPropertyChange>();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(changes.Add);
+
+        var sensor = new ExternalSensor(context);
+        sensor.ExternalValueProvider = () => externalValue;
+        var property = new PropertyReference(sensor, nameof(ExternalSensor.CalibratedTemperature));
+        property.RecalculateDerivedProperty();
+        changes.Clear();
+
+        // Act
+        property.RecalculateDerivedProperty();
+
+        // Assert
+        Assert.Empty(changes);
+    }
+
+    [Fact]
+    public void WhenRecalculateCalledOnNonDerivedProperty_ThenNoOp()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var sensor = new ExternalSensor(context);
+
+        // Act & Assert
+        var property = new PropertyReference(sensor, nameof(ExternalSensor.Label));
+        property.RecalculateDerivedProperty();
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -79,4 +79,50 @@ public class RecalculateDerivedPropertyTests
         var property = new PropertyReference(sensor, nameof(ExternalSensor.Label));
         property.RecalculateDerivedProperty();
     }
+
+    [Fact]
+    public void WhenRecalculateCalledConcurrently_ThenAllChangesAreSerializedAndNoNotificationsLost()
+    {
+        // Arrange
+        var callCount = 0;
+        var changes = new List<SubjectPropertyChange>();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(change =>
+            {
+                lock (changes) { changes.Add(change); }
+            });
+
+        var sensor = new ExternalSensor(context);
+        sensor.ExternalValueProvider = () => Interlocked.Increment(ref callCount);
+        var property = new PropertyReference(sensor, nameof(ExternalSensor.CalibratedTemperature));
+        property.RecalculateDerivedProperty();
+
+        lock (changes) { changes.Clear(); }
+        Interlocked.Exchange(ref callCount, 0);
+
+        // Act
+        Parallel.For(0, 100, _ =>
+        {
+            property.RecalculateDerivedProperty();
+        });
+
+        // Assert
+        lock (changes)
+        {
+            Assert.True(changes.Count > 0, "At least some recalculations should produce change notifications");
+
+            for (var i = 1; i < changes.Count; i++)
+            {
+                var previous = changes[i - 1].GetNewValue<double>();
+                var current = changes[i].GetNewValue<double>();
+                Assert.True(current > previous,
+                    $"Notifications must be monotonically increasing but got {previous} -> {current} at index {i}");
+            }
+        }
+    }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/ExternalSensor.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/ExternalSensor.cs
@@ -1,0 +1,14 @@
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+[InterceptorSubject]
+public partial class ExternalSensor
+{
+    public Func<double> ExternalValueProvider { get; set; } = () => 0.0;
+
+    public partial string? Label { get; set; }
+
+    [Derived]
+    public double CalibratedTemperature => ExternalValueProvider();
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/PropertyReferenceDataExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/PropertyReferenceDataExtensionsTests.cs
@@ -1,0 +1,127 @@
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests;
+
+public class PropertyReferenceDataExtensionsTests
+{
+    [Fact]
+    public void WhenGetOrAddCalledFirstTime_ThenCreatesNewValue()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var result = property.GetOrAddPropertyData("test-key", () => new List<string> { "initial" });
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("initial", result[0]);
+    }
+
+    [Fact]
+    public void WhenGetOrAddCalledTwice_ThenReturnsSameInstance()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var first = property.GetOrAddPropertyData("test-key", () => new List<string>());
+        first.Add("modified");
+        var second = property.GetOrAddPropertyData("test-key", () => new List<string>());
+
+        // Assert
+        Assert.Same(first, second);
+        Assert.Single(second);
+        Assert.Equal("modified", second[0]);
+    }
+
+    [Fact]
+    public void WhenGetOrAddUsedWithDifferentKeys_ThenCreatesIndependentValues()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var data1 = property.GetOrAddPropertyData("key1", () => "value1");
+        var data2 = property.GetOrAddPropertyData("key2", () => "value2");
+
+        // Assert
+        Assert.Equal("value1", data1);
+        Assert.Equal("value2", data2);
+    }
+
+    [Fact]
+    public void WhenAddOrUpdateCalledFirstTime_ThenCreatesAndUpdates()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var result = property.AddOrUpdatePropertyData<List<string>, string>(
+            "test-key",
+            (list, value) => list.Add(value),
+            "first");
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("first", result[0]);
+    }
+
+    [Fact]
+    public void WhenAddOrUpdateCalledMultipleTimes_ThenUpdatesExistingInstance()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var first = property.AddOrUpdatePropertyData<List<string>, string>(
+            "test-key",
+            (list, value) => list.Add(value),
+            "first");
+
+        var second = property.AddOrUpdatePropertyData<List<string>, string>(
+            "test-key",
+            (list, value) => list.Add(value),
+            "second");
+
+        // Assert
+        Assert.Same(first, second);
+        Assert.Equal(2, second.Count);
+        Assert.Equal("first", second[0]);
+        Assert.Equal("second", second[1]);
+    }
+
+    [Fact]
+    public void WhenDifferentPropertiesUseGetOrAdd_ThenDataIsIsolated()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var person = new Person(context);
+        var firstNameProp = new PropertyReference(person, nameof(Person.FirstName));
+        var lastNameProp = new PropertyReference(person, nameof(Person.LastName));
+
+        // Act
+        var data1 = firstNameProp.GetOrAddPropertyData("test-key", () => "first-name-data");
+        var data2 = lastNameProp.GetOrAddPropertyData("test-key", () => "last-name-data");
+
+        // Assert
+        Assert.Equal("first-name-data", data1);
+        Assert.Equal("last-name-data", data2);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Recorder/ReadPropertyRecorderScopeTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Recorder/ReadPropertyRecorderScopeTests.cs
@@ -1,0 +1,142 @@
+using Namotion.Interceptor.Tracking.Recorder;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests.Recorder;
+
+public class ReadPropertyRecorderScopeTests
+{
+    [Fact]
+    public void WhenPropertiesReadDuringScope_ThenRecordedPropertiesReturned()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithReadPropertyRecorder()
+            .WithFullPropertyTracking();
+
+        var person = new Person(context) { FirstName = "John", LastName = "Doe" };
+
+        // Act
+        using var scope = ReadPropertyRecorder.Start();
+        _ = person.FirstName;
+        _ = person.LastName;
+        var properties = scope.GetPropertiesAndDispose();
+
+        // Assert
+        Assert.Equal(2, properties.Count);
+        Assert.Contains(properties, p => p.Name == nameof(Person.FirstName));
+        Assert.Contains(properties, p => p.Name == nameof(Person.LastName));
+    }
+
+    [Fact]
+    public void WhenNoPropertiesRead_ThenEmptyCollectionReturned()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithReadPropertyRecorder()
+            .WithFullPropertyTracking();
+
+        _ = new Person(context);
+
+        // Act
+        using var scope = ReadPropertyRecorder.Start();
+        var properties = scope.GetPropertiesAndDispose();
+
+        // Assert
+        Assert.Empty(properties);
+    }
+
+    [Fact]
+    public void WhenScopeDisposedTwice_ThenNoException()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithReadPropertyRecorder()
+            .WithFullPropertyTracking();
+
+        _ = new Person(context);
+
+        // Act & Assert
+        var scope = ReadPropertyRecorder.Start();
+        scope.Dispose();
+        scope.Dispose();
+    }
+
+    [Fact]
+    public void WhenPropertyReadAfterDispose_ThenNotRecorded()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithReadPropertyRecorder()
+            .WithFullPropertyTracking();
+
+        var person = new Person(context) { FirstName = "John", LastName = "Doe" };
+
+        // Act
+        var scope = ReadPropertyRecorder.Start();
+        _ = person.FirstName;
+        var properties = scope.GetPropertiesAndDispose();
+
+        _ = person.LastName;
+
+        // Assert
+        Assert.Single(properties);
+        Assert.Contains(properties, p => p.Name == nameof(Person.FirstName));
+    }
+
+    [Fact]
+    public void WhenNestedScopesUsed_ThenEachRecordsIndependently()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithReadPropertyRecorder()
+            .WithFullPropertyTracking();
+
+        var person = new Person(context) { FirstName = "John", LastName = "Doe" };
+
+        // Act
+        using var outerScope = ReadPropertyRecorder.Start();
+        _ = person.FirstName;
+
+        using var innerScope = ReadPropertyRecorder.Start();
+        _ = person.LastName;
+        var innerProperties = innerScope.GetPropertiesAndDispose();
+
+        var outerProperties = outerScope.GetPropertiesAndDispose();
+
+        // Assert
+        Assert.Single(innerProperties);
+        Assert.Contains(innerProperties, p => p.Name == nameof(Person.LastName));
+
+        Assert.Equal(2, outerProperties.Count);
+        Assert.Contains(outerProperties, p => p.Name == nameof(Person.FirstName));
+        Assert.Contains(outerProperties, p => p.Name == nameof(Person.LastName));
+    }
+
+    [Fact]
+    public void WhenSharedDictionaryProvided_ThenPropertiesAccumulateAcrossScopes()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithReadPropertyRecorder()
+            .WithFullPropertyTracking();
+
+        var person = new Person(context) { FirstName = "John", LastName = "Doe" };
+        var sharedDict = new System.Collections.Concurrent.ConcurrentDictionary<PropertyReference, bool>();
+
+        // Act
+        using (var scope1 = ReadPropertyRecorder.Start(sharedDict))
+        {
+            _ = person.FirstName;
+            scope1.GetPropertiesAndDispose();
+        }
+
+        using (var scope2 = ReadPropertyRecorder.Start(sharedDict))
+        {
+            _ = person.LastName;
+            scope2.GetPropertiesAndDispose();
+        }
+
+        // Assert
+        Assert.Equal(2, sharedDict.Count);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -1,13 +1,40 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Transactions;
+using Namotion.Interceptor.Tracking.Tests.Models;
 
 namespace Namotion.Interceptor.Tracking.Tests.Transactions;
 
 public class SubjectTransactionTests
 {
-    [Fact]
-    public async Task BeginTransactionAsync_ThrowsWhenTransactionsNotEnabled()
+    private static async Task RunWithoutAsyncLocalFlowAsync(Action action)
     {
-        // Arrange - context WITHOUT WithTransactions()
+        Task task;
+        var flowControl = ExecutionContext.SuppressFlow();
+        try
+        {
+            task = Task.Run(action);
+        }
+        finally
+        {
+            flowControl.Undo();
+        }
+
+        await task;
+    }
+
+    private static IInterceptorSubjectContext CreateTransactionContext()
+    {
+        return InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+    }
+
+    [Fact]
+    public async Task WhenTransactionsNotEnabled_ThenBeginThrows()
+    {
+        // Arrange
         var context = InterceptorSubjectContext.Create()
             .WithPropertyChangeObservable();
 
@@ -18,5 +45,473 @@ public class SubjectTransactionTests
         });
 
         Assert.Contains("WithTransactions()", exception.Message);
+    }
+
+    [Fact]
+    public async Task WhenTransactionCommitted_ThenChangesAreApplied()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+            person.LastName = "Doe";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal("John", person.FirstName);
+        Assert.Equal("Doe", person.LastName);
+    }
+
+    [Fact]
+    public async Task WhenTransactionDisposedWithoutCommit_ThenChangesAreDiscarded()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original" };
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "Modified";
+        }
+
+        // Assert
+        Assert.Equal("Original", person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenReadingPropertyDuringTransaction_ThenPendingValueIsReturned()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original" };
+
+        // Act & Assert
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "Pending";
+            Assert.Equal("Pending", person.FirstName);
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task WhenSamePropertyWrittenTwice_ThenLastWriteWinsAndOriginalOldValuePreserved()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original" };
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "First";
+            person.FirstName = "Second";
+
+            var pending = transaction.GetPendingChanges();
+            Assert.Single(pending);
+            Assert.Equal("Original", pending[0].GetOldValue<string?>());
+            Assert.Equal("Second", pending[0].GetNewValue<string?>());
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal("Second", person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenCommittedWithNoChanges_ThenSucceeds()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+
+        // Act & Assert
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task WhenConflictDetected_ThenConflictExceptionThrown()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original" };
+
+        using (var transaction = await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Optimistic,
+            conflictBehavior: TransactionConflictBehavior.FailOnConflict))
+        {
+            person.FirstName = "InTransaction";
+
+            await RunWithoutAsyncLocalFlowAsync(() => { person.FirstName = "ExternalChange"; });
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(
+                () => transaction.CommitAsync(CancellationToken.None));
+
+            Assert.Single(ex.ConflictingProperties);
+            Assert.Equal(nameof(Person.FirstName), ex.ConflictingProperties[0].Name);
+            Assert.Empty(ex.AppliedChanges);
+            Assert.Empty(ex.FailedChanges);
+        }
+    }
+
+    [Fact]
+    public async Task WhenConflictBehaviorIsIgnore_ThenNoConflictException()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original" };
+
+        using (var transaction = await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Optimistic,
+            conflictBehavior: TransactionConflictBehavior.Ignore))
+        {
+            person.FirstName = "InTransaction";
+
+            await RunWithoutAsyncLocalFlowAsync(() => { person.FirstName = "ExternalChange"; });
+
+            // Act
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal("InTransaction", person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenTransactionAlreadyCommitted_ThenCommitAgainThrows()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            await transaction.CommitAsync(CancellationToken.None);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => transaction.CommitAsync(CancellationToken.None));
+        }
+    }
+
+    [Fact]
+    public async Task WhenTransactionDisposed_ThenCommitThrows()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        transaction.Dispose();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => transaction.CommitAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenNestedTransactionAttempted_ThenThrows()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task WhenExclusiveLocking_ThenSecondTransactionWaits()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var order = new List<int>();
+
+        // Act
+        var task1Started = new ManualResetEventSlim(false);
+        var task1 = Task.Run(async () =>
+        {
+            using (var t = await context.BeginTransactionAsync(
+                TransactionFailureHandling.BestEffort,
+                TransactionLocking.Exclusive))
+            {
+                lock (order) { order.Add(1); }
+                task1Started.Set();
+                await Task.Delay(100);
+                await t.CommitAsync(CancellationToken.None);
+            }
+        });
+
+        task1Started.Wait();
+        var task2 = Task.Run(async () =>
+        {
+            using (var t = await context.BeginTransactionAsync(
+                TransactionFailureHandling.BestEffort,
+                TransactionLocking.Exclusive))
+            {
+                lock (order) { order.Add(2); }
+                await t.CommitAsync(CancellationToken.None);
+            }
+        });
+
+        await Task.WhenAll(task1, task2);
+
+        // Assert
+        Assert.Equal([1, 2], order);
+    }
+
+    [Fact]
+    public async Task WhenOptimisticLocking_ThenBothTransactionsCanBegin()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var bothStarted = new CountdownEvent(2);
+
+        // Act
+        var task1 = Task.Run(async () =>
+        {
+            using (var t = await context.BeginTransactionAsync(
+                TransactionFailureHandling.BestEffort,
+                TransactionLocking.Optimistic,
+                conflictBehavior: TransactionConflictBehavior.Ignore))
+            {
+                bothStarted.Signal();
+                bothStarted.Wait(TimeSpan.FromSeconds(5));
+                await t.CommitAsync(CancellationToken.None);
+            }
+        });
+
+        var task2 = Task.Run(async () =>
+        {
+            using (var t = await context.BeginTransactionAsync(
+                TransactionFailureHandling.BestEffort,
+                TransactionLocking.Optimistic,
+                conflictBehavior: TransactionConflictBehavior.Ignore))
+            {
+                bothStarted.Signal();
+                bothStarted.Wait(TimeSpan.FromSeconds(5));
+                await t.CommitAsync(CancellationToken.None);
+            }
+        });
+
+        // Assert
+        await Task.WhenAll(task1, task2);
+    }
+
+    [Fact]
+    public async Task WhenTransactionCommitted_ThenObservableNotificationsFire()
+    {
+        // Arrange
+        var changes = new List<SubjectPropertyChange>();
+        var context = CreateTransactionContext();
+
+        context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(changes.Add);
+
+        var person = new Person(context);
+        changes.Clear();
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+            Assert.Empty(changes);
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Contains(changes, c =>
+            c.Property.Name == nameof(Person.FirstName) &&
+            c.GetNewValue<string?>() == "John");
+    }
+
+    [Fact]
+    public async Task WhenTransactionDisposedWithoutCommit_ThenNoObservableNotificationsFire()
+    {
+        // Arrange
+        var changes = new List<SubjectPropertyChange>();
+        var context = CreateTransactionContext();
+
+        context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(changes.Add);
+
+        var person = new Person(context) { FirstName = "Original" };
+        changes.Clear();
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "Modified";
+        }
+
+        // Assert
+        Assert.Empty(changes);
+    }
+
+    [Fact]
+    public async Task WhenGetPendingChangesCalled_ThenReturnsSnapshotOfPendingChanges()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+            person.LastName = "Doe";
+
+            var pending = transaction.GetPendingChanges();
+
+            // Assert
+            Assert.Equal(2, pending.Count);
+            Assert.Contains(pending, c => c.Property.Name == nameof(Person.FirstName));
+            Assert.Contains(pending, c => c.Property.Name == nameof(Person.LastName));
+        }
+    }
+
+    [Fact]
+    public async Task WhenDisposeCalledMultipleTimes_ThenIsIdempotent()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+
+        // Act & Assert
+        transaction.Dispose();
+        transaction.Dispose();
+    }
+
+    [Fact]
+    public async Task WhenMultipleSubjectsModified_ThenAllChangesCommittedAtomically()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person1 = new Person(context);
+        var person2 = new Person(context);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person1.FirstName = "Alice";
+            person2.FirstName = "Bob";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal("Alice", person1.FirstName);
+        Assert.Equal("Bob", person2.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenExclusiveTransactionDisposed_ThenLockIsReleased()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+
+        using (await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Exclusive))
+        {
+        }
+
+        // Act & Assert
+        using (var transaction = await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Exclusive))
+        {
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task WhenDerivedPropertyRead_ThenReflectsPendingChanges()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+            person.LastName = "Doe";
+
+            // Assert
+            Assert.Equal("John Doe", person.FullName);
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        Assert.Equal("John Doe", person.FullName);
+    }
+
+    [Fact]
+    public async Task WhenConflictExceptionThrown_ThenConflictingPropertiesAreReported()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original1", LastName = "Original2" };
+
+        using (var transaction = await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Optimistic,
+            conflictBehavior: TransactionConflictBehavior.FailOnConflict))
+        {
+            person.FirstName = "InTx1";
+            person.LastName = "InTx2";
+
+            await RunWithoutAsyncLocalFlowAsync(() =>
+            {
+                person.FirstName = "External1";
+                person.LastName = "External2";
+            });
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(
+                () => transaction.CommitAsync(CancellationToken.None));
+
+            Assert.Equal(2, ex.ConflictingProperties.Count);
+            Assert.Contains(ex.ConflictingProperties, p => p.Name == nameof(Person.FirstName));
+            Assert.Contains(ex.ConflictingProperties, p => p.Name == nameof(Person.LastName));
+        }
+    }
+
+    [Fact]
+    public async Task WhenPropertyNotChangedExternally_ThenNoConflictDetected()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Original" };
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Optimistic,
+            conflictBehavior: TransactionConflictBehavior.FailOnConflict))
+        {
+            person.FirstName = "Modified";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal("Modified", person.FirstName);
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -240,9 +240,10 @@ public class SubjectTransactionTests
         // Arrange
         var context = CreateTransactionContext();
         var order = new List<int>();
+        var task1CanCommit = new ManualResetEventSlim(false);
+        var task2Waiting = new ManualResetEventSlim(false);
 
         // Act
-        var task1Started = new ManualResetEventSlim(false);
         var task1 = Task.Run(async () =>
         {
             using (var t = await context.BeginTransactionAsync(
@@ -250,15 +251,16 @@ public class SubjectTransactionTests
                 TransactionLocking.Exclusive))
             {
                 lock (order) { order.Add(1); }
-                task1Started.Set();
-                await Task.Delay(100);
+                task2Waiting.Set();
+                task1CanCommit.Wait();
                 await t.CommitAsync(CancellationToken.None);
             }
         });
 
-        task1Started.Wait();
+        task2Waiting.Wait();
         var task2 = Task.Run(async () =>
         {
+            task1CanCommit.Set();
             using (var t = await context.BeginTransactionAsync(
                 TransactionFailureHandling.BestEffort,
                 TransactionLocking.Exclusive))

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -188,7 +188,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
     /// IsRecalculating serializes concurrent recalculations; RecalculationNeeded catches state changes
     /// (writes, attach, detach) that occur during the unlocked evaluation window.
     /// </summary>
-    private static void RecalculateDerivedProperty(ref PropertyReference derivedProperty, long timestampUtcTicks)
+    internal static void RecalculateDerivedProperty(ref PropertyReference derivedProperty, long timestampUtcTicks)
     {
         // TODO(perf): Avoid boxing when possible (use TProperty generic parameter?)
 

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandlerExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandlerExtensions.cs
@@ -32,6 +32,24 @@ public static class DerivedPropertyChangeHandlerExtensions
     }
 
     /// <summary>
+    /// Recalculates a derived property by re-evaluating its getter and firing change
+    /// notifications if the value changed. Use this when the getter depends on external
+    /// (non-intercepted) data and that data has changed.
+    /// No-op if the property is not a derived property or is not attached to a context.
+    /// </summary>
+    public static void RecalculateDerivedProperty(this PropertyReference property)
+    {
+        var data = property.TryGetDerivedPropertyData();
+        if (data is null || !Volatile.Read(ref data.IsDerived))
+        {
+            return;
+        }
+
+        DerivedPropertyChangeHandler.RecalculateDerivedProperty(
+            ref property, SubjectChangeContext.Current.ChangedTimestampUtcTicks);
+    }
+
+    /// <summary>
     /// Gets the consolidated tracking data for a property, creating it if needed.
     /// A single dictionary lookup provides access to UsedByProperties, RequiredProperties, and LastKnownValue.
     /// </summary>

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandlerExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandlerExtensions.cs
@@ -37,6 +37,7 @@ public static class DerivedPropertyChangeHandlerExtensions
     /// (non-intercepted) data and that data has changed.
     /// No-op if the property is not a derived property or is not attached to a context.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void RecalculateDerivedProperty(this PropertyReference property)
     {
         var data = property.TryGetDerivedPropertyData();


### PR DESCRIPTION
## Summary
- Add `PropertyReference.RecalculateDerivedProperty()` extension method for derived properties that depend on external (non-intercepted) data
- Add comprehensive tests for PropertyChangeQueue, transactions, PropertyReferenceDataExtensions, and ReadPropertyRecorderScope
- Update tracking docs with manual recalculation section

## Test plan
- [x] All 246 tracking tests pass
- [x] Full solution test suite passes (0 failures)
- [x] Tracking library coverage increased from 69.4% to 90.1%