### PR TITLE
Fix CI release pack failing on non-publishable projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_VERSION: 9.0.x
+  DOTNET_VERSION: 10.0.x
   NUGET_DIRECTORY: ${{ github.workspace }}/nuget
 
 defaults:
@@ -120,11 +120,6 @@ jobs:
       - name: Build
         run: dotnet build src/Namotion.Interceptor.slnx --configuration Release
 
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
-
       - name: Install Playwright browsers
         run: pwsh src/HomeBlaze/HomeBlaze.E2E.Tests/bin/Release/net10.0/playwright.ps1 install --with-deps
 
@@ -157,11 +152,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
 
       - name: Build
         run: dotnet build src/Namotion.Interceptor.slnx --configuration Release
@@ -303,6 +293,9 @@ jobs:
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
 
       - run: dotnet pack src/Namotion.Interceptor.slnx --configuration Release --output ${{ env.NUGET_DIRECTORY }} -p:PackageVersion=${{ steps.version.outputs.VERSION }}
+
+      - name: Remove non-Namotion packages
+        run: Get-ChildItem "${{ env.NUGET_DIRECTORY }}" -Include *.nupkg -Recurse | Where-Object { $_.Name -notlike "Namotion.*" } | Remove-Item -Force
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,8 +294,8 @@ jobs:
 
       - run: dotnet pack src/Namotion.Interceptor.slnx --configuration Release --output ${{ env.NUGET_DIRECTORY }} -p:PackageVersion=${{ steps.version.outputs.VERSION }}
 
-      - name: Remove non-Namotion packages
-        run: Get-ChildItem "${{ env.NUGET_DIRECTORY }}" -Include *.nupkg -Recurse | Where-Object { $_.Name -notlike "Namotion.*" } | Remove-Item -Force
+      - name: Remove non-library packages
+        run: Get-ChildItem "${{ env.NUGET_DIRECTORY }}" -Include *.nupkg -Recurse | Where-Object { $_.Name -notlike "Namotion.Interceptor*" } | Remove-Item -Force
 
       - uses: actions/upload-artifact@v4
         with:

--- a/src/HomeBlaze/HomeBlaze.Samples/HomeBlaze.Samples.csproj
+++ b/src/HomeBlaze/HomeBlaze.Samples/HomeBlaze.Samples.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/HomeBlaze/Namotion.NuGet.Plugins/Namotion.NuGet.Plugins.csproj
+++ b/src/HomeBlaze/Namotion.NuGet.Plugins/Namotion.NuGet.Plugins.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Namotion.Interceptor.SampleBlazor/Namotion.Interceptor.SampleBlazor.csproj
+++ b/src/Namotion.Interceptor.SampleBlazor/Namotion.Interceptor.SampleBlazor.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Namotion.Interceptor.SampleMachine/Namotion.Interceptor.SampleMachine.csproj
+++ b/src/Namotion.Interceptor.SampleMachine/Namotion.Interceptor.SampleMachine.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Namotion.Interceptor.SampleWeb/Namotion.Interceptor.SampleWeb.csproj
+++ b/src/Namotion.Interceptor.SampleWeb/Namotion.Interceptor.SampleWeb.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Namotion.Interceptor.WebSocket.SampleClient/Namotion.Interceptor.WebSocket.SampleClient.csproj
+++ b/src/Namotion.Interceptor.WebSocket.SampleClient/Namotion.Interceptor.WebSocket.SampleClient.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Namotion.Interceptor.WebSocket.SampleServer/Namotion.Interceptor.WebSocket.SampleServer.csproj
+++ b/src/Namotion.Interceptor.WebSocket.SampleServer/Namotion.Interceptor.WebSocket.SampleServer.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- Upgrade global `DOTNET_VERSION` from `9.0.x` to `10.0.x` so HomeBlaze `net10.0` projects can build in all CI jobs
- Remove redundant per-job .NET 10 setup steps (now covered by global version)
- Mark 6 sample projects as `<IsPackable>false</IsPackable>` to prevent unnecessary pack attempts
- Add a post-pack filter step that keeps only `Namotion.Interceptor*` packages before upload

## NuGet packages published by this CI

- Namotion.Interceptor
- Namotion.Interceptor.AspNetCore
- Namotion.Interceptor.Blazor
- Namotion.Interceptor.Connectors
- Namotion.Interceptor.Dynamic
- Namotion.Interceptor.Generator
- Namotion.Interceptor.GraphQL
- Namotion.Interceptor.Hosting
- Namotion.Interceptor.Mcp
- Namotion.Interceptor.Mqtt
- Namotion.Interceptor.OpcUa
- Namotion.Interceptor.Registry
- Namotion.Interceptor.Tracking
- Namotion.Interceptor.Validation
- Namotion.Interceptor.WebSocket

## Test plan

- [x] Verify CI build/test jobs pass with .NET 10 SDK for both net9.0 and net10.0 targets
- [x] Trigger a release and confirm only the packages listed above are uploaded