### PR TITLE
fix: build before pack so Razor static web assets manifest exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,9 @@ jobs:
           $version = "${{ github.event.release.tag_name }}" -replace '^v', ''
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
 
-      - run: dotnet pack src/Namotion.Interceptor.slnx --configuration Release --output ${{ env.NUGET_DIRECTORY }} -p:PackageVersion=${{ steps.version.outputs.VERSION }}
+      - run: dotnet build src/Namotion.Interceptor.slnx --configuration Release
+
+      - run: dotnet pack src/Namotion.Interceptor.slnx --configuration Release --no-build --output ${{ env.NUGET_DIRECTORY }} -p:PackageVersion=${{ steps.version.outputs.VERSION }}
 
       - name: Remove non-library packages
         run: Get-ChildItem "${{ env.NUGET_DIRECTORY }}" -Include *.nupkg -Recurse | Where-Object { $_.Name -notlike "Namotion.Interceptor*" } | Remove-Item -Force


### PR DESCRIPTION
## Summary
- The 0.6.0 release pack still failed after #301 with `NU5026` and `staticwebassets.build.json not found` on the `MyCompany.*` plugin demo projects (`IsPackable=true` is intentional because they ship via `GeneratePackageOnBuild=true` to power the runtime plugin-loading feature).
- Running `dotnet pack` alone does not write the build-time static web assets manifest the Razor pack target reads, which cascaded into missing DLL outputs for `MyCompany.Abstractions` / `MyCompany.SamplePlugin{1,2}`.
- Added an explicit `dotnet build` before `dotnet pack --no-build` so the manifests and DLLs exist before pack runs. The post-pack `Namotion.Interceptor*` filter still strips the `MyCompany.*` plugin packages before upload.

## Why 0.5.2 worked
The `MyCompany.*` plugin demo projects did not exist at v0.5.2; they landed in #251 between v0.5.2 and v0.6.0. The pre-#301 pack step had no project to crash on.

## Test plan
- [x] Verified locally with .NET 10 SDK 10.0.107: `dotnet build` succeeds with 0 warnings/0 errors, `dotnet pack --no-build` exits 0 and produces 20 nupkgs.
- [x] Applied the post-pack filter locally; 15 `Namotion.Interceptor.*` packages remain (the expected release set), the 5 `MyCompany.*` plugin packages are stripped.
- [x] Re-run the v0.6.0 release workflow to confirm CI publishes the 15 packages to NuGet.org.