### PR TITLE
OPC UA: Support multi-segment root path for OPC UA client (source)

### DIFF
--- a/src/HomeBlaze/HomeBlaze.OpcUa.Blazor/OpcUaClientEditComponent.razor
+++ b/src/HomeBlaze/HomeBlaze.OpcUa.Blazor/OpcUaClientEditComponent.razor
@@ -26,7 +26,7 @@
 
     <MudTextField @bind-Value="_rootPath"
                   Label="Root Path"
-                  HelperText="Optional path under Objects folder (use / as delimiter, e.g. foo/bar)"
+                  HelperText="Optional path under Objects folder (use / as delimiter, e.g. Machines/MyMachine)"
                   Immediate="true"
                   OnKeyUp="OnFieldChanged"
                   Class="mt-4" />

--- a/src/HomeBlaze/HomeBlaze.OpcUa.Blazor/OpcUaClientEditComponent.razor
+++ b/src/HomeBlaze/HomeBlaze.OpcUa.Blazor/OpcUaClientEditComponent.razor
@@ -24,9 +24,9 @@
                   OnKeyUp="OnFieldChanged"
                   Class="mt-4" />
 
-    <MudTextField @bind-Value="_rootName"
-                  Label="Root Name"
-                  HelperText="Optional OPC UA root node name under Objects folder"
+    <MudTextField @bind-Value="_rootPath"
+                  Label="Root Path"
+                  HelperText="Optional path under Objects folder (use / as delimiter, e.g. foo/bar)"
                   Immediate="true"
                   OnKeyUp="OnFieldChanged"
                   Class="mt-4" />
@@ -61,19 +61,19 @@
 
     private string _name = string.Empty;
     private string _serverUrl = string.Empty;
-    private string? _rootName;
+    private string? _rootPath;
     private bool _isEnabled = true;
 
     private string _originalName = string.Empty;
     private string _originalServerUrl = string.Empty;
-    private string? _originalRootName;
+    private string? _originalRootPath;
     private bool _originalIsEnabled = true;
 
     public bool IsValid => !string.IsNullOrWhiteSpace(_name) && !string.IsNullOrWhiteSpace(_serverUrl);
 
     public bool IsDirty => _name != _originalName ||
                            _serverUrl != _originalServerUrl ||
-                           _rootName != _originalRootName ||
+                           _rootPath != _originalRootPath ||
                            _isEnabled != _originalIsEnabled;
 
     public string PreferredDialogSize => "Medium";
@@ -87,12 +87,12 @@
         {
             _name = ClientSubject.Name ?? string.Empty;
             _serverUrl = ClientSubject.ServerUrl ?? string.Empty;
-            _rootName = ClientSubject.RootName;
+            _rootPath = ClientSubject.RootPath;
             _isEnabled = ClientSubject.IsEnabled;
 
             _originalName = _name;
             _originalServerUrl = _serverUrl;
-            _originalRootName = _rootName;
+            _originalRootPath = _rootPath;
             _originalIsEnabled = _isEnabled;
         }
     }
@@ -109,12 +109,12 @@
         {
             ClientSubject.Name = _name;
             ClientSubject.ServerUrl = _serverUrl;
-            ClientSubject.RootName = _rootName;
+            ClientSubject.RootPath = _rootPath;
             ClientSubject.IsEnabled = _isEnabled;
 
             _originalName = _name;
             _originalServerUrl = _serverUrl;
-            _originalRootName = _rootName;
+            _originalRootPath = _rootPath;
             _originalIsEnabled = _isEnabled;
 
             IsDirtyChanged?.Invoke(false);

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -40,7 +40,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     public partial string ServerUrl { get; set; }
 
     /// <summary>
-    /// Optional root path to start browsing from under the Objects folder (use / as delimiter, e.g. "foo/bar").
+    /// Optional root path to start browsing from under the Objects folder (use / as delimiter, e.g. "Machines/MyMachine").
     /// </summary>
     [Configuration]
     public partial string? RootPath { get; set; }

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -40,10 +40,10 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     public partial string ServerUrl { get; set; }
 
     /// <summary>
-    /// Optional OPC UA root node name to start browsing from under the Objects folder.
+    /// Optional root path to start browsing from under the Objects folder (use / as delimiter, e.g. "foo/bar").
     /// </summary>
     [Configuration]
-    public partial string? RootName { get; set; }
+    public partial string? RootPath { get; set; }
 
     /// <summary>
     /// Whether the client is enabled and should auto-start on application startup.
@@ -194,13 +194,14 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
                 return;
             }
 
-            var root = new OpcUaDynamicSubject(RootName ?? "Root");
+            var rootPathSegments = RootPath?.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var root = new OpcUaDynamicSubject(rootPathSegments is { Length: > 0 } ? rootPathSegments[^1] : "Root");
             Root = root;
 
             var configuration = new OpcUaClientConfiguration
             {
                 ServerUrl = ServerUrl,
-                RootName = RootName,
+                RootPath = rootPathSegments,
                 TypeResolver = new HomeBlazeOpcUaTypeResolver(_logger),
                 ValueConverter = new OpcUaValueConverter(),
                 SubjectFactory = new HomeBlazeOpcUaSubjectFactory(),

--- a/src/Namotion.Interceptor.ConnectorTester/Program.cs
+++ b/src/Namotion.Interceptor.ConnectorTester/Program.cs
@@ -251,7 +251,7 @@ for (var clientIndex = 0; clientIndex < configuration.Clients.Count; clientIndex
                     return new OpcUaClientConfiguration
                     {
                         ServerUrl = $"opc.tcp://localhost:{serverPort}",
-                        RootName = "Root",
+                        RootPath = ["Root"],
                         TypeResolver = new OpcUaTypeResolver(sp.GetRequiredService<ILogger<OpcUaTypeResolver>>()),
                         ValueConverter = new OpcUaValueConverter(),
                         SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),

--- a/src/Namotion.Interceptor.OpcUa.SampleClient/Program.cs
+++ b/src/Namotion.Interceptor.OpcUa.SampleClient/Program.cs
@@ -25,7 +25,7 @@ context.AddService(root);
 
 builder.Services.AddSingleton(root);
 builder.Services.AddHostedService<ClientWorker>();
-builder.Services.AddOpcUaSubjectClientSource<Root>("opc.tcp://localhost:4840", "opc", rootName: "Root");
+builder.Services.AddOpcUaSubjectClientSource<Root>("opc.tcp://localhost:4840", "opc", rootPath: ["Root"]);
 
 using var performanceProfiler = new PerformanceProfiler(context, "Client");
 var host = builder.Build();

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/Testing/OpcUaTestClient.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/Testing/OpcUaTestClient.cs
@@ -80,7 +80,7 @@ public class OpcUaTestClient<TRoot> : IAsyncDisposable
                 var config = new OpcUaClientConfiguration
                 {
                     ServerUrl = serverUrl,
-                    RootName = "Root",
+                    RootPath = ["Root"],
                     TypeResolver = new OpcUaTypeResolver(sp.GetRequiredService<ILogger<OpcUaTypeResolver>>()),
                     ValueConverter = new OpcUaValueConverter(),
                     SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),

--- a/src/Namotion.Interceptor.OpcUa.Tests/OpcUaRegistrationTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/OpcUaRegistrationTests.cs
@@ -232,7 +232,7 @@ public partial class OpcUaRegistrationTests
         services.AddOpcUaSubjectClientSource<RegistrationTestSubject>(
             serverUrl: "opc.tcp://localhost:4840",
             sourceName: "opc",
-            rootName: "Root");
+            rootPath: ["Root"]);
 
         // Act
         using var serviceProvider = services.BuildServiceProvider();
@@ -273,7 +273,7 @@ public partial class OpcUaRegistrationTests
             name: "server1",
             serverUrl: "opc.tcp://localhost:4840",
             sourceName: "opc",
-            rootName: "Root");
+            rootPath: ["Root"]);
 
         // Act
         using var serviceProvider = services.BuildServiceProvider();

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -6,13 +6,13 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class OpcUaSubjectExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedOpcUaSubjectClientSource(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, System.Func<System.IServiceProvider, Namotion.Interceptor.IInterceptorSubject> subjectSelector, System.Func<System.IServiceProvider, Namotion.Interceptor.OpcUa.Client.OpcUaClientConfiguration> configurationProvider) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedOpcUaSubjectClientSource<TSubject>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, string serverUrl, string sourceName, string? rootName = null)
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedOpcUaSubjectClientSource<TSubject>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, string serverUrl, string sourceName, string[]? rootPath = null)
             where TSubject : Namotion.Interceptor.IInterceptorSubject { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedOpcUaSubjectServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, System.Func<System.IServiceProvider, Namotion.Interceptor.IInterceptorSubject> subjectSelector, System.Func<System.IServiceProvider, Namotion.Interceptor.OpcUa.Server.OpcUaServerConfiguration> configurationProvider) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddKeyedOpcUaSubjectServer<TSubject>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, string sourceName, string? rootName = null)
             where TSubject : Namotion.Interceptor.IInterceptorSubject { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOpcUaSubjectClientSource(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Namotion.Interceptor.IInterceptorSubject> subjectSelector, System.Func<System.IServiceProvider, Namotion.Interceptor.OpcUa.Client.OpcUaClientConfiguration> configurationProvider) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOpcUaSubjectClientSource<TSubject>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string serverUrl, string sourceName, string? rootName = null)
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOpcUaSubjectClientSource<TSubject>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string serverUrl, string sourceName, string[]? rootPath = null)
             where TSubject : Namotion.Interceptor.IInterceptorSubject { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOpcUaSubjectServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Namotion.Interceptor.IInterceptorSubject> subjectSelector, System.Func<System.IServiceProvider, Namotion.Interceptor.OpcUa.Server.OpcUaServerConfiguration> configurationProvider) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOpcUaSubjectServer<TSubject>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string sourceName, string? rootName = null)
@@ -111,7 +111,7 @@ namespace Namotion.Interceptor.OpcUa.Client
         public System.TimeSpan ReconnectHandlerTimeout { get; set; }
         public System.TimeSpan ReconnectInterval { get; set; }
         public System.TimeSpan? RetryTime { get; set; }
-        public string? RootName { get; set; }
+        public string[]? RootPath { get; set; }
         public required string ServerUrl { get; set; }
         public System.TimeSpan SessionDisposalTimeout { get; set; }
         public Opc.Ua.Client.ISessionFactory? SessionFactory { get; set; }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
@@ -21,7 +21,7 @@ public class OpcUaClientConfiguration
 
     /// <summary>
     /// Gets the optional root path segments to start browsing from under the Objects folder.
-    /// Each element is a browse name to resolve one level deeper (e.g., ["foo", "bar"] browses Objects/foo/bar).
+    /// Each element is a browse name to resolve one level deeper (e.g., ["Machines", "MyMachine"] browses Objects/Machines/MyMachine).
     /// If not specified or empty, browsing starts from the ObjectsFolder root.
     /// </summary>
     public string[]? RootPath { get; set; }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
@@ -20,10 +20,11 @@ public class OpcUaClientConfiguration
     public required string ServerUrl { get; set; }
 
     /// <summary>
-    /// Gets the optional root node name to start browsing from under the Objects folder.
-    /// If not specified, browsing starts from the ObjectsFolder root.
+    /// Gets the optional root path segments to start browsing from under the Objects folder.
+    /// Each element is a browse name to resolve one level deeper (e.g., ["foo", "bar"] browses Objects/foo/bar).
+    /// If not specified or empty, browsing starts from the ObjectsFolder root.
     /// </summary>
-    public string? RootName { get; set; }
+    public string[]? RootPath { get; set; }
     
     /// <summary>
     /// Gets the OPC UA client application name used for identification and certificate generation.

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
@@ -524,10 +524,26 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
 
     private async Task<ReferenceDescription?> TryGetRootNodeAsync(Session session, CancellationToken cancellationToken)
     {
-        if (_configuration.RootName is not null)
+        if (_configuration.RootPath is { Length: > 0 } rootPath)
         {
-            var references = await BrowseNodeAsync(session, ObjectIds.ObjectsFolder, cancellationToken).ConfigureAwait(false);
-            return references.FirstOrDefault(reference => reference.BrowseName.Name == _configuration.RootName);
+            var currentNodeId = ObjectIds.ObjectsFolder;
+
+            for (var i = 0; i < rootPath.Length; i++)
+            {
+                var references = await BrowseNodeAsync(session, currentNodeId, cancellationToken).ConfigureAwait(false);
+                var match = references.FirstOrDefault(reference => reference.BrowseName.Name == rootPath[i]);
+                if (match is null)
+                {
+                    return null;
+                }
+
+                if (i == rootPath.Length - 1)
+                {
+                    return match;
+                }
+
+                currentNodeId = ExpandedNodeId.ToNodeId(match.NodeId, session.NamespaceUris);
+            }
         }
 
         return new ReferenceDescription

--- a/src/Namotion.Interceptor.OpcUa/OpcUaSubjectExtensions.cs
+++ b/src/Namotion.Interceptor.OpcUa/OpcUaSubjectExtensions.cs
@@ -50,12 +50,12 @@ public static class OpcUaSubjectExtensions
         this IServiceCollection services,
         string serverUrl,
         string sourceName,
-        string? rootName = null)
+        string[]? rootPath = null)
         where TSubject : IInterceptorSubject
     {
         return services.AddOpcUaSubjectClientSource(
             sp => sp.GetRequiredService<TSubject>(),
-            sp => CreateDefaultClientConfiguration(sp, serverUrl, sourceName, rootName));
+            sp => CreateDefaultClientConfiguration(sp, serverUrl, sourceName, rootPath));
     }
 
     public static IServiceCollection AddOpcUaSubjectClientSource(
@@ -76,13 +76,13 @@ public static class OpcUaSubjectExtensions
         string name,
         string serverUrl,
         string sourceName,
-        string? rootName = null)
+        string[]? rootPath = null)
         where TSubject : IInterceptorSubject
     {
         return services.AddKeyedOpcUaSubjectClientSource(
             name,
             sp => sp.GetRequiredService<TSubject>(),
-            sp => CreateDefaultClientConfiguration(sp, serverUrl, sourceName, rootName));
+            sp => CreateDefaultClientConfiguration(sp, serverUrl, sourceName, rootPath));
     }
 
     public static IServiceCollection AddKeyedOpcUaSubjectClientSource(
@@ -191,7 +191,7 @@ public static class OpcUaSubjectExtensions
     }
 
     private static OpcUaClientConfiguration CreateDefaultClientConfiguration(
-        IServiceProvider sp, string serverUrl, string sourceName, string? rootName)
+        IServiceProvider sp, string serverUrl, string sourceName, string[]? rootPath)
     {
         var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
         var telemetryContext = DefaultTelemetry.Create(builder =>
@@ -200,7 +200,7 @@ public static class OpcUaSubjectExtensions
         return new OpcUaClientConfiguration
         {
             ServerUrl = serverUrl,
-            RootName = rootName,
+            RootPath = rootPath,
             TypeResolver = new OpcUaTypeResolver(sp.GetRequiredService<ILogger<OpcUaTypeResolver>>()),
             ValueConverter = new OpcUaValueConverter(),
             SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),


### PR DESCRIPTION
## Summary
- Replace `RootName` (`string?`) with `RootPath` (`string[]?`) on `OpcUaClientConfiguration` so the client can browse from deeper starting nodes (e.g., `["foo", "bar"]` resolves `Objects/foo/bar`)
- HomeBlaze `OpcUaClient` uses a slash-delimited `string` for UI/config convenience, split on `/` when building the configuration
- Update all call sites: extension methods, tests, samples, connector tester, Blazor edit component

## Test plan
- [x] All unit tests pass (224 OPC UA tests, full solution green)
- [x] Public API snapshot updated and accepted
- [x] Manual: verify single-segment path (e.g., `["Root"]`) behaves identically to old `RootName = "Root"`
- [x] Manual: verify multi-segment path resolves correctly against a real OPC UA server

(Adopted for Bernhard S.)