### PR TITLE
bench: add realistic write benchmarks

### DIFF
--- a/src/Namotion.Interceptor.Benchmark/RegistryBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/RegistryBenchmark.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using BenchmarkDotNet.Attributes;
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Tracking;
@@ -12,6 +14,7 @@ public class RegistryBenchmark
 {
     private Car _object;
     private IInterceptorSubjectContext? _context;
+    private int _writeCounter;
     
     [Params(
         // "regular",
@@ -61,13 +64,53 @@ public class RegistryBenchmark
         _object.PreviousCars = null;
     }
 
+    /// <summary>
+    /// No-op write fast path: writes the same constant values every iteration. After warmup the
+    /// equality-check interceptor short-circuits each write, so the terminal store, derived
+    /// cascade, and any UtcNow snap never run. Measures interceptor-chain overhead for writes
+    /// whose new value equals the current value, which is common when a connector republishes
+    /// unchanged data.
+    /// </summary>
     [Benchmark]
-    public void Write()
+    public void WriteNoOp()
     {
         _object.Tires[0].Pressure = 5;
         _object.Tires[1].Pressure = 6;
         _object.Tires[2].Pressure = 7;
         _object.Tires[3].Pressure = 8;
+    }
+
+    /// <summary>
+    /// Real write: values change every iteration so the equality check passes, the terminal
+    /// store runs, and the write timestamp is snapped. Writes to <c>Pressure_Minimum</c>
+    /// (no derived dependents) to isolate the leaf-write cost from cascade work.
+    /// </summary>
+    [Benchmark]
+    public void Write()
+    {
+        var v = (decimal)Interlocked.Increment(ref _writeCounter);
+        _object.Tires[0].Pressure_Minimum = v;
+        _object.Tires[1].Pressure_Minimum = v + 1;
+        _object.Tires[2].Pressure_Minimum = v + 2;
+        _object.Tires[3].Pressure_Minimum = v + 3;
+    }
+
+    /// <summary>
+    /// Real write under an active <see cref="SubjectChangeContext.WithChangedTimestamp(System.DateTimeOffset?)"/>
+    /// scope: the connector-import path, where each imported value carries a source timestamp.
+    /// Exercises the scope-ticks branch of the write-timestamp pipeline.
+    /// </summary>
+    [Benchmark]
+    public void WriteWithTimestampScope()
+    {
+        var v = (decimal)Interlocked.Increment(ref _writeCounter);
+        using (SubjectChangeContext.WithChangedTimestamp(DateTimeOffset.UtcNow))
+        {
+            _object.Tires[0].Pressure_Minimum = v;
+            _object.Tires[1].Pressure_Minimum = v + 1;
+            _object.Tires[2].Pressure_Minimum = v + 2;
+            _object.Tires[3].Pressure_Minimum = v + 3;
+        }
     }
 
     [Benchmark]


### PR DESCRIPTION
## Summary
The existing `RegistryBenchmark.Write` writes `5,6,7,8` to four `Tire.Pressure` properties every iteration. After warmup the values match what is already stored, so the equality-check interceptor short-circuits each write before the terminal store and the derived-cascade for `AveragePressure` ever runs. It measures the **no-op write fast path**, not a typical real-world write.

This PR renames the existing bench and adds two realistic ones so the suite covers the full write surface.

## Changes
- Rename `Write` → `WriteNoOp` with a doc comment that names what it measures.
- Add `Write` (real leaf write). Varies the value via a counter and writes to `Tire.Pressure_Minimum`, which has no derived dependents, so the equality check passes and the terminal store + write-timestamp snap run, but no cascade work happens.
- Add `WriteWithTimestampScope` (connector import path). Same writes wrapped in `using (SubjectChangeContext.WithChangedTimestamp(DateTimeOffset.UtcNow))`. The scope provides ticks directly, so the terminal does not snap `UtcNow` per write.

## Smoke-test numbers (ShortRun, 3 iterations)
| Method | Mean |
|---|---:|
| `WriteNoOp` | 490 ns |
| `Write` | 1,370 ns |
| `WriteWithTimestampScope` | 1,237 ns |

The gap between `Write` and `WriteWithTimestampScope` (~130 ns) reflects 4 vs 1 `UtcNow` calls per iteration.

## Note on historical comparisons
The renames break historical "Write" tracking. Future runs that need to compare against pre-PR numbers should read the old `Write` as `WriteNoOp`.