### PR TITLE
perf(bench): add KnownSubjectsSnapshot benchmark

### DIFF
--- a/src/Namotion.Interceptor.Benchmark/RegistryBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/RegistryBenchmark.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using BenchmarkDotNet.Attributes;
 using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Abstractions;
 using Namotion.Interceptor.Tracking;
 
 namespace Namotion.Interceptor.Benchmark;
@@ -14,8 +15,9 @@ public class RegistryBenchmark
 {
     private Car _object;
     private IInterceptorSubjectContext? _context;
+    private ISubjectRegistry? _registry;
     private int _writeCounter;
-    
+
     [Params(
         // "regular",
         "interceptor"
@@ -39,6 +41,7 @@ public class RegistryBenchmark
 
                 _object = new Car(_context);
                 AddLotsOfPreviousCars();
+                _registry = _context.TryGetService<ISubjectRegistry>();
                 break;
         }
     }
@@ -153,5 +156,11 @@ public class RegistryBenchmark
     public string GenerateSubjectId()
     {
         return SubjectRegistryExtensions.GenerateSubjectId();
+    }
+
+    [Benchmark]
+    public int KnownSubjectsSnapshot()
+    {
+        return _registry!.KnownSubjects.Count;
     }
 }


### PR DESCRIPTION
Adds a benchmark that reads `ISubjectRegistry.KnownSubjects` after the 1000-car graph is built. Establishes a baseline for the `cache-known-subjects` and `concurrent-known-subjects` candidates tracked in #271 and #273 which avoid the per-call `ToImmutableDictionary` allocation.

Extracted from #274 so that `scripts/benchmark.ps1 -Stash` can produce a real side-by-side compare for `KnownSubjectsSnapshot` against the perf changes once this lands on master, instead of showing `n/a` on the master side.

No production code touched. Single benchmark addition.

## Test plan
- [x] Solution builds (0 warnings, 0 errors)
- [x] Existing benchmark suite still runs (no signature/setup regressions)