### PR TITLE
HomeBlaze: Add history support [PLAN]

### DIFF
--- a/src/HomeBlaze/HomeBlaze/Data/Docs/plans/history-mvp-impl-plan.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/plans/history-mvp-impl-plan.md
@@ -1,0 +1,1934 @@
+# History MVP Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship the History MVP end-to-end: abstractions, in-memory store, Timescale store, edit components, MCP tool, and property history dialog, with unit + integration tests proving every layer.
+
+**Architecture:** Three new packages under `HomeBlaze.History.*` (Abstractions, InMemory, TimescaleDb) plus Blazor edit components. Each store is a `[InterceptorSubject] BackgroundService` that subscribes to the change pipeline via its own `ChangeQueueProcessor`. Writes route values into typed Postgres columns (`value_long`/`value_double`/`value_json`) or per-property ring buffers. Reads dispatch a single-column SQL or per-property buffer scan. A `SubjectRegistry`-level `QueryHistoryAsync` extension merges results across stores (raw split by coverage; bucketed dispatch per-bucket).
+
+**Tech Stack:** .NET 10, C# 13 partial properties (`[InterceptorSubject]`), Npgsql (binary `COPY`), TimescaleDB hypertable + `time_bucket`, MudBlazor 9.2 (`MudTimeSeriesChart`), Testcontainers PostgreSQL, xUnit.
+
+**Companion design doc:** [history-mvp.md](history-mvp.md). Read it before starting; this plan implements it task-by-task.
+
+---
+
+## Phase 0: Prerequisite — Promote `ThroughputCounter`
+
+`ThroughputCounter` currently lives `internal sealed` in `Namotion.Interceptor.OpcUa`. Both history stores need it. Move it to `Namotion.Interceptor.Connectors` (already the home of `ChangeQueueProcessor`, already referenced by both OPC UA and the future history stores) and make it `public`.
+
+### Task 1: Move `ThroughputCounter` to `Namotion.Interceptor.Connectors`
+
+**Files:**
+- Move: `src/Namotion.Interceptor.OpcUa/ThroughputCounter.cs` → `src/Namotion.Interceptor.Connectors/ThroughputCounter.cs`
+- Modify: `src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs` (update `using`)
+- Modify: `src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs` (update `using`)
+- Move test: `src/Namotion.Interceptor.OpcUa.Tests/Client/ThroughputCounterTests.cs` → `src/Namotion.Interceptor.Connectors.Tests/ThroughputCounterTests.cs`
+
+**Step 1:** `git mv src/Namotion.Interceptor.OpcUa/ThroughputCounter.cs src/Namotion.Interceptor.Connectors/ThroughputCounter.cs`
+
+**Step 2:** Edit the moved file. Change `namespace Namotion.Interceptor.OpcUa;` to `namespace Namotion.Interceptor.Connectors;`. Change `internal sealed class ThroughputCounter` to `public sealed class ThroughputCounter`.
+
+**Step 3:** `git mv src/Namotion.Interceptor.OpcUa.Tests/Client/ThroughputCounterTests.cs src/Namotion.Interceptor.Connectors.Tests/ThroughputCounterTests.cs`
+
+**Step 4:** Update the test file's namespace from `Namotion.Interceptor.OpcUa.Tests.Client` to `Namotion.Interceptor.Connectors.Tests`. Update `using` directives.
+
+**Step 5:** Update the two OpcUa source files to use the new namespace. In `OpcUaSubjectClientSource.cs` and `OpcUaSubjectServer.cs`, add `using Namotion.Interceptor.Connectors;` and remove any `ThroughputCounter` reference that resolved via the old namespace.
+
+**Step 6:** Build and run existing tests:
+```
+dotnet build src/Namotion.Interceptor.slnx
+dotnet test src/Namotion.Interceptor.Connectors.Tests --filter "Category!=Integration"
+dotnet test src/Namotion.Interceptor.OpcUa.Tests --filter "Category!=Integration"
+```
+Expected: both green.
+
+**Step 7:** Commit:
+```bash
+git add -A
+git commit -m "refactor: promote ThroughputCounter to Namotion.Interceptor.Connectors
+
+ThroughputCounter is a general change-pipeline utility, not OPC UA specific.
+Moving it next to ChangeQueueProcessor lets the upcoming history stores
+share one implementation without adding a new dependency."
+```
+
+---
+
+## Phase 1: Abstractions package
+
+Define the interface and shared types every consumer (stores, UI, MCP) talks to.
+
+### Task 2: Create `HomeBlaze.History.Abstractions` project
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HomeBlaze.History.Abstractions.csproj`
+
+**Step 1:** Create the csproj:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Namotion.Interceptor.Registry\Namotion.Interceptor.Registry.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+**Step 2:** Add the project to the solution:
+```bash
+dotnet sln src/Namotion.Interceptor.slnx add src/HomeBlaze/HomeBlaze.History.Abstractions/HomeBlaze.History.Abstractions.csproj
+```
+
+**Step 3:** Build:
+```bash
+dotnet build src/HomeBlaze/HomeBlaze.History.Abstractions
+```
+Expected: succeeds with no source files (empty assembly).
+
+**Step 4:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/ src/Namotion.Interceptor.slnx
+git commit -m "feat: scaffold HomeBlaze.History.Abstractions package"
+```
+
+### Task 3: Define query types and `IHistoryStore` interface
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/IHistoryStore.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryQuery.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryCoverage.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryAggregation.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryPoint.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistorySeries.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryAggregationNotSupportedException.cs`
+
+**Step 1:** Write `HistoryCoverage.cs`:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+/// <summary>
+/// Range a history store guarantees it can answer queries over.
+/// Returning a tighter coverage than physically held is safe.
+/// Returning a wider coverage is a bug.
+/// </summary>
+public readonly record struct HistoryCoverage(DateTimeOffset From, DateTimeOffset To)
+{
+    public bool Contains(HistoryCoverage other) =>
+        other.From >= From && other.To <= To;
+
+    public bool Overlaps(HistoryCoverage other) =>
+        other.From < To && other.To > From;
+}
+```
+
+**Step 2:** Write `HistoryAggregation.cs`:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+public enum HistoryAggregation { Last, Average, Minimum, Maximum, Sum, Count }
+```
+
+**Step 3:** Write `HistoryQuery.cs`:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+public record HistoryQuery(
+    string PropertyPath,
+    DateTimeOffset From,
+    DateTimeOffset To,
+    TimeSpan? Bucket = null,
+    HistoryAggregation Aggregation = HistoryAggregation.Last,
+    int MaxPoints = 10_000);
+```
+
+**Step 4:** Write `HistoryPoint.cs`:
+
+```csharp
+using System.Text.Json;
+
+namespace HomeBlaze.History.Abstractions;
+
+public record HistoryPoint(
+    DateTimeOffset Timestamp,
+    double? Number,
+    JsonElement? Json);
+```
+
+**Step 5:** Write `HistorySeries.cs`:
+
+```csharp
+using System.Collections.Immutable;
+
+namespace HomeBlaze.History.Abstractions;
+
+public record HistorySeries(
+    string PropertyPath,
+    ImmutableArray<HistoryPoint> Points,
+    bool Truncated);
+```
+
+**Step 6:** Write `HistoryAggregationNotSupportedException.cs`:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+public class HistoryAggregationNotSupportedException : InvalidOperationException
+{
+    public HistoryAggregationNotSupportedException(
+        HistoryAggregation aggregation, string propertyPath, string column)
+        : base($"Aggregation '{aggregation}' is not supported for property '{propertyPath}' (storage column: {column}).")
+    {
+        Aggregation = aggregation;
+        PropertyPath = propertyPath;
+        Column = column;
+    }
+
+    public HistoryAggregation Aggregation { get; }
+    public string PropertyPath { get; }
+    public string Column { get; }
+}
+```
+
+**Step 7:** Write `IHistoryStore.cs`:
+
+```csharp
+using Namotion.Interceptor;
+
+namespace HomeBlaze.History.Abstractions;
+
+public interface IHistoryStore : IInterceptorSubject
+{
+    int Priority { get; }
+    HistoryCoverage Coverage { get; }
+    Task<HistorySeries> QueryAsync(HistoryQuery query, CancellationToken cancellationToken);
+}
+```
+
+**Step 8:** Build:
+```bash
+dotnet build src/HomeBlaze/HomeBlaze.History.Abstractions
+```
+Expected: succeeds.
+
+**Step 9:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/
+git commit -m "feat: add IHistoryStore interface and query types"
+```
+
+### Task 4: Implement `HistoryEligibility.HasHistory` (TDD)
+
+**Files:**
+- Create test: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/HomeBlaze.History.Abstractions.Tests.csproj`
+- Create test: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/HistoryEligibilityTests.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryEligibility.cs`
+
+**Step 1:** Create the test csproj:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HomeBlaze.History.Abstractions\HomeBlaze.History.Abstractions.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+Add to solution: `dotnet sln src/Namotion.Interceptor.slnx add src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/HomeBlaze.History.Abstractions.Tests.csproj`
+
+**Step 2:** Write the failing tests in `HistoryEligibilityTests.cs`:
+
+```csharp
+using System.IO;
+using HomeBlaze.History.Abstractions;
+using Xunit;
+
+namespace HomeBlaze.History.Abstractions.Tests;
+
+public class HistoryEligibilityTests
+{
+    public enum Color { Red, Green, Blue }
+
+    [Theory]
+    [InlineData(typeof(double))]
+    [InlineData(typeof(float))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(short))]
+    [InlineData(typeof(byte))]
+    [InlineData(typeof(sbyte))]
+    [InlineData(typeof(uint))]
+    [InlineData(typeof(ulong))]
+    [InlineData(typeof(ushort))]
+    [InlineData(typeof(bool))]
+    [InlineData(typeof(decimal))]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(Color))]
+    [InlineData(typeof(double?))]
+    [InlineData(typeof(int?))]
+    public void WhenTypeIsAllowed_ThenIsRecordableTypeIsTrue(Type type)
+    {
+        // Act & Assert
+        Assert.True(HistoryEligibility.IsRecordableType(type));
+    }
+
+    [Theory]
+    [InlineData(typeof(byte[]))]
+    [InlineData(typeof(Stream))]
+    [InlineData(typeof(object))]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(DateTimeOffset))]
+    [InlineData(typeof(Guid))]
+    [InlineData(typeof(List<int>))]
+    public void WhenTypeIsNotAllowed_ThenIsRecordableTypeIsFalse(Type type)
+    {
+        // Act & Assert
+        Assert.False(HistoryEligibility.IsRecordableType(type));
+    }
+}
+```
+
+**Step 3:** Run tests, verify they fail:
+```bash
+dotnet test src/HomeBlaze/HomeBlaze.History.Abstractions.Tests
+```
+Expected: FAIL with "HistoryEligibility does not contain a definition for IsRecordableType."
+
+**Step 4:** Implement `HistoryEligibility.cs`:
+
+```csharp
+using Namotion.Interceptor.Registry.Abstractions;
+
+namespace HomeBlaze.History.Abstractions;
+
+public static class HistoryEligibility
+{
+    public static bool HasHistory(this RegisteredSubjectProperty property)
+    {
+        if (!property.IsState) return false;
+        if (property.HasChildren) return false;
+        return IsRecordableType(property.Type);
+    }
+
+    public static bool IsRecordableType(Type type)
+    {
+        var t = Nullable.GetUnderlyingType(type) ?? type;
+        if (t == typeof(double) || t == typeof(float)) return true;
+        if (IsBigIntCompatible(t)) return true;
+        if (t == typeof(decimal)) return true;
+        if (t == typeof(string)) return true;
+        if (t.IsEnum) return true;
+        return false;
+    }
+
+    internal static bool IsBigIntCompatible(Type t) =>
+        t == typeof(long)   || t == typeof(int)   || t == typeof(short) ||
+        t == typeof(sbyte)  || t == typeof(byte)  ||
+        t == typeof(ushort) || t == typeof(uint)  || t == typeof(ulong) ||
+        t == typeof(bool);
+}
+```
+
+Note: `IsState` and `HasChildren` are extension methods or properties on `RegisteredSubjectProperty`. If they don't compile, look for equivalent names in `Namotion.Interceptor.Registry.Abstractions` (the registry exposes `[State]` detection via attribute metadata; you may need `property.HasAttribute<StateAttribute>()` or similar). Adjust to the actual API.
+
+**Step 5:** Run tests, verify they pass:
+```bash
+dotnet test src/HomeBlaze/HomeBlaze.History.Abstractions.Tests
+```
+Expected: PASS for all type-routing tests.
+
+**Step 6:** Add a `HasHistory` test that uses a real registered subject (separate test class once you confirm the registry API; for now the `IsRecordableType` coverage proves the type rules).
+
+**Step 7:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryEligibility.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/
+git commit -m "feat: add HistoryEligibility predicate for recordable types"
+```
+
+### Task 5: Implement `HistoryColumns` dispatch (TDD)
+
+**Files:**
+- Modify test: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/HistoryColumnsTests.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryColumns.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/ValueColumn.cs`
+
+**Step 1:** Add `ValueColumn.cs`:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+public enum ValueColumn { Long, Double, Json }
+```
+
+**Step 2:** Write the failing test `HistoryColumnsTests.cs`:
+
+```csharp
+using HomeBlaze.History.Abstractions;
+using Xunit;
+
+namespace HomeBlaze.History.Abstractions.Tests;
+
+public class HistoryColumnsTests
+{
+    public enum Color { Red, Green }
+
+    [Theory]
+    [InlineData(typeof(double),  ValueColumn.Double)]
+    [InlineData(typeof(float),   ValueColumn.Double)]
+    [InlineData(typeof(double?), ValueColumn.Double)]
+    [InlineData(typeof(int),     ValueColumn.Long)]
+    [InlineData(typeof(long),    ValueColumn.Long)]
+    [InlineData(typeof(short),   ValueColumn.Long)]
+    [InlineData(typeof(byte),    ValueColumn.Long)]
+    [InlineData(typeof(sbyte),   ValueColumn.Long)]
+    [InlineData(typeof(uint),    ValueColumn.Long)]
+    [InlineData(typeof(ulong),   ValueColumn.Long)]
+    [InlineData(typeof(ushort),  ValueColumn.Long)]
+    [InlineData(typeof(bool),    ValueColumn.Long)]
+    [InlineData(typeof(decimal), ValueColumn.Json)]
+    [InlineData(typeof(string),  ValueColumn.Json)]
+    [InlineData(typeof(Color),   ValueColumn.Json)]
+    public void WhenTypeIsGiven_ThenValueColumnForReturnsExpected(Type t, ValueColumn expected)
+    {
+        // Act & Assert
+        Assert.Equal(expected, HistoryColumns.ValueColumnFor(t));
+    }
+
+    [Fact]
+    public void WhenTypeIsUlong_ThenIsUlongPropertyIsTrue()
+    {
+        // Act & Assert
+        Assert.True(HistoryColumns.IsUlongProperty(typeof(ulong)));
+        Assert.True(HistoryColumns.IsUlongProperty(typeof(ulong?)));
+    }
+
+    [Theory]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(double))]
+    [InlineData(typeof(string))]
+    public void WhenTypeIsNotUlong_ThenIsUlongPropertyIsFalse(Type t)
+    {
+        // Act & Assert
+        Assert.False(HistoryColumns.IsUlongProperty(t));
+    }
+}
+```
+
+**Step 3:** Run tests, verify they fail:
+```bash
+dotnet test src/HomeBlaze/HomeBlaze.History.Abstractions.Tests --filter HistoryColumnsTests
+```
+Expected: FAIL with "HistoryColumns does not exist."
+
+**Step 4:** Implement `HistoryColumns.cs`:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+public static class HistoryColumns
+{
+    public static ValueColumn ValueColumnFor(Type propertyType)
+    {
+        var t = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        if (t == typeof(double) || t == typeof(float)) return ValueColumn.Double;
+        if (HistoryEligibility.IsBigIntCompatible(t)) return ValueColumn.Long;
+        return ValueColumn.Json;
+    }
+
+    public static bool IsUlongProperty(Type propertyType) =>
+        (Nullable.GetUnderlyingType(propertyType) ?? propertyType) == typeof(ulong);
+}
+```
+
+**Step 5:** Run tests, verify pass:
+```bash
+dotnet test src/HomeBlaze/HomeBlaze.History.Abstractions.Tests --filter HistoryColumnsTests
+```
+Expected: PASS.
+
+**Step 6:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/ValueColumn.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryColumns.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/HistoryColumnsTests.cs
+git commit -m "feat: add HistoryColumns dispatch helper"
+```
+
+### Task 6: Implement bucket alignment helper (TDD)
+
+**Files:**
+- Create test: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/BucketAlignmentTests.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/BucketAlignment.cs`
+
+**Step 1:** Failing test:
+
+```csharp
+using HomeBlaze.History.Abstractions;
+using Xunit;
+
+namespace HomeBlaze.History.Abstractions.Tests;
+
+public class BucketAlignmentTests
+{
+    [Fact]
+    public void WhenTimestampIsAtBucketBoundary_ThenBucketStartIsThatTimestamp()
+    {
+        // Arrange
+        var ts = new DateTimeOffset(2026, 5, 20, 12, 30, 0, TimeSpan.Zero);
+        var bucket = TimeSpan.FromMinutes(1);
+
+        // Act
+        var start = BucketAlignment.BucketStart(ts, bucket);
+
+        // Assert
+        Assert.Equal(ts, start);
+    }
+
+    [Fact]
+    public void WhenTimestampIsInsideBucket_ThenBucketStartIsBoundary()
+    {
+        // Arrange
+        var ts = new DateTimeOffset(2026, 5, 20, 12, 30, 37, TimeSpan.Zero);
+        var bucket = TimeSpan.FromMinutes(1);
+
+        // Act
+        var start = BucketAlignment.BucketStart(ts, bucket);
+
+        // Assert
+        Assert.Equal(new DateTimeOffset(2026, 5, 20, 12, 30, 0, TimeSpan.Zero), start);
+    }
+
+    [Fact]
+    public void WhenBucketIsTenMinutes_ThenBucketStartsAtMultipleOfTen()
+    {
+        // Arrange
+        var ts = new DateTimeOffset(2026, 5, 20, 12, 37, 23, TimeSpan.Zero);
+        var bucket = TimeSpan.FromMinutes(10);
+
+        // Act
+        var start = BucketAlignment.BucketStart(ts, bucket);
+
+        // Assert
+        Assert.Equal(new DateTimeOffset(2026, 5, 20, 12, 30, 0, TimeSpan.Zero), start);
+    }
+
+    [Fact]
+    public void WhenSameTimestampAndBucket_ThenSqlTimeBucketAndBucketAlignmentMatch()
+    {
+        // This test exists to lock the formula. PG's time_bucket('1min', ts) for
+        // ts='2026-05-20T12:30:37Z' returns '2026-05-20T12:30:00Z'. Our formula
+        // must match for cross-store concatenation to work without interleaving.
+        // (See integration test 'Bucket alignment' for the real cross-check.)
+        var ts = new DateTimeOffset(2026, 5, 20, 12, 30, 37, TimeSpan.Zero);
+        Assert.Equal(
+            new DateTimeOffset(2026, 5, 20, 12, 30, 0, TimeSpan.Zero),
+            BucketAlignment.BucketStart(ts, TimeSpan.FromMinutes(1)));
+    }
+}
+```
+
+**Step 2:** Run, verify fail.
+
+**Step 3:** Implement:
+
+```csharp
+namespace HomeBlaze.History.Abstractions;
+
+/// <summary>
+/// Epoch-anchored bucket-start math. Must match Postgres time_bucket(interval, ts)
+/// so in-memory and Timescale buckets concatenate cleanly without interleaving.
+/// </summary>
+public static class BucketAlignment
+{
+    private static readonly DateTimeOffset Epoch = DateTimeOffset.UnixEpoch;
+
+    public static DateTimeOffset BucketStart(DateTimeOffset timestamp, TimeSpan bucket)
+    {
+        var ticksFromEpoch = (timestamp - Epoch).Ticks;
+        var bucketTicks = bucket.Ticks;
+        var bucketIndex = ticksFromEpoch / bucketTicks;
+        return Epoch.AddTicks(bucketIndex * bucketTicks);
+    }
+}
+```
+
+**Step 4:** Run, verify pass.
+
+**Step 5:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/BucketAlignment.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/BucketAlignmentTests.cs
+git commit -m "feat: add epoch-anchored BucketAlignment helper"
+```
+
+### Task 7: Cross-store merge — raw path (TDD)
+
+**Files:**
+- Create test: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/QueryHistoryAsyncRawTests.cs`
+- Create test fake: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/FakeHistoryStore.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryQueryExtensions.cs`
+
+**Step 1:** Write the fake store helper:
+
+```csharp
+using System.Collections.Immutable;
+using HomeBlaze.History.Abstractions;
+using Namotion.Interceptor;
+using Namotion.Interceptor.Attributes;
+
+namespace HomeBlaze.History.Abstractions.Tests;
+
+[InterceptorSubject]
+public partial class FakeHistoryStore : IHistoryStore
+{
+    private readonly List<HistoryPoint> _samples;
+
+    public FakeHistoryStore(int priority, HistoryCoverage coverage, IEnumerable<HistoryPoint>? samples = null)
+    {
+        Priority = priority;
+        Coverage = coverage;
+        _samples = samples?.ToList() ?? new List<HistoryPoint>();
+    }
+
+    public int Priority { get; }
+    public HistoryCoverage Coverage { get; }
+    public bool ShouldThrow { get; set; }
+    public int QueryCount { get; private set; }
+    public List<HistoryQuery> Queries { get; } = new();
+
+    public Task<HistorySeries> QueryAsync(HistoryQuery query, CancellationToken ct)
+    {
+        QueryCount++;
+        Queries.Add(query);
+        if (ShouldThrow) throw new InvalidOperationException("fake store error");
+
+        var filtered = _samples
+            .Where(p => p.Timestamp >= query.From && p.Timestamp < query.To)
+            .OrderBy(p => p.Timestamp)
+            .Take(query.MaxPoints + 1)
+            .ToList();
+        var truncated = filtered.Count > query.MaxPoints;
+        if (truncated) filtered.RemoveAt(filtered.Count - 1);
+        return Task.FromResult(new HistorySeries(query.PropertyPath, filtered.ToImmutableArray(), truncated));
+    }
+}
+```
+
+(The `[InterceptorSubject]` attribute is required so the fake satisfies `IInterceptorSubject`. Source generation provides the rest.)
+
+**Step 2:** Failing test `QueryHistoryAsyncRawTests.cs`:
+
+```csharp
+using System.Collections.Immutable;
+using HomeBlaze.History.Abstractions;
+using Namotion.Interceptor;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Abstractions;
+using Xunit;
+
+namespace HomeBlaze.History.Abstractions.Tests;
+
+public class QueryHistoryAsyncRawTests
+{
+    private static SubjectRegistry BuildRegistryWith(params IHistoryStore[] stores)
+    {
+        var context = InterceptorSubjectContext.Create().WithRegistry();
+        foreach (var store in stores) context.AddSubject(store);
+        return context.GetService<SubjectRegistry>();
+    }
+
+    [Fact]
+    public async Task WhenSingleStoreCoversRange_ThenAllPointsComeFromIt()
+    {
+        // Arrange
+        var t0 = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+        var store = new FakeHistoryStore(
+            priority: 10,
+            coverage: new HistoryCoverage(t0, t0.AddMinutes(30)),
+            samples: new[]
+            {
+                new HistoryPoint(t0.AddMinutes(1), 1.0, null),
+                new HistoryPoint(t0.AddMinutes(2), 2.0, null),
+            });
+        var registry = BuildRegistryWith(store);
+
+        // Act
+        var result = await registry.QueryHistoryAsync(
+            new HistoryQuery("Devices/X/Temperature", t0, t0.AddMinutes(30)),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Points.Length);
+        Assert.Equal(1, store.QueryCount);
+    }
+
+    [Fact]
+    public async Task WhenTwoStoresHaveDisjointCoverage_ThenEachServesItsRange()
+    {
+        // Arrange
+        var t0 = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+        var inMem = new FakeHistoryStore(
+            priority: 100,
+            coverage: new HistoryCoverage(t0.AddMinutes(25), t0.AddMinutes(30)),
+            samples: new[] { new HistoryPoint(t0.AddMinutes(28), 28.0, null) });
+        var timescale = new FakeHistoryStore(
+            priority: 10,
+            coverage: new HistoryCoverage(t0, t0.AddMinutes(25)),
+            samples: new[] { new HistoryPoint(t0.AddMinutes(5), 5.0, null) });
+        var registry = BuildRegistryWith(inMem, timescale);
+
+        // Act
+        var result = await registry.QueryHistoryAsync(
+            new HistoryQuery("Devices/X/T", t0, t0.AddMinutes(30)),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Points.Length);
+        Assert.Equal(5.0, result.Points[0].Number);
+        Assert.Equal(28.0, result.Points[1].Number);
+        Assert.Equal(1, inMem.QueryCount);
+        Assert.Equal(1, timescale.QueryCount);
+    }
+
+    [Fact]
+    public async Task WhenTwoStoresOverlap_ThenHigherPriorityWinsTimestamp()
+    {
+        // Arrange
+        var t0 = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+        var sampleTs = t0.AddMinutes(20);
+        var inMem = new FakeHistoryStore(
+            priority: 100,
+            coverage: new HistoryCoverage(t0.AddMinutes(15), t0.AddMinutes(30)),
+            samples: new[] { new HistoryPoint(sampleTs, 100.0, null) });
+        var timescale = new FakeHistoryStore(
+            priority: 10,
+            coverage: new HistoryCoverage(t0, t0.AddMinutes(30)),
+            samples: new[] { new HistoryPoint(sampleTs, 10.0, null) });
+        var registry = BuildRegistryWith(inMem, timescale);
+
+        // Act
+        var result = await registry.QueryHistoryAsync(
+            new HistoryQuery("Devices/X/T", t0, t0.AddMinutes(30)),
+            CancellationToken.None);
+
+        // Assert: in-memory's value wins for the overlapping timestamp.
+        var match = result.Points.Single(p => p.Timestamp == sampleTs);
+        Assert.Equal(100.0, match.Number);
+    }
+
+    [Fact]
+    public async Task WhenStoreThrows_ThenExceptionPropagates()
+    {
+        // Arrange
+        var store = new FakeHistoryStore(
+            priority: 10,
+            coverage: new HistoryCoverage(DateTimeOffset.MinValue, DateTimeOffset.MaxValue))
+        { ShouldThrow = true };
+        var registry = BuildRegistryWith(store);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            registry.QueryHistoryAsync(
+                new HistoryQuery("p", DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenRegistryHasNoStores_ThenResultIsEmpty()
+    {
+        // Arrange
+        var registry = BuildRegistryWith();
+
+        // Act
+        var result = await registry.QueryHistoryAsync(
+            new HistoryQuery("p", DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result.Points);
+    }
+}
+```
+
+**Step 3:** Run, verify fail.
+
+**Step 4:** Implement `HistoryQueryExtensions.cs` (raw path only for now):
+
+```csharp
+using System.Collections.Immutable;
+using Namotion.Interceptor.Registry;
+
+namespace HomeBlaze.History.Abstractions;
+
+public static class HistoryQueryExtensions
+{
+    public static async Task<HistorySeries> QueryHistoryAsync(
+        this SubjectRegistry registry,
+        HistoryQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var stores = registry.KnownSubjects
+            .OfType<IHistoryStore>()
+            .OrderByDescending(s => s.Priority)
+            .ToArray();
+
+        if (stores.Length == 0)
+            return new HistorySeries(query.PropertyPath, ImmutableArray<HistoryPoint>.Empty, false);
+
+        if (query.Bucket is null)
+            return await RawMergeAsync(stores, query, cancellationToken);
+
+        // Bucketed path: implemented in Task 8
+        throw new NotImplementedException("Bucketed merge implemented in Task 8.");
+    }
+
+    private static async Task<HistorySeries> RawMergeAsync(
+        IHistoryStore[] stores, HistoryQuery query, CancellationToken ct)
+    {
+        var gaps = new List<HistoryCoverage> { new(query.From, query.To) };
+        var merged = new SortedDictionary<DateTimeOffset, HistoryPoint>();
+        var truncated = false;
+
+        foreach (var store in stores)
+        {
+            if (gaps.Count == 0) break;
+            var subRanges = IntersectAll(gaps, store.Coverage).ToList();
+            foreach (var sub in subRanges)
+            {
+                var subSeries = await store.QueryAsync(
+                    query with { From = sub.From, To = sub.To }, ct);
+                truncated |= subSeries.Truncated;
+                foreach (var point in subSeries.Points)
+                    merged.TryAdd(point.Timestamp, point);
+            }
+            gaps = SubtractAll(gaps, store.Coverage).ToList();
+        }
+
+        return new HistorySeries(
+            query.PropertyPath,
+            merged.Values.ToImmutableArray(),
+            truncated);
+    }
+
+    private static IEnumerable<HistoryCoverage> IntersectAll(
+        IEnumerable<HistoryCoverage> ranges, HistoryCoverage other)
+    {
+        foreach (var r in ranges)
+        {
+            var from = r.From > other.From ? r.From : other.From;
+            var to   = r.To   < other.To   ? r.To   : other.To;
+            if (from < to) yield return new HistoryCoverage(from, to);
+        }
+    }
+
+    private static IEnumerable<HistoryCoverage> SubtractAll(
+        IEnumerable<HistoryCoverage> ranges, HistoryCoverage other)
+    {
+        foreach (var r in ranges)
+        {
+            if (r.To <= other.From || r.From >= other.To) { yield return r; continue; }
+            if (r.From < other.From) yield return new HistoryCoverage(r.From, other.From);
+            if (r.To > other.To)     yield return new HistoryCoverage(other.To, r.To);
+        }
+    }
+}
+```
+
+**Step 5:** Run, verify pass for all 5 tests.
+
+**Step 6:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryQueryExtensions.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/QueryHistoryAsyncRawTests.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/FakeHistoryStore.cs
+git commit -m "feat: QueryHistoryAsync raw merge with coverage-based dispatch"
+```
+
+### Task 8: Cross-store merge — bucketed per-bucket dispatch (TDD)
+
+**Files:**
+- Create test: `src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/QueryHistoryAsyncBucketedTests.cs`
+- Modify: `src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryQueryExtensions.cs`
+
+**Step 1:** Add bucketed tests. The fake store needs to honor bucket queries — extend `FakeHistoryStore.QueryAsync` to compute per-bucket aggregates over its samples when `query.Bucket` is non-null. Use `BucketAlignment.BucketStart` and group by bucket. For `Average`, average the `Number` values; for `Count`, count non-null entries; etc.
+
+Sample failing test:
+
+```csharp
+[Fact]
+public async Task WhenBucketFullyContainedByHigherPriority_ThenOnlyHigherPriorityQueried()
+{
+    // Arrange
+    var t0 = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+    var inMem = new FakeHistoryStore(
+        priority: 100,
+        coverage: new HistoryCoverage(t0.AddMinutes(28), t0.AddMinutes(30)),
+        samples: new[] { new HistoryPoint(t0.AddMinutes(29), 29.0, null) });
+    var timescale = new FakeHistoryStore(
+        priority: 10,
+        coverage: new HistoryCoverage(t0, t0.AddMinutes(30)),
+        samples: Enumerable.Range(0, 30).Select(i => new HistoryPoint(t0.AddMinutes(i), i, null)));
+    var registry = BuildRegistryWith(inMem, timescale);
+
+    // Act: 30-min range, 1-min buckets. Last 2 buckets fit in-memory.
+    var result = await registry.QueryHistoryAsync(
+        new HistoryQuery("p", t0, t0.AddMinutes(30),
+            Bucket: TimeSpan.FromMinutes(1),
+            Aggregation: HistoryAggregation.Average),
+        CancellationToken.None);
+
+    // Assert
+    Assert.Equal(30, result.Points.Length);
+    // Buckets 28 and 29 (the last two) came from in-memory (only one query against the in-mem range).
+    Assert.Equal(1, inMem.QueryCount);
+    Assert.Equal(1, timescale.QueryCount);
+}
+```
+
+Add more tests for:
+- Effective-range clipping at the right edge
+- Single bucket spanning both stores → falls back to the wider-coverage store
+- Buckets entirely outside any store coverage → not present in output
+
+**Step 2:** Run, verify fail (NotImplementedException).
+
+**Step 3:** Implement the bucketed merge in `HistoryQueryExtensions.cs`:
+
+```csharp
+private static async Task<HistorySeries> BucketedMergeAsync(
+    IHistoryStore[] stores, HistoryQuery query, CancellationToken ct)
+{
+    var bucket = query.Bucket!.Value;
+    var buckets = EnumerateBuckets(query.From, query.To, bucket).ToList();
+
+    var assignments = buckets
+        .Select(b => (Bucket: b, Store: AssignBucket(stores, b, query)))
+        .Where(a => a.Store is not null)
+        .ToList();
+
+    var merged = new SortedDictionary<DateTimeOffset, HistoryPoint>();
+    var truncated = false;
+
+    // Group consecutive buckets assigned to the same store into one sub-query.
+    var groupedRanges = GroupConsecutive(assignments);
+    foreach (var group in groupedRanges)
+    {
+        var subQuery = query with
+        {
+            From = group.First().Bucket.From,
+            To   = group.Last().Bucket.To
+        };
+        var part = await group.Key!.QueryAsync(subQuery, ct);
+        truncated |= part.Truncated;
+        foreach (var point in part.Points)
+            merged[point.Timestamp] = point;
+    }
+
+    return new HistorySeries(query.PropertyPath, merged.Values.ToImmutableArray(), truncated);
+}
+
+private static IEnumerable<HistoryCoverage> EnumerateBuckets(
+    DateTimeOffset from, DateTimeOffset to, TimeSpan bucket)
+{
+    var start = BucketAlignment.BucketStart(from, bucket);
+    for (var t = start; t < to; t = t + bucket)
+        yield return new HistoryCoverage(t, t + bucket);
+}
+
+private static IHistoryStore? AssignBucket(IHistoryStore[] stores, HistoryCoverage bucket, HistoryQuery query)
+{
+    var effective = new HistoryCoverage(
+        From: bucket.From > query.From ? bucket.From : query.From,
+        To:   bucket.To   < query.To   ? bucket.To   : query.To);
+
+    // Highest-priority store whose coverage fully contains the effective range.
+    foreach (var s in stores)
+        if (s.Coverage.Contains(effective)) return s;
+
+    // Fall back to lowest-priority store with overlap.
+    for (var i = stores.Length - 1; i >= 0; i--)
+        if (stores[i].Coverage.Overlaps(effective)) return stores[i];
+
+    return null;
+}
+
+private static IEnumerable<IGrouping<IHistoryStore, (HistoryCoverage Bucket, IHistoryStore? Store)>>
+    GroupConsecutive(List<(HistoryCoverage Bucket, IHistoryStore? Store)> assignments)
+{
+    return assignments
+        .Select((a, idx) => (a.Bucket, a.Store, Group: idx == 0 || assignments[idx - 1].Store != a.Store ? idx : -1))
+        // Easier: use a running counter.
+        .GroupBy(x => x.Store!);
+    // NOTE: A cleaner implementation walks the list once, accumulating runs.
+    // Replace this LINQ with a manual loop if you need strict consecutiveness.
+}
+```
+
+(The `GroupConsecutive` implementation above is a placeholder; in code, walk the list and emit runs. The tests will catch a wrong implementation. Replace with: scan assignments, when store changes, close the current group.)
+
+**Step 4:** Update the entry point to call `BucketedMergeAsync` when `query.Bucket is not null`.
+
+**Step 5:** Run all tests, verify pass.
+
+**Step 6:** Commit:
+```bash
+git add src/HomeBlaze/HomeBlaze.History.Abstractions/HistoryQueryExtensions.cs \
+        src/HomeBlaze/HomeBlaze.History.Abstractions.Tests/QueryHistoryAsyncBucketedTests.cs
+git commit -m "feat: QueryHistoryAsync bucketed merge with per-bucket dispatch"
+```
+
+---
+
+## Phase 2: In-memory store
+
+### Task 9: Create `HomeBlaze.History.InMemory` project
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory/HomeBlaze.History.InMemory.csproj`
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory.Tests/HomeBlaze.History.InMemory.Tests.csproj`
+
+**Step 1:** Create the source csproj. Target `net10.0`, reference `HomeBlaze.History.Abstractions`, `Namotion.Interceptor.Connectors`, `HomeBlaze.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions`.
+
+**Step 2:** Create the test csproj. Reference xUnit, the source project, `HomeBlaze.History.Abstractions.Tests` (for the fake store, or duplicate it locally).
+
+**Step 3:** Add both to solution.
+
+**Step 4:** Build, verify both empty assemblies succeed.
+
+**Step 5:** Commit.
+
+### Task 10: Define `Sample` record struct
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory/Sample.cs`
+
+**Step 1:** Define:
+
+```csharp
+namespace HomeBlaze.History.InMemory;
+
+internal readonly record struct Sample(DateTimeOffset Timestamp, object? Value);
+```
+
+**Step 2:** Commit.
+
+### Task 11: `PropertyBuffer.Add` with ring buffer (TDD)
+
+**Files:**
+- Create test: `src/HomeBlaze/HomeBlaze.History.InMemory.Tests/PropertyBufferAddTests.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory/PropertyBuffer.cs`
+
+**Step 1:** Failing test:
+
+```csharp
+using HomeBlaze.History.InMemory;
+using Xunit;
+
+namespace HomeBlaze.History.InMemory.Tests;
+
+public class PropertyBufferAddTests
+{
+    [Fact]
+    public void WhenSampleAddedAndCapacityNotExceeded_ThenCountIncrements()
+    {
+        // Arrange
+        var buffer = new PropertyBuffer(maxPoints: 10, maxAge: TimeSpan.FromMinutes(5));
+
+        // Act
+        buffer.Add(new Sample(DateTimeOffset.UtcNow, 42.0));
+
+        // Assert
+        Assert.Equal(1, buffer.Count);
+    }
+
+    [Fact]
+    public void WhenCapacityExceeded_ThenOldestEvictedAndEvictedCountIncrements()
+    {
+        // Arrange
+        var buffer = new PropertyBuffer(maxPoints: 3, maxAge: TimeSpan.FromMinutes(5));
+        var t0 = DateTimeOffset.UtcNow;
+
+        // Act
+        for (var i = 0; i < 5; i++) buffer.Add(new Sample(t0.AddSeconds(i), i));
+
+        // Assert
+        Assert.Equal(3, buffer.Count);
+        Assert.Equal(2, buffer.EvictedCount);
+        Assert.Equal(2, buffer.OldestTimestamp.Subtract(t0).TotalSeconds, 1);
+    }
+}
+```
+
+**Step 2:** Run, verify fail.
+
+**Step 3:** Implement `PropertyBuffer.cs`:
+
+```csharp
+namespace HomeBlaze.History.InMemory;
+
+internal sealed class PropertyBuffer
+{
+    private readonly object _lock = new();
+    private readonly Sample[] _ring;
+    private readonly TimeSpan _maxAge;
+    private int _head;
+    private int _count;
+
+    public PropertyBuffer(int maxPoints, TimeSpan maxAge)
+    {
+        _ring = new Sample[maxPoints];
+        _maxAge = maxAge;
+    }
+
+    public int Count { get { lock (_lock) return _count; } }
+    public long EvictedCount { get; private set; }
+
+    public DateTimeOffset OldestTimestamp
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _count == 0 ? DateTimeOffset.MinValue : _ring[_head].Timestamp;
+            }
+        }
+    }
+
+    public void Add(Sample sample)
+    {
+        lock (_lock)
+        {
+            if (_count < _ring.Length)
+            {
+                _ring[(_head + _count) % _ring.Length] = sample;
+                _count++;
+            }
+            else
+            {
+                // Full: overwrite the oldest.
+                _ring[_head] = sample;
+                _head = (_head + 1) % _ring.Length;
+                EvictedCount++;
+            }
+        }
+    }
+}
+```
+
+**Step 4:** Run, verify pass.
+
+**Step 5:** Commit.
+
+### Task 12: `PropertyBuffer.Range` with binary search (TDD)
+
+**Step 1:** Failing test for range query that:
+- Returns samples in `[from, to)` ordered by ts.
+- Respects `maxPoints` and sets `truncated`.
+- Trims by age first (samples older than `maxAge` excluded).
+
+**Step 2:** Implement:
+
+```csharp
+public ImmutableArray<Sample> Range(DateTimeOffset from, DateTimeOffset to, int maxPoints, out bool truncated)
+{
+    lock (_lock)
+    {
+        TrimExpired();
+        if (_count == 0) { truncated = false; return ImmutableArray<Sample>.Empty; }
+
+        // Binary search in the logical view.
+        var startIdx = LowerBound(from);
+        var endIdx = LowerBound(to);
+        var available = endIdx - startIdx;
+        truncated = available > maxPoints;
+        var taken = truncated ? maxPoints : available;
+        var builder = ImmutableArray.CreateBuilder<Sample>(taken);
+        for (var i = 0; i < taken; i++)
+            builder.Add(_ring[(_head + startIdx + i) % _ring.Length]);
+        return builder.ToImmutable();
+    }
+}
+
+private int LowerBound(DateTimeOffset ts)
+{
+    int lo = 0, hi = _count;
+    while (lo < hi)
+    {
+        var mid = (lo + hi) / 2;
+        if (_ring[(_head + mid) % _ring.Length].Timestamp < ts) lo = mid + 1;
+        else hi = mid;
+    }
+    return lo;
+}
+
+private void TrimExpired()
+{
+    var cutoff = DateTimeOffset.UtcNow - _maxAge;
+    while (_count > 0 && _ring[_head].Timestamp < cutoff)
+    {
+        _head = (_head + 1) % _ring.Length;
+        _count--;
+        EvictedCount++;
+    }
+}
+```
+
+**Step 3:** Verify with edge-case tests (empty buffer, all-expired, partial expire, range entirely outside data, truncation).
+
+**Step 4:** Commit.
+
+### Task 13: `PropertyBuffer.Bucket` with aggregations (TDD)
+
+**Step 1:** Failing tests, one per `HistoryAggregation`:
+- `Last`: returns the last sample's value per bucket.
+- `Average`: arithmetic mean of `Number`.
+- `Minimum` / `Maximum`: min/max over `Number`.
+- `Sum`: sum of `Number`.
+- `Count`: count of samples regardless of value type.
+
+**Step 2:** Implement `Bucket(...)` as a single linear pass over the logical view. Use `BucketAlignment.BucketStart`. Group samples by bucket start; for each bucket compute the aggregate. Output `ImmutableArray<HistoryPoint>`. For aggregations not supported on `value_json` (i.e., when the property's `ValueColumn` is `Json`), throw `HistoryAggregationNotSupportedException`. Note: the buffer doesn't know the property type — the store passes a `ValueColumn` hint into `Bucket`.
+
+```csharp
+public ImmutableArray<HistoryPoint> Bucket(
+    DateTimeOffset from, DateTimeOffset to, TimeSpan bucket,
+    HistoryAggregation aggregation, ValueColumn column, int maxBuckets, out bool truncated)
+{
+    // Validate
+    if (column == ValueColumn.Json &&
+        aggregation is not (HistoryAggregation.Last or HistoryAggregation.Count))
+    {
+        throw new HistoryAggregationNotSupportedException(aggregation, "(in-memory)", "value_json");
+    }
+    // ... linear scan, group by BucketAlignment.BucketStart, compute per-bucket aggregate.
+}
+```
+
+**Step 3:** Run tests, verify pass.
+
+**Step 4:** Commit.
+
+### Task 14: `InMemoryHistoryStore` skeleton
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory/InMemoryHistoryStore.cs`
+
+**Step 1:** Define the subject. Look at `OpcUaServer.cs` as a template. Required pieces:
+
+```csharp
+using HomeBlaze.Abstractions;
+using HomeBlaze.Abstractions.Attributes;
+using HomeBlaze.History.Abstractions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Registry.Attributes;
+using System.Collections.Concurrent;
+
+namespace HomeBlaze.History.InMemory;
+
+[Category("History")]
+[Description("In-memory history store (hot buffer; dev/test).")]
+[InterceptorSubject]
+public partial class InMemoryHistoryStore : BackgroundService, IHistoryStore, IConfigurable, ITitleProvider, IIconProvider
+{
+    private readonly ConcurrentDictionary<string, PropertyBuffer> _buffers = new();
+    private readonly DateTimeOffset _startTime = DateTimeOffset.UtcNow;
+    private readonly ILogger<InMemoryHistoryStore> _logger;
+
+    // Configuration
+    [Configuration] public partial string Name { get; set; }
+    [Configuration] public partial bool IsEnabled { get; set; }
+    [Configuration] public partial TimeSpan? MaxAge { get; set; }
+    [Configuration] public partial int? MaxPointsPerProperty { get; set; }
+    [Configuration] public partial TimeSpan? BufferTime { get; set; }
+    [Configuration] public partial int? MaxJsonSize { get; set; }
+
+    // State
+    [State] public partial ServiceStatus Status { get; set; }
+    [State] public partial string? StatusMessage { get; set; }
+    [State] public partial long RecordedCount { get; set; }
+    [State] public partial long OversizeCount { get; set; }
+    [State] public partial long EvictedCount { get; set; }
+    [State] public partial int TrackedPropertyCount { get; set; }
+    [State] public partial long TotalSampleCount { get; set; }
+    [State] public partial long EstimatedMemoryBytes { get; set; }
+    [State] public partial double? IncomingChangesPerSecond { get; set; }
+    [State] public partial double? RecordedChangesPerSecond { get; set; }
+
+    // IHistoryStore
+    public int Priority => 100;
+    public HistoryCoverage Coverage
+    {
+        get
+        {
+            var now = DateTimeOffset.UtcNow;
+            var maxAge = MaxAge ?? TimeSpan.FromSeconds(60);
+            var from = _startTime > now - maxAge ? _startTime : now - maxAge;
+            // Also clamp to actual oldest sample, since cold properties may not reach maxAge.
+            return new HistoryCoverage(from, now);
+        }
+    }
+
+    public Task<HistorySeries> QueryAsync(HistoryQuery query, CancellationToken ct) => /* Task 17 */;
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken) => /* Task 16 */;
+}
+```
+
+Adjust to actual `IConfigurable` / `ITitleProvider` / `IIconProvider` interfaces in `HomeBlaze.Abstractions`; copy the patterns from `OpcUaServer.cs`.
+
+**Step 2:** Build. Source generator should produce backing fields for partial properties. Fix any compile errors (likely around the HomeBlaze interfaces).
+
+**Step 3:** Commit.
+
+### Task 15: Wire ChangeQueueProcessor + HasHistory gate + Record dispatch (TDD)
+
+**Step 1:** Tests:
+- `WhenStateChangesArrive_ThenSamplesAreAdded`
+- `WhenConfigurationChangesArrive_ThenNothingAdded`
+- `WhenRefusedTypeChanges_ThenNothingAdded` (e.g., a property whose declared type is `byte[]`)
+
+Use a minimal interceptor-subject set up in the test that registers the store, then triggers property changes and waits for them to be recorded.
+
+**Step 2:** Implement `ExecuteAsync`:
+
+```csharp
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    using var processor = new ChangeQueueProcessor(
+        context: this.GetContext(),
+        bufferTime: BufferTime ?? TimeSpan.FromMilliseconds(250),
+        handler: HandleBatch,
+        logger: _logger);
+
+    await processor.RunAsync(stoppingToken);
+}
+
+private Task HandleBatch(IReadOnlyList<PropertyChangedContext> changes)
+{
+    foreach (var change in changes)
+    {
+        _incomingThroughput.Add(1);
+        var registered = change.Property.TryGetRegisteredProperty();
+        if (registered is null || !registered.HasHistory()) continue;
+
+        var path = /* resolve path via PathProvider */;
+        var value = change.NewValue;
+        var sample = SerializeOrPlaceholder(value);
+        var buffer = _buffers.GetOrAdd(path,
+            _ => new PropertyBuffer(MaxPointsPerProperty ?? 1000, MaxAge ?? TimeSpan.FromSeconds(60)));
+        buffer.Add(sample);
+        _recordedThroughput.Add(1);
+        RecordedCount++;
+    }
+    UpdateMetrics();
+    return Task.CompletedTask;
+}
+```
+
+The exact `ChangeQueueProcessor` constructor and `PropertyChangedContext` may differ; cross-check against `Namotion.Interceptor.Connectors/ChangeQueueProcessor.cs` and how `OpcUaServer` wires it up.
+
+**Step 3:** Implement throughput metrics:
+- `_incomingThroughput = new ThroughputCounter();`
+- `_recordedThroughput = new ThroughputCounter();`
+- Update `IncomingChangesPerSecond = _incomingThroughput.CurrentRate;` on a timer or per batch.
+
+**Step 4:** Run tests, verify pass.
+
+**Step 5:** Commit.
+
+### Task 16: Oversize placeholder for long strings (TDD)
+
+**Step 1:** Test:
+- Write a string longer than `MaxJsonSize` to a recordable property.
+- Verify the sample value is a `JsonElement` matching `{"$oversize": true, "size": N}`.
+- Verify `OversizeCount` incremented.
+
+**Step 2:** Implement `SerializeOrPlaceholder`:
+
+```csharp
+private Sample SerializeOrPlaceholder(object? value)
+{
+    if (value is null) return new Sample(DateTimeOffset.UtcNow, null);
+
+    // Numerics/bool: store as the value object directly.
+    if (value is double or float or int or long or short or sbyte or byte or
+        ushort or uint or ulong or bool or decimal)
+        return new Sample(DateTimeOffset.UtcNow, value);
+
+    // Strings: check size before storing.
+    if (value is string s)
+    {
+        var maxSize = MaxJsonSize ?? 8 * 1024;
+        var byteCount = System.Text.Encoding.UTF8.GetByteCount(s);
+        if (byteCount > maxSize)
+        {
+            OversizeCount++;
+            return new Sample(DateTimeOffset.UtcNow, MakePlaceholder(byteCount));
+        }
+        return new Sample(DateTimeOffset.UtcNow, value);
+    }
+
+    // Enums: store the name.
+    if (value.GetType().IsEnum)
+        return new Sample(DateTimeOffset.UtcNow, value.ToString());
+
+    // Should not happen if HasHistory() did its job.
+    return new Sample(DateTimeOffset.UtcNow, value);
+}
+
+private static JsonElement MakePlaceholder(int size) =>
+    JsonSerializer.SerializeToElement(new { dollarOversize = true, size }, new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = null,
+    });
+// Note: serialize with literal "$oversize" key — System.Text.Json doesn't easily emit "$" in property names;
+// use JsonObject or write the JSON string manually.
+```
+
+The `$oversize` key needs careful JSON construction; use `JsonObject` from `System.Text.Json.Nodes` or hand-build the JSON:
+
+```csharp
+var placeholder = new System.Text.Json.Nodes.JsonObject
+{
+    ["$oversize"] = true,
+    ["size"] = size
+};
+return JsonDocument.Parse(placeholder.ToJsonString()).RootElement;
+```
+
+**Step 3:** Run, verify pass.
+
+**Step 4:** Commit.
+
+### Task 17: `InMemoryHistoryStore.QueryAsync` (TDD)
+
+**Step 1:** Tests:
+- Raw query returns samples from the property's buffer.
+- Bucketed query returns per-bucket aggregates.
+- Query for unknown path returns empty series.
+- Aggregations on a `value_json`-stored property throw `HistoryAggregationNotSupportedException`.
+
+**Step 2:** Implement:
+
+```csharp
+public Task<HistorySeries> QueryAsync(HistoryQuery query, CancellationToken ct)
+{
+    if (!_buffers.TryGetValue(query.PropertyPath, out var buffer))
+        return Task.FromResult(new HistorySeries(query.PropertyPath, ImmutableArray<HistoryPoint>.Empty, false));
+
+    // Determine the property's value column for aggregation gating.
+    // We don't have direct type access here; the buffer stores object?,
+    // so we look at the first sample's runtime type as a proxy (or pass column via the query, future).
+    var sampleType = PeekSampleType(buffer);
+    var column = sampleType is null ? ValueColumn.Json : HistoryColumns.ValueColumnFor(sampleType);
+
+    if (query.Bucket is null)
+    {
+        var raw = buffer.Range(query.From, query.To, query.MaxPoints, out var truncated);
+        var points = raw.Select(s => ToHistoryPoint(s)).ToImmutableArray();
+        return Task.FromResult(new HistorySeries(query.PropertyPath, points, truncated));
+    }
+    else
+    {
+        var bucketed = buffer.Bucket(
+            query.From, query.To, query.Bucket.Value, query.Aggregation, column, maxBuckets: 1000, out var truncated);
+        return Task.FromResult(new HistorySeries(query.PropertyPath, bucketed, truncated));
+    }
+}
+```
+
+**Step 3:** Verify all tests pass.
+
+**Step 4:** Commit.
+
+### Task 18: Metrics roll-up (TrackedPropertyCount, TotalSampleCount, EstimatedMemoryBytes)
+
+**Step 1:** Test that after recording N samples across M properties, the state metrics report sensible values.
+
+**Step 2:** Implement `UpdateMetrics()` invoked at the end of each batch:
+
+```csharp
+private void UpdateMetrics()
+{
+    var total = 0L;
+    var props = 0;
+    var evicted = 0L;
+    foreach (var b in _buffers.Values)
+    {
+        total += b.Count;
+        evicted += b.EvictedCount;
+        props++;
+    }
+    TrackedPropertyCount = props;
+    TotalSampleCount = total;
+    EstimatedMemoryBytes = total * 50;
+    EvictedCount = evicted;
+    IncomingChangesPerSecond = _incomingThroughput.CurrentRate;
+    RecordedChangesPerSecond = _recordedThroughput.CurrentRate;
+}
+```
+
+**Step 3:** Commit.
+
+### Task 19: In-memory store under-load shakedown test
+
+**Step 1:** Test: spawn 10k properties, push 100 changes each, query several at random, assert counts. Also a stress test with a `Stopwatch` to confirm reasonable per-op time (<1µs per add). Mark as `[Trait("Category", "Slow")]` if it takes >1s so default `dotnet test` runs stay fast.
+
+**Step 2:** Commit.
+
+---
+
+## Phase 3: In-memory Blazor
+
+### Task 20: Create `HomeBlaze.History.InMemory.Blazor` project
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory.Blazor/HomeBlaze.History.InMemory.Blazor.csproj`
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory.Blazor/_Imports.razor`
+
+Pattern: mirror `HomeBlaze.OpcUa.Blazor`. Target net10.0, RazorSdk, reference `MudBlazor` 9.2.*, `HomeBlaze.Components.Abstractions`, `HomeBlaze.History.InMemory`.
+
+### Task 21: `InMemoryHistoryStoreEditComponent.razor`
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.InMemory.Blazor/InMemoryHistoryStoreEditComponent.razor`
+
+Pattern: copy `OpcUaServerEditComponent.razor` and adapt fields. Show: Name, IsEnabled, MaxAge, MaxPointsPerProperty, BufferTime, MaxJsonSize. Wire `[SubjectComponent(SubjectComponentType.Edit, typeof(InMemoryHistoryStore))]` + `ISubjectEditComponent`.
+
+Commit.
+
+---
+
+## Phase 4: Timescale store
+
+### Task 22: Create `HomeBlaze.History.TimescaleDb` project
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.TimescaleDb/HomeBlaze.History.TimescaleDb.csproj`
+
+Reference: `HomeBlaze.History.Abstractions`, `Namotion.Interceptor.Connectors`, `Npgsql` (latest), `HomeBlaze.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions`.
+
+### Task 23: `TimescaleDbHistoryStore` skeleton
+
+Same pattern as `InMemoryHistoryStore`: `[InterceptorSubject] partial class : BackgroundService, IHistoryStore`. Add `[Configuration]` for ConnectionString, Retention, BufferTime, FlushInterval, MaxJsonSize. Add `[State]` for Status, StatusMessage, QueueDepth, DropCount, OversizeCount, RecordedCount, IncomingChangesPerSecond, RecordedChangesPerSecond, LastFlushUtc, LastError. Priority = 10.
+
+Commit.
+
+### Task 24: Schema bootstrap (integration test)
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.History.TimescaleDb.Tests/HomeBlaze.History.TimescaleDb.Tests.csproj`
+- Create: `src/HomeBlaze/HomeBlaze.History.TimescaleDb.Tests/TimescaleDbFixture.cs`
+- Create: `src/HomeBlaze/HomeBlaze.History.TimescaleDb.Tests/SchemaBootstrapTests.cs`
+
+**Step 1:** Add Testcontainers + xUnit references. Add `[Trait("Category", "Integration")]` at the class level. Use `IClassFixture<TimescaleDbFixture>`.
+
+**Step 2:** `TimescaleDbFixture.cs`:
+
+```csharp
+using Testcontainers.PostgreSql;
+
+namespace HomeBlaze.History.TimescaleDb.Tests;
+
+public sealed class TimescaleDbFixture : IAsyncLifetime
+{
+    public PostgreSqlContainer Container { get; } =
+        new PostgreSqlBuilder()
+            .WithImage("timescale/timescaledb:latest-pg16")
+            .WithDatabase("history")
+            .WithUsername("test")
+            .WithPassword("test")
+            .Build();
+
+    public string ConnectionString => Container.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await Container.StartAsync();
+    }
+
+    public Task DisposeAsync() => Container.DisposeAsync().AsTask();
+}
+```
+
+**Step 3:** Failing test that asserts `property_history` table + hypertable + index exist after the store starts. Verify second start is a no-op.
+
+**Step 4:** Implement `EnsureSchemaAsync(connectionString, ct)` in the store. Idempotent SQL:
+
+```sql
+CREATE TABLE IF NOT EXISTS property_history (
+  ts            timestamptz       NOT NULL,
+  path          text              NOT NULL,
+  value_long    bigint            NULL,
+  value_double  double precision  NULL,
+  value_json    jsonb             NULL
+);
+SELECT create_hypertable('property_history', 'ts', if_not_exists => true);
+CREATE INDEX IF NOT EXISTS ix_property_history_path_ts ON property_history (path, ts DESC);
+```
+
+**Step 5:** Verify test passes. Commit.
+
+### Task 25: Per-property write routing into typed columns (integration test)
+
+**Step 1:** Test: instantiate the store, push synthetic changes (one per supported type), query the underlying table via raw Npgsql, assert correct column populated per row.
+
+Cover:
+- `double` 3.14 → `value_double = 3.14`, others null
+- `long` 9_007_199_254_740_993 (above 2^53!) → `value_long = 9_007_199_254_740_993` exactly
+- `bool true` → `value_long = 1`
+- `decimal 123.4567890123456789m` → `value_json = 123.4567890123456789`, lossless round-trip
+- `string "hello"` → `value_json = "hello"`
+- enum `Color.Red` → `value_json = "Red"`
+
+**Step 2:** Implement value routing in the store. For COPY:
+
+```csharp
+private async Task FlushBatchAsync(IReadOnlyList<(string Path, Sample Sample)> batch, CancellationToken ct)
+{
+    await using var conn = await OpenAsync(ct);
+    await using var writer = await conn.BeginBinaryImportAsync(
+        "COPY property_history (ts, path, value_long, value_double, value_json) FROM STDIN (FORMAT BINARY)",
+        ct);
+    foreach (var (path, sample) in batch)
+    {
+        await writer.StartRowAsync(ct);
+        await writer.WriteAsync(sample.Timestamp.UtcDateTime, NpgsqlDbType.TimestampTz, ct);
+        await writer.WriteAsync(path, NpgsqlDbType.Text, ct);
+        RouteValue(writer, sample.Value, ct);
+    }
+    await writer.CompleteAsync(ct);
+}
+
+private static async ValueTask RouteValue(NpgsqlBinaryImporter w, object? value, CancellationToken ct)
+{
+    switch (value)
+    {
+        case null:
+            await w.WriteNullAsync(ct);  // value_long
+            await w.WriteNullAsync(ct);  // value_double
+            await w.WriteNullAsync(ct);  // value_json
+            break;
+        case double d:
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync(d, NpgsqlDbType.Double, ct);
+            await w.WriteNullAsync(ct);
+            break;
+        case float f:
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync((double)f, NpgsqlDbType.Double, ct);
+            await w.WriteNullAsync(ct);
+            break;
+        case ulong ul when ul > long.MaxValue:
+            // overflow case: route to JSON
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync(JsonSerializer.SerializeToDocument(ul.ToString()).RootElement, NpgsqlDbType.Jsonb, ct);
+            break;
+        case ulong ul:
+            await w.WriteAsync((long)ul, NpgsqlDbType.Bigint, ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            break;
+        case long l:
+            await w.WriteAsync(l, NpgsqlDbType.Bigint, ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            break;
+        // ... int, short, byte, uint, ushort, sbyte, bool similarly to value_long ...
+        case decimal m:
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync(JsonSerializer.SerializeToDocument(m).RootElement, NpgsqlDbType.Jsonb, ct);
+            break;
+        case string s:
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync(JsonSerializer.SerializeToDocument(s).RootElement, NpgsqlDbType.Jsonb, ct);
+            break;
+        case Enum e:
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync(JsonSerializer.SerializeToDocument(e.ToString()).RootElement, NpgsqlDbType.Jsonb, ct);
+            break;
+        // Special placeholder (oversize) — already a JsonElement from the in-memory path.
+        case JsonElement je:
+            await w.WriteNullAsync(ct);
+            await w.WriteNullAsync(ct);
+            await w.WriteAsync(je, NpgsqlDbType.Jsonb, ct);
+            break;
+    }
+}
+```
+
+**Step 3:** Verify integration tests pass. Commit.
+
+### Task 26: BufferTime + FlushInterval dual-knob batching (integration test)
+
+**Step 1:** Test verifies:
+- With `BufferTime = 100ms` and `FlushInterval = 500ms`, 5 batches accumulate per flush.
+- A property that changes 100× within one `BufferTime` window stores 1 sample (coalesce).
+
+**Step 2:** Implement: the `ChangeQueueProcessor` already coalesces within `BufferTime`. The store's `HandleBatch` appends to a pending list; a separate timer fires every `FlushInterval` and calls `FlushBatchAsync`. Validate `FlushInterval >= BufferTime` at startup (clamp up with a log warning).
+
+**Step 3:** Commit.
+
+### Task 27: Raw query SQL builder per column (integration test)
+
+Tests cover `value_long`-, `value_double`-, and `value_json`-typed properties. For each, write 5 samples, query the raw range, assert ordering, count, and that `number` (vs `json`) is populated correctly.
+
+Implement the SQL builder. Use parameterized commands:
+
+```csharp
+private async Task<HistorySeries> RawQueryAsync(HistoryQuery query, Type propertyType, CancellationToken ct)
+{
+    var column = HistoryColumns.ValueColumnFor(propertyType);
+    var (selectNumber, selectJson) = column switch
+    {
+        ValueColumn.Long   => ("value_long::double precision",  "NULL::jsonb"),
+        ValueColumn.Double => ("value_double",                  "NULL::jsonb"),
+        ValueColumn.Json   => ("NULL::double precision",        "value_json"),
+        _ => throw new InvalidOperationException()
+    };
+    var sql = $@"SELECT ts, {selectNumber} AS number, {selectJson} AS json
+                 FROM property_history
+                 WHERE path = $1 AND ts >= $2 AND ts < $3
+                 ORDER BY ts ASC
+                 LIMIT $4 + 1";
+    // ... execute, materialize, set truncated when count == query.MaxPoints + 1.
+}
+```
+
+Property type is looked up via the registry on entry; the store needs a `PathProvider` or `SubjectRegistry` reference.
+
+Commit.
+
+### Task 28: Bucketed query SQL builder (integration test)
+
+Cover all 6 aggregations on `value_long` and `value_double`. Also verify `Last` on `value_json` returns the JSON literal.
+
+Implement the bucketed SQL with column dispatch, casting bigint aggregates to double precision on output, and switching on aggregation in C# to produce the SQL fragment.
+
+Commit.
+
+### Task 29: ulong COALESCE read variant (integration test)
+
+Test:
+- Write a `ulong`-typed property with values both below and above `long.MaxValue`.
+- Query bucketed `Average`.
+- Result must be the true mean across both columns.
+
+Implement: when `HistoryColumns.IsUlongProperty(propertyType)` is true, emit the COALESCE SQL variant per the design doc (lines around 244-254 in `history-mvp.md`).
+
+Commit.
+
+### Task 30: Unsupported aggregation error (integration test)
+
+Test: `Average` requested on a string-typed property raises `HistoryAggregationNotSupportedException`.
+
+Implement: in the bucketed-query builder, when `ValueColumnFor(propertyType) == Json` and `aggregation not in (Last, Count)`, throw before touching the DB.
+
+Commit.
+
+### Task 31: Retention via `add_retention_policy` (integration test)
+
+Test: with `Retention = 1 second`, insert synthetic old rows, wait for Timescale's retention job, assert rows removed.
+
+Implement: in `EnsureSchemaAsync`, after creating the hypertable, run:
+
+```sql
+SELECT add_retention_policy('property_history', INTERVAL '30 days', if_not_exists => true);
+```
+
+Reload the policy whenever `Retention` changes (drop + re-add).
+
+Commit.
+
+### Task 32: State metrics (throughput, last-flush, last-error) (integration test)
+
+Tests verify each state property updates as expected (after a successful flush `LastFlushUtc` is recent; after a DB failure `LastError` is populated).
+
+Implement throughput counters using the shared `ThroughputCounter`. Update state in `UpdateMetrics` invoked from `HandleBatch` and `FlushBatchAsync`.
+
+Commit.
+
+### Task 33: Backpressure + reconnect integration tests
+
+Tests:
+- Throttle DB → queue overflows → oldest dropped → `DropCount` increments.
+- Restart container mid-run → sink reconnects on next flush.
+
+These exercise the `ChangeQueueProcessor` semantics inherited from the platform; verify the store's error handling doesn't crash the host.
+
+Commit.
+
+---
+
+## Phase 5: Timescale Blazor
+
+### Task 34: Create `HomeBlaze.History.TimescaleDb.Blazor`
+
+Mirror `InMemory.Blazor`. Commit.
+
+### Task 35: `TimescaleDbHistoryStoreEditComponent.razor`
+
+Tabs: General (Name, IsEnabled, ConnectionString, Retention) and Advanced (BufferTime, FlushInterval, MaxJsonSize). Status block at the bottom. Pattern from `OpcUaServerEditComponent.razor`. Commit.
+
+---
+
+## Phase 6: MCP tool
+
+### Task 36: Add `get_property_history` tool to `HomeBlaze.AI/Mcp`
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.AI/Mcp/HistoryMcpToolProvider.cs`
+- Modify: `src/HomeBlaze/HomeBlaze.AI/McpBuilderExtensions.cs` (register the new provider)
+
+**Step 1:** Follow the `HomeBlazeMcpToolProvider` pattern. Implement `IMcpToolProvider`. Yield one tool:
+
+```csharp
+yield return new McpToolInfo
+{
+    Name = "get_property_history",
+    Description = "Query historical values for a property. Aggregates across all history stores by priority and coverage.",
+    InputSchema = JsonSerializer.SerializeToElement(new
+    {
+        type = "object",
+        properties = new
+        {
+            path = new { type = "string", description = "Subject property path" },
+            from = new { type = "string", description = "ISO 8601 start timestamp (UTC assumed if no offset)" },
+            to = new { type = "string", description = "ISO 8601 end timestamp; defaults to now" },
+            bucket = new { type = "string", description = "Bucket interval (e.g., '5m'); omit for raw" },
+            aggregation = new { type = "string", description = "last|average|minimum|maximum|sum|count", @enum = new[] { "last", "average", "minimum", "maximum", "sum", "count" } }
+        },
+        required = new[] { "path", "from" }
+    }),
+    Handler = HandleAsync
+};
+```
+
+`HandleAsync` parses parameters, builds a `HistoryQuery`, and calls `_registry.QueryHistoryAsync`.
+
+**Step 2:** Register in `McpBuilderExtensions.cs` next to the existing providers.
+
+**Step 3:** Add unit tests in `HomeBlaze.AI.Tests/Mcp/HistoryMcpToolProviderTests.cs`:
+- Parses `from`/`to`/`bucket`/`aggregation` correctly.
+- Defaults `to` to now when omitted.
+- Case-insensitive aggregation.
+- Unknown path returns empty `points` (not an error).
+- Bare timestamp without offset parses as UTC.
+
+**Step 4:** Run tests, verify pass.
+
+**Step 5:** Commit.
+
+---
+
+## Phase 7: UI dialog
+
+### Task 37: `PropertyHistoryDialog` component
+
+**Files:**
+- Create: `src/HomeBlaze/HomeBlaze.Components/Dialogs/PropertyHistoryDialog.razor`
+- Create: `src/HomeBlaze/HomeBlaze.Components/Dialogs/PropertyHistoryDialog.razor.cs`
+
+**Step 1:** Implement the layout per the design doc: range buttons, bucket auto, aggregation selector, `MudTimeSeriesChart`, source/truncated footer.
+
+**Step 2:** Calls `_registry.QueryHistoryAsync` on parameter change. Converts `HistorySeries` to `MudTimeSeriesChart`'s `ChartSeries`.
+
+**Step 3:** Defaults from the design doc: 24h, Auto bucket, Average for numerics; raw + Last for non-numerics.
+
+**Step 4:** Auto-bucket function picks `range / 200` rounded to a sane interval.
+
+**Step 5:** Manual test by running the sample. Commit.
+
+### Task 38: Add "View history" icon to property view
+
+**Files:**
+- Modify: `src/HomeBlaze/HomeBlaze.Components/Editors/PropertyEditor.razor`
+
+**Step 1:** Add a `MudIconButton` next to the property value that renders only when both conditions hold:
+- `property.HasHistory()`
+- registry contains at least one `IHistoryStore` (resolved once on init)
+
+Clicking opens `PropertyHistoryDialog` with the property's path pre-filled.
+
+**Step 2:** Manual test by running the sample. Commit.
+
+---
+
+## Phase 8: Solution wiring + smoke
+
+### Task 39: Verify everything builds together
+
+```bash
+dotnet build src/Namotion.Interceptor.slnx
+```
+Expected: 0 errors, 0 warnings (warnings are errors per Directory.Build.props).
+
+Fix any issues. Commit.
+
+### Task 40: Run all non-integration tests
+
+```bash
+dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"
+```
+Expected: all green.
+
+### Task 41: Run history integration tests
+
+```bash
+dotnet test src/HomeBlaze/HomeBlaze.History.TimescaleDb.Tests
+```
+Expected: all green (requires Docker).
+
+### Task 42: Manual end-to-end smoke
+
+**Step 1:** Run the sample app: `dotnet run --project src/HomeBlaze/HomeBlaze.Host --launch-profile HomeBlaze`. Add an `InMemoryHistoryStore` subject via the UI. Wait a minute. Open a `[State]` property, click the history icon, verify a chart appears with recent data.
+
+**Step 2:** Add a `TimescaleDbHistoryStore` subject pointing at a local TimescaleDB instance (Docker run if needed). Wait, query the history of a property, verify Timescale serves older buckets while in-memory serves the freshest.
+
+**Step 3:** From an MCP client (Claude Desktop with the HomeBlaze MCP server configured), invoke `get_property_history` for a real property path. Verify JSON response.
+
+**Step 4:** No commit needed unless you found bugs.
+
+### Task 43: Update `state.md` to reflect implementation status
+
+**Files:**
+- Modify: `src/HomeBlaze/HomeBlaze/Data/Docs/architecture/state.md`
+
+Move the Time-series history row from Planned to Implemented. Commit.
+
+---
+
+## Notes for the executing engineer
+
+- **The design doc is the source of truth for behavior.** When the plan and design conflict, the design wins (the plan may be coarser).
+- **CLAUDE.md rules apply:** descriptive identifiers, no em dashes in docs, integration tests use `[Trait("Category", "Integration")]`.
+- **TDD is strict for the abstractions and in-memory store** (Tasks 4-8, 11-13). The Timescale phase is integration-test-driven because the value of testing it without a real DB is low.
+- **Path resolution** (turning a `PropertyChangedContext` into a string path) likely needs `PathProviderBase`. Look at how `OpcUaServer` does it and mirror.
+- **Source generator for `[InterceptorSubject] partial class`** runs at build; partial properties materialize backing fields automatically. If a property doesn't seem to compile, check `Namotion.Interceptor.Generator/`.
+- **`IConfigurable` / `ITitleProvider` / `IIconProvider`** are the HomeBlaze contracts that make a subject editable/displayable in the UI. Implement them on both stores; copy from `OpcUaServer`.
+- **For the MCP tool:** `IMcpToolProvider` is the registration extension point. `HomeBlazeMcpToolProvider` shows the pattern (constructor injection of registry/services, `GetTools` enumerator).
+- **Commit cadence:** commit after each task. Frequent small commits make rebases and reviews easy.
+- **If a step doesn't compile against the actual codebase:** stop, investigate the relevant interface, adjust the code in the plan, and proceed. The plan codifies the design; minor API discrepancies are expected.

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/plans/history-mvp.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/plans/history-mvp.md
@@ -1,0 +1,570 @@
+---
+title: History MVP
+navTitle: History MVP
+status: Planned
+---
+
+# Time-Series History MVP Plan
+
+**Status: Planned**
+
+**Companion to:** [History Design](../architecture/design/history.md) (architectural target).
+This plan narrows that target to a first shippable slice.
+
+## Problem
+
+The architecture defines history as a plugin-based subsystem with multiple store types and tiered query merging. Nothing of it exists yet. The MVP delivers an end-to-end slice: one production store (TimescaleDB), one dev/test store (in-memory), a property-centric chart dialog in the UI, and one MCP tool. Just enough to prove the abstraction, recording path, and query path under real load, while leaving the seams in place for the tiered model the architecture document describes.
+
+## Scope
+
+**In:**
+
+- `IHistoryStore` abstraction, query types, eligibility predicate.
+- `InMemoryHistoryStore` for tests, samples, and the hot buffer that fills the Timescale write-batch lag.
+- `TimescaleDbHistoryStore` for production, with Npgsql binary `COPY` writes and hypertable storage.
+- Store edit components in the Blazor UI.
+- A property history dialog reachable from any historizable `[State]` property.
+- `get_property_history` MCP tool in `HomeBlaze.Mcp`.
+- Integration tests against a real TimescaleDB container via Testcontainers.
+
+**Out (deferred post-MVP):**
+
+- Additional stores (file-based, Influx, Kusto, S3 archive).
+- Dashboard history tile.
+- Multi-property compare in the chart.
+- Per-property opt-in or opt-out attributes (`[Historize]` / `[NoHistory]`).
+- Store-level include/exclude filter UI.
+- CSV/JSON export from the dialog.
+- Streaming `IAsyncEnumerable` query path.
+- Cross-instance history sync beyond what the existing WebSocket topology already provides as a side effect.
+
+## Package Structure
+
+| Package | Role |
+|---|---|
+| `HomeBlaze.History.Abstractions` | `IHistoryStore`, `HistoryQuery`, `HistoryPoint`, `HistorySeries`, `HistoryCoverage`, `HistoryAggregation`, `HistoryEligibility` extension methods, `HistoryQueryExtensions.QueryHistoryAsync` cross-store helper. No implementation. References `Namotion.Interceptor.Registry`. |
+| `HomeBlaze.History.Abstractions.Tests` | Unit tests for `HistoryEligibility.HasHistory` and the `QueryHistoryAsync` merge helper, using fake `IHistoryStore` implementations. |
+| `HomeBlaze.History.InMemory` | `InMemoryHistoryStore` subject. Ring buffer per property path. Priority 100. Intended for dev, tests, samples, and as the hot buffer covering the Timescale flush window. |
+| `HomeBlaze.History.InMemory.Tests` | Unit tests for the in-memory store: recording, retention, raw and bucketed queries, oversize placeholder, refused types, `Coverage` correctness. |
+| `HomeBlaze.History.InMemory.Blazor` | Edit component for the in-memory store. |
+| `HomeBlaze.History.TimescaleDb` | `TimescaleDbHistoryStore` subject. Npgsql client, hypertable bootstrap, batched binary `COPY` writes. Priority 10. |
+| `HomeBlaze.History.TimescaleDb.Blazor` | Edit component for the Timescale store. |
+| `HomeBlaze.History.TimescaleDb.Tests` | Integration tests using Testcontainers with the `timescale/timescaledb` image. |
+
+Target framework: `net10.0` for everything, matching the rest of the HomeBlaze tree.
+
+## Abstractions
+
+```csharp
+public interface IHistoryStore : IInterceptorSubject
+{
+    int Priority { get; }
+    HistoryCoverage Coverage { get; }
+    Task<HistorySeries> QueryAsync(HistoryQuery query, CancellationToken cancellationToken);
+}
+
+public readonly record struct HistoryCoverage(
+    DateTimeOffset From,
+    DateTimeOffset To);
+
+public record HistoryQuery(
+    string PropertyPath,
+    DateTimeOffset From,
+    DateTimeOffset To,
+    TimeSpan? Bucket = null,
+    HistoryAggregation Aggregation = HistoryAggregation.Last,
+    int MaxPoints = 10_000);
+
+public enum HistoryAggregation { Last, Average, Minimum, Maximum, Sum, Count }
+
+public record HistoryPoint(
+    DateTimeOffset Timestamp,
+    double? Number,
+    JsonElement? Json);
+
+public record HistorySeries(
+    string PropertyPath,
+    ImmutableArray<HistoryPoint> Points,
+    bool Truncated);
+```
+
+### Coverage contract
+
+`Coverage` returns the range a store guarantees it can answer queries over. A query passed to `QueryAsync` is always inside this range, enforced by the merger. Returning a tighter coverage than the store physically holds is safe. Returning a wider coverage is a bug.
+
+### Eligibility predicate
+
+`HasHistory()` is the single source of truth for whether a property is recorded and whether the UI offers the history action. Both stores and the UI gate on it.
+
+```csharp
+public static class HistoryEligibility
+{
+    public static bool HasHistory(this RegisteredSubjectProperty property)
+    {
+        if (!property.IsState) return false;
+        if (property.HasChildren) return false;
+        return IsRecordableType(property.Type);
+    }
+
+    public static bool IsRecordableType(Type type)
+    {
+        var t = Nullable.GetUnderlyingType(type) ?? type;
+        if (t == typeof(double) || t == typeof(float)) return true;  // value_double
+        if (IsBigIntCompatible(t)) return true;                       // value_long
+        if (t == typeof(decimal)) return true;                        // value_json (lossless)
+        if (t == typeof(string)) return true;                         // value_json
+        if (t.IsEnum) return true;                                    // value_json (enum name)
+        return false;                                                 // complex types deferred
+    }
+
+    static bool IsBigIntCompatible(Type t) =>
+        t == typeof(long)   || t == typeof(int)   || t == typeof(short) ||
+        t == typeof(sbyte)  || t == typeof(byte)  ||
+        t == typeof(ushort) || t == typeof(uint)  || t == typeof(ulong) ||
+        t == typeof(bool);
+}
+```
+
+The allow-list is deliberately tight for MVP: numerics, bool, string, and enums. Sub-subjects and subject collections are excluded structurally. Records, value objects, byte arrays, streams, and other complex types are not recorded yet; supporting them is a noted follow-up.
+
+### Column dispatch
+
+`ValueColumnFor` is the single source of truth used by both the write path (to route a value into the correct column) and the read path (to build the column-targeted SQL). Keeping write and read in agreement is the whole point of centralising it.
+
+```csharp
+public enum ValueColumn { Long, Double, Json }
+
+public static class HistoryColumns
+{
+    public static ValueColumn ValueColumnFor(Type propertyType)
+    {
+        var t = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        if (t == typeof(double) || t == typeof(float)) return ValueColumn.Double;
+        if (IsBigIntCompatible(t)) return ValueColumn.Long;
+        return ValueColumn.Json;  // decimal, string, enum
+    }
+
+    // For ulong properties only: a single row's storage depends on whether the
+    // value exceeds long.MaxValue. Read paths must coalesce across both columns.
+    public static bool IsUlongProperty(Type propertyType) =>
+        (Nullable.GetUnderlyingType(propertyType) ?? propertyType) == typeof(ulong);
+}
+```
+
+`ValueColumnFor(typeof(ulong))` returns `Long` (the primary column for ulong properties). On the write path, the store performs an additional per-value check: if `value > long.MaxValue`, the row goes to `value_json` instead. On the read path, when `IsUlongProperty(...)` is true, the SQL builder produces a COALESCE-aware variant (see Query Path) so aggregations include rows from both columns. This is the only type that needs the dual-column read path; all others have a static column for life.
+
+## Recording Path
+
+Each store is a `BackgroundService` subject with its own `ChangeQueueProcessor`. The change pipeline already provides bounded queue depth, oldest-dropped backpressure, and per-batch coalescing of repeated writes within the flush window. The store inherits all of that.
+
+For each change in a batch:
+
+```csharp
+if (!change.Property.HasHistory()) continue;
+Record(change);
+```
+
+`Record` routes the value:
+
+| Value type | Column | Notes |
+|---|---|---|
+| `double` / `float` | `value_double` | `double precision` |
+| `int` / `uint` / `short` / `ushort` / `byte` / `sbyte` / `long` / `bool` | `value_long` | `bigint`, `bool` as 0/1 |
+| `ulong` if `<= long.MaxValue` | `value_long` | Range check at write time |
+| `ulong` if `> long.MaxValue` | `value_json` | Rare overflow case |
+| `decimal` | `value_json` | JSON number, lossless via jsonb's internal `numeric` |
+| `string` | `value_json` | JSON string |
+| `enum` | `value_json` | JSON string, enum name |
+| `null` | all columns `NULL` | Explicit null is meaningful |
+
+### Oversize and refused values
+
+Within the allow-list, only `string` is unbounded in length. The store writes serialized JSON into a pooled buffer with a hard cap (default 8 KB, configurable per store as `MaxJsonSize`). On overflow the store writes a small placeholder row instead:
+
+```json
+{ "$oversize": true, "size": 73218 }
+```
+
+A placeholder preserves the timeline. `Last` still surfaces a marker with the original size. Numeric aggregations skip it because the numeric value columns are null. The store exposes an `OversizeCount` `[State]` property so operators can see it climb.
+
+Numerics, bool, and enums are bounded by their type; they never trigger the cap. Types outside the allow-list are blocked by `HasHistory()` before reaching the store.
+
+## Query Path
+
+Two paths, dispatched on whether `Bucket` is null. In both, the Timescale store inspects the property's declared type via the registry and builds a single-column query targeting `value_long`, `value_double`, or `value_json`. No COALESCE in the aggregate expression; the planner sees direct column references.
+
+The store uses `HistoryColumns.ValueColumnFor(propertyType)` (defined in the abstractions) to pick the column. For ulong properties, the read path additionally consults `IsUlongProperty` and emits the COALESCE variant described below.
+
+### Raw path
+
+Return individual samples within `[From, To]`. Example for a `long`-typed property:
+
+```sql
+select ts, value_long::double precision as number, null::jsonb as json
+from property_history
+where path = $1 and ts >= $2 and ts < $3
+order by ts asc
+limit $4 + 1;
+```
+
+For a `string`-typed property, `value_json` is selected and `number` is `NULL`. The `+1` lets the consumer detect overflow without a separate `count(*)`; if the result hits `MaxPoints + 1` rows, drop the last and set `Truncated = true`. The in-memory implementation does the same in a linear scan over the property's sorted sample list, bounded by binary search on the range endpoints.
+
+### Bucketed path
+
+One row per bucket, computed server-side via `time_bucket`. The aggregation function targets the property's column directly:
+
+```sql
+select time_bucket($1::interval, ts) as bucket,
+       <agg>(<column>)               as number,
+       <last_json_expr>              as json
+from property_history
+where path = $2 and ts >= $3 and ts < $4
+group by bucket
+order by bucket asc
+limit $5 + 1;
+```
+
+`<column>` is the result of `HistoryColumns.ValueColumnFor(propertyType)`. `<agg>` switches per `HistoryAggregation`:
+
+| Aggregation | SQL fragment |
+|---|---|
+| `Last` | `last(<column>, ts)` |
+| `Average` | `avg(<column>)` |
+| `Minimum` | `min(<column>)` |
+| `Maximum` | `max(<column>)` |
+| `Sum` | `sum(<column>)` |
+| `Count` | `count(*)` returned as the `number` field |
+
+`<last_json_expr>` is `last(value_json, ts)` when aggregation is `Last` and the column is `value_json`; otherwise `NULL`. Bigint aggregates cast to `double precision` on the way out so the C# `HistoryPoint.Number` field stays a unified `double?`. Buckets with no rows are absent. Bucket cap defaults to 1000, same `+1 / Truncated` pattern.
+
+### `ulong` read path
+
+For ulong properties whose values can straddle `long.MaxValue`, the read path uses a COALESCE-aware variant so aggregates see both columns. Example for bucketed `Average`:
+
+```sql
+select time_bucket($1::interval, ts) as bucket,
+       avg(coalesce(value_long::numeric,
+                    (value_json #>> '{}')::numeric))::double precision as number,
+       null::jsonb as json
+from property_history
+where path = $2 and ts >= $3 and ts < $4
+group by bucket
+order by bucket asc
+limit $5 + 1;
+```
+
+This branch only fires when `HistoryColumns.IsUlongProperty(propertyType)` is true. All other property types use the single-column SQL shown above with no COALESCE overhead.
+
+### Aggregation support per column
+
+| Column | `Last` | `Count` | `Average` | `Minimum` | `Maximum` | `Sum` |
+|---|---|---|---|---|---|---|
+| `value_long` | yes | yes | yes | yes | yes | yes |
+| `value_double` | yes | yes | yes | yes | yes | yes |
+| `value_json` | yes | yes | no | no | no | no |
+
+Asking for `Average`/`Minimum`/`Maximum`/`Sum` on a `value_json`-stored property (decimal, string, enum) returns a typed error: `HistoryAggregationNotSupportedException` from the store, surfaced as a structured MCP error response and as a disabled option in the UI's aggregation dropdown. Casting `value_json` to `numeric` for decimal aggregation is a noted post-MVP improvement.
+
+The in-memory implementation mirrors these semantics with a single linear pass grouping samples by the same epoch-anchored bucket-start formula used in the cross-store merge section (`floor((ts - epoch).Ticks / bucket.Ticks) * bucket.Ticks + epoch`). It does not maintain three internal storage slots; samples are kept as `(ts, object? value)` and the column-dispatch logic at query time inspects the value's runtime type.
+
+## Cross-Store Merge
+
+Timescale batches writes for efficiency (default `FlushInterval = 5 s`, configurable). Between flushes, the in-memory store already holds the very recent samples that Timescale has not yet committed. The merger uses each store's `Coverage` to dispatch queries efficiently and to fill the recent-data gap from in-memory.
+
+### Raw merge
+
+Split the query range across stores by coverage. Each store gets a sub-range it can fully serve. Higher-priority stores claim their range first; lower-priority stores fill what remains.
+
+```csharp
+var stores = registry.KnownSubjects.OfType<IHistoryStore>()
+    .OrderByDescending(s => s.Priority).ToArray();
+
+var gaps = new List<HistoryCoverage> { new(query.From, query.To) };
+var merged = new SortedDictionary<DateTimeOffset, HistoryPoint>();
+var truncated = false;
+
+foreach (var store in stores)
+{
+    if (gaps.Count == 0) break;
+    foreach (var sub in Intersect(gaps, store.Coverage))
+    {
+        var subSeries = await store.QueryAsync(
+            query with { From = sub.From, To = sub.To }, ct);
+        truncated |= subSeries.Truncated;
+        foreach (var p in subSeries.Points)
+            merged.TryAdd(p.Timestamp, p);
+    }
+    gaps = Subtract(gaps, store.Coverage);
+}
+
+return new HistorySeries(query.PropertyPath, merged.Values.ToImmutableArray(), truncated);
+```
+
+### Bucketed merge
+
+**Per-bucket dispatch, no cross-store aggregation.** Each bucket in the query range is assigned to a single store; that store computes the bucket's aggregate using only its own samples. No data from two stores is ever combined inside one bucket's aggregate. This sidesteps the "average of averages" problem entirely: every aggregation (`Average`, `Minimum`, `Maximum`, `Sum`, `Count`, `Last`) works trivially per bucket because each bucket has one source of truth.
+
+**Assignment rule per bucket:** the highest-priority store whose `Coverage` fully contains the bucket's *effective range*. If none fully contains, fall back to the lowest-priority store with overlap (typically Timescale).
+
+The *effective range* clips the bucket's logical span to the query bounds:
+
+```
+effective = [max(bucket.From, query.From), min(bucket.To, query.To)]
+```
+
+This matters at the right edge of live queries: a bucket whose logical end extends past `query.To` (= "now") only needs to contain the truncated portion, so in-memory wins boundary buckets it otherwise would have lost to Timescale by a few seconds.
+
+**SQL economy via grouping.** A naive implementation would issue one SQL per bucket. The merger groups consecutive buckets assigned to the same store into one ranged sub-query, so a typical chart is at most one or two round-trips:
+
+```csharp
+var buckets = EnumerateBucketRanges(query);
+var assignments = buckets.Select(b => (Bucket: b, Store: AssignBucket(stores, b, query)));
+var groups = GroupConsecutive(assignments, a => a.Store);
+
+foreach (var group in groups)
+{
+    var subQuery = query with {
+        From = group.First().Bucket.From,
+        To   = group.Last().Bucket.To
+    };
+    var part = await group.Key.QueryAsync(subQuery, ct);
+    truncated |= part.Truncated;
+    foreach (var p in part.Points) allPoints[p.Timestamp] = p;
+}
+```
+
+**Bucket alignment invariant.** The in-memory implementation must use the same bucket-boundary computation as Postgres `time_bucket` (epoch-anchored: `floor((ts - epoch).Ticks / bucket.Ticks) * bucket.Ticks + epoch`). If alignment ever drifts, two stores would produce buckets at different timestamps and concatenation would interleave them. This is enforced by a shared helper in `HomeBlaze.History.Abstractions`.
+
+### Resulting behaviour
+
+| Query | Routing |
+|---|---|
+| `last 30 s`, raw or bucketed | In-memory fully contains every bucket. Timescale never touched. |
+| `last 1 hr`, raw | Split by coverage: in-memory serves the last 60 s, Timescale the rest. Two queries. |
+| `last 5 min`, bucket=10s | Per-bucket dispatch: Timescale serves buckets 1-24 in one SQL, in-memory serves buckets 25-30. Latest data without buffer lag. |
+| `last 1 hr`, bucket=1min | Most buckets don't fit in in-memory (60 s) → Timescale alone. One query. |
+| `last 30 days`, bucket=1hr | Timescale alone. |
+| Timescale offline, `last 30 s`, raw or bucketed | In-memory still answers. The DB outage is invisible for ranges it covers. |
+
+A store that raises an exception during `QueryAsync` propagates that exception. The merger does not silently swallow errors. A misconfigured Timescale must not masquerade as "no data".
+
+## TimescaleDB Store
+
+### Schema
+
+```sql
+create table property_history (
+  ts            timestamptz       not null,
+  path          text              not null,
+  value_long    bigint            null,
+  value_double  double precision  null,
+  value_json    jsonb             null
+);
+
+select create_hypertable('property_history', 'ts', if_not_exists => true);
+create index if not exists ix_property_history_path_ts
+  on property_history (path, ts desc);
+```
+
+Three nullable value columns, dispatched per property type at write and read time. NULL columns in Postgres cost roughly one bit per column per row in the row header; the only payload byte cost is the populated column. Snake_case columns; C# DTOs and parameters remain PascalCase. Schema bootstrap runs idempotently on store start.
+
+### Driver choice
+
+Npgsql native, no ORM. EF Core's migrations fight `create_hypertable`, and change tracking on the hot write path is exactly the overhead to avoid. Dapper offers nothing for bulk writes. Reads are two or three SQL strings and don't earn an abstraction. Writes use `NpgsqlBinaryImporter` (`COPY` binary protocol) per batch.
+
+### Configuration
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `ConnectionString` | required | Npgsql connection string |
+| `Retention` | 30 days | Timescale `add_retention_policy` chunk delete job |
+| `BufferTime` | 250 ms | `ChangeQueueProcessor` coalesce window. Within one window only the last value per property is kept. Decides sample resolution. Min 50 ms. |
+| `FlushInterval` | 5 s | How often the store actually issues a `COPY`. The store accumulates batches delivered every `BufferTime` and writes them all at once on each flush. Must be `>= BufferTime` (validated at startup; clamped if lower). Larger values reduce DB write frequency at the cost of staleness up to `FlushInterval`. Setting it equal to `BufferTime` means one COPY per delivered batch. |
+| `MaxJsonSize` | 8 KB | Per-string cap; overflow becomes a placeholder row |
+
+`[State]` properties for operator observability: `Status`, `StatusMessage`, `QueueDepth`, `DropCount`, `OversizeCount`, `RecordedCount`, `IncomingChangesPerSecond`, `RecordedChangesPerSecond`, `LastFlushUtc`, `LastError`. `IncomingChangesPerSecond` and `RecordedChangesPerSecond` are rolling 1-minute averages, same shape and naming as `OpcUaClient.IncomingChangesPerSecond`. The gap between the two surfaces filtering and backpressure.
+
+**Shared rate counter.** Both rolling rates reuse the existing `ThroughputCounter` (lock-free 60-second sliding window) currently `internal sealed` in `Namotion.Interceptor.OpcUa`. As part of the MVP work, that file is promoted to `Namotion.Interceptor.Connectors` and made `public` so the OPC UA connectors, the history stores, and future change-pipeline consumers can share one implementation. `Namotion.Interceptor.Connectors` is the natural home: it already hosts `ChangeQueueProcessor` (which both OPC UA and the history stores already depend on), so no new dependency is introduced. The two existing OPC UA usages (`OpcUaSubjectClientSource`, `OpcUaSubjectServer`) update their `using` to the new namespace; the existing `ThroughputCounterTests` move to `Namotion.Interceptor.Connectors.Tests`.
+
+### Coverage
+
+`Coverage.From = DateTimeOffset.UtcNow - Retention`, `Coverage.To = DateTimeOffset.UtcNow`. Both derived without DB calls.
+
+## InMemory Store
+
+Top layer: `ConcurrentDictionary<string, PropertyBuffer>` keyed by property path. Inner layer: array-backed ring buffer per path with a per-buffer lock. Buffers are created on first write — properties that never change consume zero memory.
+
+### Configuration
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `MaxAge` | 60 s | Drop samples older than this. Tuned to cover the Timescale `FlushInterval` plus a generous safety margin and to serve "last 1 min" charts entirely in-memory. |
+| `MaxPointsPerProperty` | 1 000 | Per-property hard cap on the ring buffer. Sized to comfortably hold 16 Hz over a minute; protects against a single runaway property dominating memory. |
+| `BufferTime` | 250 ms | `ChangeQueueProcessor` batch window. Coalesces repeated writes to the same property within the window down to one sample. Larger values dramatically reduce per-property memory at the cost of slightly less granular recent history; users with 100k+ properties may set this to 1 s to halve memory pressure. Min 50 ms. |
+| `MaxJsonSize` | 8 KB | Same placeholder rule as Timescale |
+
+**Realistic memory at scale:**
+
+Memory tracks actual change rate per property, not the per-property cap. With the defaults and a 250ms coalesce window, ~25% of raw writes survive coalescing.
+
+| Scenario | Memory |
+|---|---|
+| 1 000 properties at 1 Hz average | ~750 KB |
+| 10 000 properties at 1 Hz average | ~7.5 MB |
+| 100 000 properties at 1 Hz average | ~75 MB |
+| 100 000 properties, 10% at 10 Hz (cap-hitting) and 90% at 0.1 Hz | ~500 MB |
+
+Operators with extreme scale (well above 100k properties) tune `MaxAge` down (to 30 s or 10 s) or `BufferTime` up (to 1 s) to keep memory bounded.
+
+`[State]` properties for operator observability mirror the Timescale store where applicable, plus memory metrics: `Status`, `StatusMessage`, `RecordedCount`, `OversizeCount`, `EvictedCount` (samples dropped by `MaxAge` or `MaxPointsPerProperty`), `IncomingChangesPerSecond`, `RecordedChangesPerSecond`, `TrackedPropertyCount`, `TotalSampleCount`, `EstimatedMemoryBytes`. `TotalSampleCount × 50` gives a rough byte estimate; the metric is exposed so operators can confirm tuning matches expectations. No queue or flush metrics since writes are synchronous.
+
+### Coverage
+
+`Coverage.From = max(StartTime, DateTimeOffset.UtcNow - MaxAge)`, `Coverage.To = DateTimeOffset.UtcNow`. The `max(StartTime, …)` clamp matters during the first `MaxAge` window after the store starts: the buffer doesn't actually have samples from before startup, so advertising coverage back to "now − 5 min" would cause the merger to route old-range queries here and get empty results while Timescale (which does have that data) gets skipped.
+
+### Use cases
+
+1. Hot buffer in front of Timescale, covering the batch-flush window.
+2. Default store in unit tests and the dev sample, since it has no external dependency.
+3. Local fallback during a brief Timescale outage for queries that fit its window.
+
+It is documented as not a production substitute for the DB store.
+
+## UI
+
+### Edit components
+
+One Blazor project per store, matching the `HomeBlaze.OpcUa.Blazor` convention.
+
+`TimescaleDbHistoryStoreEditComponent.razor`: tabs General (name, enabled, connection string, retention) and Advanced (`BufferTime`, `FlushInterval`, `MaxJsonSize`). Status block at the bottom shows `Status` and `StatusMessage` from the subject, same pattern as `OpcUaServerEditComponent`.
+
+`InMemoryHistoryStoreEditComponent.razor`: name, enabled, `MaxAge`, `MaxPointsPerProperty`, `BufferTime`, `MaxJsonSize`.
+
+No setup component. Neither store has an out-of-band discovery step; the standard "create new subject" flow is sufficient. The browser already renders store `[State]` properties, so no custom status view is needed.
+
+### Property history dialog
+
+Reachable from any `[State]` property in the existing property view via a small clock icon. The icon renders only when `property.HasHistory()` is true and at least one `IHistoryStore` exists in the registry. Both conditions are checked once per property render.
+
+Layout:
+
+```
+History: <property path>                                      [x]
+
+Range:  [1h] [6h] [24h] [7d] [30d] [Custom...]
+Bucket: [Auto v]   Aggregation: [Average v]
+
+[ MudTimeSeriesChart, 400px high ]
+
+3 042 points · Truncated: no · Source: TimescaleDB + InMem
+
+                                                       [Close]
+```
+
+Defaults: 24h, Auto bucket, Average for numerics; 24h, raw, Last for non-numerics. Auto bucket picks `range / 200` rounded to a sane interval (1s, 5s, 30s, 1min, 5min, 15min, 1h, 6h, 1d), keeping the chart near 200 points across zoom levels.
+
+Chart: MudBlazor 9.2's `MudTimeSeriesChart` (built in, no new dependency). Linear interpolation for numeric aggregations. Stepped interpolation when displaying `Last` of a non-numeric property, with hover tooltip showing the JSON value.
+
+`Truncated` flag from the response surfaces as a small warning indicator. The "Source" line names the stores that contributed, for trust and debugging.
+
+## MCP Tool
+
+Tool `get_property_history` lives in `HomeBlaze.Mcp` (the enriched layer), since it depends on `HomeBlaze.History.Abstractions`. Base `Namotion.Interceptor.Mcp` stays free of history concerns.
+
+| Parameter | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `path` | string | yes | | Subject property path |
+| `from` | string | yes | | ISO 8601 timestamp. Parsed with `DateTimeStyles.AssumeUniversal`: an explicit offset (`Z`, `+02:00`) is honoured, a bare timestamp like `2026-05-19T00:00:00` is treated as UTC. |
+| `to` | string | no | `now` (UTC) | ISO 8601, same parsing rule as `from`. |
+| `bucket` | string | no | null (raw) | `TimeSpan`-parseable, e.g. `5m` |
+| `aggregation` | string | no | `last` | One of `last`, `average`, `minimum`, `maximum`, `sum`, `count` (case insensitive) |
+
+Response:
+
+```json
+{
+  "path": "Devices/LivingRoomThermostat/Temperature",
+  "from": "2026-05-19T00:00:00Z",
+  "to":   "2026-05-20T00:00:00Z",
+  "bucket": "5m",
+  "aggregation": "average",
+  "points": [
+    { "ts": "2026-05-19T00:00:00Z", "value": 21.3 },
+    { "ts": "2026-05-19T00:05:00Z", "value": 21.4 },
+    { "ts": "2026-05-19T00:10:00Z", "value": null }
+  ],
+  "truncated": false
+}
+```
+
+`value` is a polymorphic JSON value: number when populated via `value_long` or `value_double`, JSON literal when populated via `value_json`, `null` when no value column is populated (explicit-null sample). Empty `points` and missing paths are not errors; they return successfully with an empty array. Real errors (DB unreachable, malformed parameters) propagate as MCP error responses.
+
+`MaxPoints` is intentionally not exposed as a tool parameter. Callers that need more detail narrow `from`/`to` instead; the cap (10 000 raw, 1 000 bucketed) keeps any single response bounded and the `truncated` flag signals when it was hit.
+
+## Configuration Summary
+
+Per store, expressed as `[Configuration]` properties so the registry, edit components, and config persistence all see the same surface.
+
+| Knob | Timescale | InMemory |
+|---|---|---|
+| `ConnectionString` | required | n/a |
+| `Retention` | 30 days | n/a |
+| `MaxAge` | n/a | 60 s |
+| `MaxPointsPerProperty` | n/a | 1 000 |
+| `BufferTime` | 250 ms | 250 ms |
+| `FlushInterval` | 5 s | n/a |
+| `MaxJsonSize` | 8 KB | 8 KB |
+
+## Tests
+
+### Unit tests
+
+- `HistoryEligibility.HasHistory` over every recordable and refused type.
+- `InMemoryHistoryStore` recording, retention trimming, raw and bucketed queries, oversize placeholder for long strings, refused types blocked by `HasHistory()`.
+- `HistoryQueryExtensions.QueryHistoryAsync` merge logic with fake `IHistoryStore` implementations covering: single store, two stores with disjoint coverage, two stores with overlapping coverage, store throwing, empty registry.
+- MCP tool: parameter parsing, case-insensitive aggregation, empty result on unknown path.
+
+No Docker required for any unit test.
+
+### Integration tests
+
+`HomeBlaze.History.TimescaleDb.Tests` with `[Trait("Category", "Integration")]`, excluded from the default `dotnet test` filter, matching the existing repo convention.
+
+Container management via Testcontainers using the `timescale/timescaledb:latest-pg16` image. One container per test class via `IClassFixture<TimescaleDbFixture>`. Per-test schema (`test_<guid>`) for isolation without container churn.
+
+| Category | Verifies |
+|---|---|
+| Bootstrap | Store starts against empty DB, creates hypertable and index. Second start is a no-op. |
+| Recording (`value_long`) | Integer and bool `[State]` writes land with `value_long` populated. Within-batch coalesce collapses repeated writes. |
+| Recording (`ulong` overflow) | A `ulong`-typed property is written values both below and above `long.MaxValue`. Sub-overflow values land in `value_long`; overflow values land in `value_json`. Bucketed `Average` for the property uses the COALESCE-aware SQL and the result equals the true mean across both columns. |
+| Recording (`value_double`) | `double` and `float` `[State]` writes land with `value_double` populated. |
+| Recording (`value_json`) | String, enum, and decimal `[State]` writes land with `value_json` populated. Enums as name strings, decimals as lossless JSON numbers. |
+| Recording (null) | Null writes produce all-NULL row. Aggregates skip; `count` includes. |
+| Recording ([Configuration] skip) | `[Configuration]` writes are not recorded. |
+| Oversize | Long string value produces placeholder row; `OversizeCount` increments. |
+| Refused types | `byte[]`, records, value objects are refused upstream by `HasHistory()`; verified explicitly. |
+| Raw query | Ordered points within range, capped at `MaxPoints`, `Truncated` flag correct. |
+| Aggregated query | `time_bucket` correctness for each aggregation including `Last`, dispatched to the correct value column per property type. |
+| Unsupported aggregation | `Average` requested on a `value_json`-stored property (decimal, string, enum) raises `HistoryAggregationNotSupportedException`. |
+| Raw coverage merge | In-memory + Timescale populated for the same path; recent samples served by in-memory only, older samples by Timescale only, in-memory wins on overlapping timestamps. |
+| Per-bucket dispatch (small bucket) | Query `last 5min, bucket=10s` with in-memory `MaxAge=60s`: older buckets come from Timescale, newest 6 buckets from in-memory. Effective range clipping verified at the right edge. |
+| Per-bucket dispatch (large bucket) | Query `last 1h, bucket=1min` with in-memory `MaxAge=60s`: only the latest bucket (or none, depending on alignment) fits in-memory; the rest assigned to Timescale. |
+| Per-bucket dispatch (no overlap) | Query fully inside in-memory's coverage: zero Timescale queries. |
+| Bucket alignment | In-memory and Timescale bucket boundaries are epoch-anchored and identical for the same bucket size. Concatenation never produces duplicate-timestamp buckets. |
+| Retention | Synthetic old rows inserted; `add_retention_policy` job removes them. |
+| Backpressure | Throttled DB; queue overflows; oldest dropped; `DropCount` increments. |
+| Reconnect | Container restart mid-run; store reconnects and resumes. |
+
+The test project's README must note the Docker requirement. The fixture skips with a clear message when the Docker daemon is unreachable, rather than hanging.
+
+## Open Questions
+
+- Recording complex types (records, value objects, dictionaries, lists of primitives): deferred. The MVP allow-list is numerics, bool, string, enum, decimal. Adding a structured-type path requires schema thought (one column or per-field expansion?) and an oversize policy that goes beyond a string length cap.
+- Aggregation (`Average`/`Minimum`/`Maximum`/`Sum`) on `value_json`-stored properties: deferred. Decimal aggregation can be added by casting `value_json #>> '{}'` to `numeric` in the bucketed query; the column dispatch already isolates the change to one SQL path. String and enum aggregations stay limited to `Last` and `Count`.
+- `StoreNonNumericValues` toggle to limit a store to numeric/bool history only: dropped from MVP because the tight allow-list makes the runaway-volume scenario it defended against impossible. Add back if a real "this DB is for charts only" use case appears.
+- Per-property opt-in/out attribute (`[Historize]` / `[NoHistory]`): defer to a follow-up unless a concrete need surfaces during MVP use.
+- Store-level include/exclude filter via glob patterns on property paths: deferred to a configuration follow-up.
+- Multi-property compare in the dialog: deferred until the single-property dialog has shaken out.
+- Streaming export of large raw ranges: a separate `ExportAsync` method on `IHistoryStore` is the natural seam, not the existing `QueryAsync`.
+- Continuous aggregates inside Timescale for long-retention downsampling: post-MVP, internal to the Timescale store, transparent to consumers.
+- Global `MaxTotalSamples` cap on the in-memory store with cross-property eviction: deferred. The MVP exposes `TotalSampleCount` and `EstimatedMemoryBytes` so operators can monitor and tune `MaxAge`/`MaxPointsPerProperty`/`BufferTime`. A global cap would need an eviction policy (drop from biggest buffer, oldest globally, LRU) and that decision is worth a separate think once we see real workloads.

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/plans/history-mvp.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/plans/history-mvp.md
@@ -19,16 +19,24 @@ The architecture defines history as a plugin-based subsystem with multiple store
 
 **In:**
 
-- `IHistoryStore` abstraction, query types, eligibility predicate.
+- `IHistoryStore` abstraction with capability advertising, query types, eligibility predicate.
 - `InMemoryHistoryStore` for tests, samples, and the hot buffer that fills the Timescale write-batch lag.
 - `TimescaleDbHistoryStore` for production, with Npgsql binary `COPY` writes and hypertable storage.
 - Store edit components in the Blazor UI.
 - A property history dialog reachable from any historizable `[State]` property.
-- `get_property_history` MCP tool in `HomeBlaze.Mcp`.
-- Integration tests against a real TimescaleDB container via Testcontainers.
+- `get_property_history` MCP tool in `HomeBlaze.AI`.
+- `TimeWeightedAverage` as the default numeric aggregation, with `Last`, `First`, `Average`, `Minimum`, `Maximum`, `Sum`, `Count`, `StdDev` rounding out the closed MVP set.
+- Server-side gap-handling: auto `Last` LOCF, `TimeWeightedAverage` integration includes look-back, `Count` returns 0 for empty buckets, other aggregations return null entries.
+- Unified sequential-budget cross-store merger.
+- Integration tests against TimescaleDB containers (toolkit-available and toolkit-absent fixtures).
 
 **Out (deferred post-MVP):**
 
+- Parameterized aggregations (`Percentile:p`, `CrossingsAbove:N`); decision on syntax (colon vs preset names like `Percentile95`) deferred until the first one lands.
+- Additional aggregations: `Median`, `Percentile`, `Rate`, `Delta`, `StateDuration`, `LTTB`, `Mode`.
+- Runtime cross-store config validation (UI helper text + design-doc constraint suffice for MVP).
+- Live-edge bucket merge refinement for arbitrary bucket sizes (Path B-lite combinable partial aggregates).
+- Server-side gap-fill with linear `Interpolate` for numeric signals.
 - Additional stores (file-based, Influx, Kusto, S3 archive).
 - Dashboard history tile.
 - Multi-property compare in the chart.
@@ -37,19 +45,21 @@ The architecture defines history as a plugin-based subsystem with multiple store
 - CSV/JSON export from the dialog.
 - Streaming `IAsyncEnumerable` query path.
 - Cross-instance history sync beyond what the existing WebSocket topology already provides as a side effect.
+- TimescaleDB compression policy automation (preparation only in MVP: daily chunks).
+- Property path normalisation lookup table (observability only in MVP: `EstimatedStorageBytes`).
 
 ## Package Structure
 
 | Package | Role |
 |---|---|
-| `HomeBlaze.History.Abstractions` | `IHistoryStore`, `HistoryQuery`, `HistoryPoint`, `HistorySeries`, `HistoryCoverage`, `HistoryAggregation`, `HistoryEligibility` extension methods, `HistoryQueryExtensions.QueryHistoryAsync` cross-store helper. No implementation. References `Namotion.Interceptor.Registry`. |
-| `HomeBlaze.History.Abstractions.Tests` | Unit tests for `HistoryEligibility.HasHistory` and the `QueryHistoryAsync` merge helper, using fake `IHistoryStore` implementations. |
-| `HomeBlaze.History.InMemory` | `InMemoryHistoryStore` subject. Ring buffer per property path. Priority 100. Intended for dev, tests, samples, and as the hot buffer covering the Timescale flush window. |
-| `HomeBlaze.History.InMemory.Tests` | Unit tests for the in-memory store: recording, retention, raw and bucketed queries, oversize placeholder, refused types, `Coverage` correctness. |
+| `HomeBlaze.History.Abstractions` | `IHistoryStore`, `HistoryQuery`, `HistoryPoint`, `HistorySeries`, `HistoryCoverage`, `HistoryAggregations` constants, `HistoryEligibility` extension methods, `HistoryQueryExtensions.QueryHistoryAsync` cross-store helper. No implementation. References `Namotion.Interceptor.Registry`. |
+| `HomeBlaze.History.Abstractions.Tests` | Unit tests for eligibility, the merger (raw planner, bucketed planner, sequential-budget executor), bucket alignment, look-back contract. |
+| `HomeBlaze.History.InMemory` | `InMemoryHistoryStore` subject. Ring buffer per property path. Priority 100. Hot buffer / dev / test store. |
+| `HomeBlaze.History.InMemory.Tests` | Unit tests covering recording, retention, raw and bucketed queries (including TWA look-back), oversize placeholder, refused types, `Coverage` correctness. |
 | `HomeBlaze.History.InMemory.Blazor` | Edit component for the in-memory store. |
-| `HomeBlaze.History.TimescaleDb` | `TimescaleDbHistoryStore` subject. Npgsql client, hypertable bootstrap, batched binary `COPY` writes. Priority 10. |
+| `HomeBlaze.History.TimescaleDb` | `TimescaleDbHistoryStore` subject. Npgsql client, hypertable bootstrap with daily chunks, batched binary `COPY` writes, toolkit probe, shutdown flush. Priority 10. |
 | `HomeBlaze.History.TimescaleDb.Blazor` | Edit component for the Timescale store. |
-| `HomeBlaze.History.TimescaleDb.Tests` | Integration tests using Testcontainers with the `timescale/timescaledb` image. |
+| `HomeBlaze.History.TimescaleDb.Tests` | Integration tests using two Testcontainers fixtures: `timescale/timescaledb-ha:pg16-latest` (toolkit available) and `timescale/timescaledb:latest-pg16` (toolkit absent). |
 
 Target framework: `net10.0` for everything, matching the rest of the HomeBlaze tree.
 
@@ -60,22 +70,33 @@ public interface IHistoryStore : IInterceptorSubject
 {
     int Priority { get; }
     HistoryCoverage Coverage { get; }
+    IReadOnlySet<string> SupportedAggregations { get; }
+
     Task<HistorySeries> QueryAsync(HistoryQuery query, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the most recent sample at or before <paramref name="asOf"/> for the given
+    /// property path, or null if no such sample exists. Used by TimeWeightedAverage
+    /// integration and Last LOCF gap-fill in the merger and in per-store bucketed
+    /// computations.
+    /// </summary>
+    ValueTask<HistoryPoint?> GetSampleAtOrBeforeAsync(
+        string propertyPath, DateTimeOffset asOf, CancellationToken cancellationToken);
 }
 
-public readonly record struct HistoryCoverage(
-    DateTimeOffset From,
-    DateTimeOffset To);
+public readonly record struct HistoryCoverage(DateTimeOffset From, DateTimeOffset To)
+{
+    public bool Contains(HistoryCoverage other) => other.From >= From && other.To <= To;
+    public bool Overlaps(HistoryCoverage other) => other.From < To && other.To > From;
+}
 
 public record HistoryQuery(
     string PropertyPath,
     DateTimeOffset From,
     DateTimeOffset To,
     TimeSpan? Bucket = null,
-    HistoryAggregation Aggregation = HistoryAggregation.Last,
+    string Aggregation = HistoryAggregations.Last,
     int MaxPoints = 10_000);
-
-public enum HistoryAggregation { Last, Average, Minimum, Maximum, Sum, Count }
 
 public record HistoryPoint(
     DateTimeOffset Timestamp,
@@ -88,13 +109,42 @@ public record HistorySeries(
     bool Truncated);
 ```
 
-### Coverage contract
+### Aggregation identifiers
 
-`Coverage` returns the range a store guarantees it can answer queries over. A query passed to `QueryAsync` is always inside this range, enforced by the merger. Returning a tighter coverage than the store physically holds is safe. Returning a wider coverage is a bug.
+Aggregations are PascalCase strings rather than a closed enum. This allows toolkit-conditional availability (`TimeWeightedAverage`), per-store specialization for future stores, and additive growth without abstraction churn.
+
+```csharp
+public static class HistoryAggregations
+{
+    public const string Last                = "Last";
+    public const string First               = "First";
+    public const string Average             = "Average";              // sample mean
+    public const string TimeWeightedAverage = "TimeWeightedAverage";  // duration-weighted (UI default for numeric)
+    public const string Minimum             = "Minimum";
+    public const string Maximum             = "Maximum";
+    public const string Sum                 = "Sum";
+    public const string Count               = "Count";
+    public const string StdDev              = "StdDev";
+
+    /// <summary>
+    /// Aggregations every store guarantees to support over any column type.
+    /// </summary>
+    public static readonly IReadOnlySet<string> Universal =
+        new HashSet<string>(StringComparer.Ordinal) { Last, Count };
+}
+```
+
+The constants prevent typos at hardcoded call sites. The MCP boundary accepts case-insensitive input and normalises to canonical PascalCase. Internal equality uses `StringComparer.Ordinal`.
+
+Parameterized aggregations (`Percentile:p`, `CrossingsAbove:N`) are deferred from MVP. When the first one lands, the syntax (colon-suffix vs preset names) is decided then.
+
+### Capability advertising
+
+`SupportedAggregations` is a property (re-evaluated on each access), not a constructor-baked field. This lets `TimescaleDbHistoryStore` reflect `ToolkitAvailable` changes after the probe completes. `Last` and `Count` are present in every store's set, gated by the `Universal` shortcut so the merger can fast-path raw queries that don't depend on aggregation at all.
 
 ### Eligibility predicate
 
-`HasHistory()` is the single source of truth for whether a property is recorded and whether the UI offers the history action. Both stores and the UI gate on it.
+`HasHistory()` is the single source of truth for whether a property is recorded and whether the UI offers the history action. Both stores and the UI gate on it. Eligibility is type-based; the `IsCumulative` and `IsDiscrete` flags on `StateAttribute` govern *display* concerns (UI aggregation dropdown filtering, future `Rate`/`Delta`/`StateDuration` enablement) but do not affect recording.
 
 ```csharp
 public static class HistoryEligibility
@@ -129,7 +179,7 @@ The allow-list is deliberately tight for MVP: numerics, bool, string, and enums.
 
 ### Column dispatch
 
-`ValueColumnFor` is the single source of truth used by both the write path (to route a value into the correct column) and the read path (to build the column-targeted SQL). Keeping write and read in agreement is the whole point of centralising it.
+`ValueColumnFor` is the single source of truth used by both the write path (to route a value into the correct column) and the read path (to build column-targeted SQL).
 
 ```csharp
 public enum ValueColumn { Long, Double, Json }
@@ -151,7 +201,40 @@ public static class HistoryColumns
 }
 ```
 
-`ValueColumnFor(typeof(ulong))` returns `Long` (the primary column for ulong properties). On the write path, the store performs an additional per-value check: if `value > long.MaxValue`, the row goes to `value_json` instead. On the read path, when `IsUlongProperty(...)` is true, the SQL builder produces a COALESCE-aware variant (see Query Path) so aggregations include rows from both columns. This is the only type that needs the dual-column read path; all others have a static column for life.
+`ValueColumnFor(typeof(ulong))` returns `Long` (primary column). On the write path, if a ulong value exceeds `long.MaxValue`, the row goes to `value_json` instead. On the read path, `IsUlongProperty(...) == true` triggers a COALESCE-aware SQL variant.
+
+### Look-back primitive
+
+Both stores expose `GetSampleAtOrBeforeAsync(propertyPath, asOf, ct)` returning the most recent sample at or before `asOf`. This single primitive serves multiple needs:
+
+| Need | When | Why look-back matters |
+|---|---|---|
+| `TimeWeightedAverage` integration (MVP) | Computing TWA over a bucket | Need the value held entering the bucket. |
+| `Last` LOCF gap-fill (MVP) | Empty buckets in bucketed `Last` queries | Carry forward the most recent value, including from before `query.From`. |
+| `Delta` / `Rate` on counters (Phase 2) | Sparse counters that haven't been written in a long time | Need `value(bucket.To) - value(bucket.From)`, both via look-back. |
+| `Last` raw queries with no in-range samples (corner case) | Coverage extends back further than the first sample in range | Optional: return the look-back value as a single point. |
+
+InMemory implements look-back via binary search to the floor of `asOf` in the property buffer. Timescale uses `SELECT * FROM property_history WHERE path = $1 AND ts <= $2 ORDER BY ts DESC LIMIT 1`, which is a single-row index lookup on `(path, ts DESC)`.
+
+Look-back returning null is honest: the system can't invent history that was never recorded. Pre-first-known-sample buckets stay null in `Last` LOCF; `Delta` over a never-recorded-before range returns null.
+
+### Bucket alignment
+
+In-memory and Timescale must produce buckets at identical timestamps for the same `(bucket size, sample timestamps)` so the sequential-budget merger never produces interleaved duplicates. Both use the epoch-anchored formula matching Postgres `time_bucket`:
+
+```csharp
+public static class BucketAlignment
+{
+    private static readonly DateTimeOffset Epoch = DateTimeOffset.UnixEpoch;
+
+    public static DateTimeOffset BucketStart(DateTimeOffset ts, TimeSpan bucket)
+    {
+        var ticksFromEpoch = (ts - Epoch).Ticks;
+        var bucketIndex = ticksFromEpoch / bucket.Ticks;
+        return Epoch.AddTicks(bucketIndex * bucket.Ticks);
+    }
+}
+```
 
 ## Recording Path
 
@@ -179,7 +262,7 @@ Record(change);
 
 ### Oversize and refused values
 
-Within the allow-list, only `string` is unbounded in length. The store writes serialized JSON into a pooled buffer with a hard cap (default 8 KB, configurable per store as `MaxJsonSize`). On overflow the store writes a small placeholder row instead:
+Within the allow-list, only `string` is unbounded in length. Each store writes serialized JSON into a pooled buffer with a hard cap (default 8 KB, configurable per store as `MaxJsonSize`). On overflow the store writes a small placeholder row:
 
 ```json
 { "$oversize": true, "size": 73218 }
@@ -191,160 +274,269 @@ Numerics, bool, and enums are bounded by their type; they never trigger the cap.
 
 ## Query Path
 
-Two paths, dispatched on whether `Bucket` is null. In both, the Timescale store inspects the property's declared type via the registry and builds a single-column query targeting `value_long`, `value_double`, or `value_json`. No COALESCE in the aggregate expression; the planner sees direct column references.
+Two query types, dispatched on whether `Bucket` is null. Both share the merger's sequential-budget executor and the contract that sub-queries return the **newest N samples (or buckets)** in their requested sub-range.
 
-The store uses `HistoryColumns.ValueColumnFor(propertyType)` (defined in the abstractions) to pick the column. For ulong properties, the read path additionally consults `IsUlongProperty` and emits the COALESCE variant described below.
+### Sub-query "newest N" contract
 
-### Raw path
+Every store's `QueryAsync` returns, for a given sub-range, at most `MaxPoints` results representing the newest samples (raw) or newest buckets (bucketed) in that sub-range. The output is sorted ascending by timestamp.
 
-Return individual samples within `[From, To]`. Example for a `long`-typed property:
-
-```sql
-select ts, value_long::double precision as number, null::jsonb as json
-from property_history
-where path = $1 and ts >= $2 and ts < $3
-order by ts asc
-limit $4 + 1;
-```
-
-For a `string`-typed property, `value_json` is selected and `number` is `NULL`. The `+1` lets the consumer detect overflow without a separate `count(*)`; if the result hits `MaxPoints + 1` rows, drop the last and set `Truncated = true`. The in-memory implementation does the same in a linear scan over the property's sorted sample list, bounded by binary search on the range endpoints.
-
-### Bucketed path
-
-One row per bucket, computed server-side via `time_bucket`. The aggregation function targets the property's column directly:
+For Timescale raw:
 
 ```sql
-select time_bucket($1::interval, ts) as bucket,
-       <agg>(<column>)               as number,
-       <last_json_expr>              as json
-from property_history
-where path = $2 and ts >= $3 and ts < $4
-group by bucket
-order by bucket asc
-limit $5 + 1;
+SELECT ts, <column> AS number, <json> AS json
+FROM (
+  SELECT ts, <column>, <json>
+  FROM property_history
+  WHERE path = $1 AND ts >= $2 AND ts < $3
+  ORDER BY ts DESC
+  LIMIT $4 + 1
+) t
+ORDER BY ts ASC;
 ```
 
-`<column>` is the result of `HistoryColumns.ValueColumnFor(propertyType)`. `<agg>` switches per `HistoryAggregation`:
+For Timescale bucketed:
 
-| Aggregation | SQL fragment |
+```sql
+SELECT bucket, number, json
+FROM (
+  SELECT time_bucket($1::interval, ts)         AS bucket,
+         <aggregate>(<column>)                 AS number,
+         <last_json_or_null>                   AS json
+  FROM property_history
+  WHERE path = $2 AND ts >= $3 AND ts < $4
+  GROUP BY bucket
+  ORDER BY bucket DESC
+  LIMIT $5 + 1
+) t
+ORDER BY bucket ASC;
+```
+
+`<column>` is the column for the property's declared type. `<aggregate>` switches per aggregation (see below). Bigint aggregates cast to `double precision` on the way out so `HistoryPoint.Number` stays a unified `double?`.
+
+The `+ 1` on the LIMIT lets the store detect overflow without a separate `count(*)`: if the result hits `MaxPoints + 1`, drop the last and set `Truncated = true` in the response.
+
+In-memory implements the same semantics via a binary-search slice over the property's sorted samples, taking the last N from the slice instead of the first N.
+
+### Aggregate fragments per aggregation
+
+| Aggregation | Timescale fragment | Notes |
+|---|---|---|
+| `Last` | `locf(last(<column>, ts))` over `time_bucket_gapfill` | Server-side LOCF for empty buckets (see below). |
+| `First` | `first(<column>, ts)` | Empty buckets stay null. |
+| `Average` | `avg(<column>)` | Sample mean. Empty buckets null. |
+| `TimeWeightedAverage` | `average(time_weight('locf', ts, <column>))` (toolkit) | Look-back semantics; empty buckets receive the held value. |
+| `Minimum` | `min(<column>)` | Empty buckets null. |
+| `Maximum` | `max(<column>)` | Empty buckets null. |
+| `Sum` | `sum(<column>)` | Empty buckets null. |
+| `Count` | `count(*)` returned as `number` | Empty buckets return 0, not null. |
+| `StdDev` | `stddev_samp(<column>)` | Empty buckets null. |
+
+### Empty-bucket / gap semantics
+
+The wire format encodes gaps as **`null` entries**, not absent entries:
+
+```json
+"points": [
+  { "ts": "2026-05-23T00:05:00Z", "value": 21.3 },
+  { "ts": "2026-05-23T00:10:00Z", "value": null },
+  { "ts": "2026-05-23T00:15:00Z", "value": 22.1 }
+]
+```
+
+Empty buckets within the query range produce one entry each with `Number` and `Json` both null (except where the aggregation provides a value). This makes the response self-describing for programmatic consumers without their having to compute expected bucket boundaries.
+
+Timescale uses `time_bucket_gapfill` (TimescaleDB core, no toolkit required) to emit the empty buckets in the result set. In-memory mirrors this in the bucketed scan, walking expected bucket boundaries and emitting a `HistoryPoint(ts, null, null)` for empty buckets.
+
+Per-aggregation behavior in empty buckets:
+
+| Aggregation | Empty bucket in response |
 |---|---|
-| `Last` | `last(<column>, ts)` |
-| `Average` | `avg(<column>)` |
-| `Minimum` | `min(<column>)` |
-| `Maximum` | `max(<column>)` |
-| `Sum` | `sum(<column>)` |
-| `Count` | `count(*)` returned as the `number` field |
+| `Last` | Server-applied LOCF: most recent value before the bucket. Pre-first-sample buckets stay null. |
+| `TimeWeightedAverage` | Held value computed via integration with look-back. Pre-first-sample buckets stay null. |
+| `Count` | `0` (a count of zero is a real fact, not a gap). |
+| All others (`First`, `Average`, `Sum`, `Min`, `Max`, `StdDev`) | `null`. The chart leaves a visual gap. |
 
-`<last_json_expr>` is `last(value_json, ts)` when aggregation is `Last` and the column is `value_json`; otherwise `NULL`. Bigint aggregates cast to `double precision` on the way out so the C# `HistoryPoint.Number` field stays a unified `double?`. Buckets with no rows are absent. Bucket cap defaults to 1000, same `+1 / Truncated` pattern.
+No new `GapFill` query parameter; the right behavior is automatic per aggregation.
+
+### Aggregation support per column
+
+| Column | `Last` | `First` | `Count` | `Average` | `TimeWeightedAverage` | `Minimum` | `Maximum` | `Sum` | `StdDev` |
+|---|---|---|---|---|---|---|---|---|---|
+| `value_long` | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| `value_double` | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| `value_json` | yes | yes | yes | no | no | no | no | no | no |
+
+Asking for a numeric aggregation on a `value_json`-stored property (decimal, string, enum) raises `HistoryAggregationNotSupportedException` from the store, surfaced as a structured MCP error and as a hidden option in the UI dropdown.
 
 ### `ulong` read path
 
 For ulong properties whose values can straddle `long.MaxValue`, the read path uses a COALESCE-aware variant so aggregates see both columns. Example for bucketed `Average`:
 
 ```sql
-select time_bucket($1::interval, ts) as bucket,
-       avg(coalesce(value_long::numeric,
-                    (value_json #>> '{}')::numeric))::double precision as number,
-       null::jsonb as json
-from property_history
-where path = $2 and ts >= $3 and ts < $4
-group by bucket
-order by bucket asc
-limit $5 + 1;
+SELECT bucket, number, NULL::jsonb AS json FROM (
+  SELECT time_bucket($1::interval, ts) AS bucket,
+         avg(coalesce(value_long::numeric,
+                      (value_json #>> '{}')::numeric))::double precision AS number
+  FROM property_history
+  WHERE path = $2 AND ts >= $3 AND ts < $4
+  GROUP BY bucket
+  ORDER BY bucket DESC
+  LIMIT $5 + 1
+) t ORDER BY bucket ASC;
 ```
 
-This branch only fires when `HistoryColumns.IsUlongProperty(propertyType)` is true. All other property types use the single-column SQL shown above with no COALESCE overhead.
-
-### Aggregation support per column
-
-| Column | `Last` | `Count` | `Average` | `Minimum` | `Maximum` | `Sum` |
-|---|---|---|---|---|---|---|
-| `value_long` | yes | yes | yes | yes | yes | yes |
-| `value_double` | yes | yes | yes | yes | yes | yes |
-| `value_json` | yes | yes | no | no | no | no |
-
-Asking for `Average`/`Minimum`/`Maximum`/`Sum` on a `value_json`-stored property (decimal, string, enum) returns a typed error: `HistoryAggregationNotSupportedException` from the store, surfaced as a structured MCP error response and as a disabled option in the UI's aggregation dropdown. Casting `value_json` to `numeric` for decimal aggregation is a noted post-MVP improvement.
-
-The in-memory implementation mirrors these semantics with a single linear pass grouping samples by the same epoch-anchored bucket-start formula used in the cross-store merge section (`floor((ts - epoch).Ticks / bucket.Ticks) * bucket.Ticks + epoch`). It does not maintain three internal storage slots; samples are kept as `(ts, object? value)` and the column-dispatch logic at query time inspects the value's runtime type.
+Fired only when `HistoryColumns.IsUlongProperty(propertyType)` is true. All other property types use the single-column SQL with no COALESCE overhead.
 
 ## Cross-Store Merge
 
-Timescale batches writes for efficiency (default `FlushInterval = 5 s`, configurable). Between flushes, the in-memory store already holds the very recent samples that Timescale has not yet committed. The merger uses each store's `Coverage` to dispatch queries efficiently and to fill the recent-data gap from in-memory.
-
-### Raw merge
-
-Split the query range across stores by coverage. Each store gets a sub-range it can fully serve. Higher-priority stores claim their range first; lower-priority stores fill what remains.
+The merger is structured in two phases: a **planner** that differs by query type, and a shared **executor** that consumes the plan.
 
 ```csharp
-var stores = registry.KnownSubjects.OfType<IHistoryStore>()
-    .OrderByDescending(s => s.Priority).ToArray();
+public record StoreDispatch(IHistoryStore Store, IReadOnlyList<HistoryRange> Ranges);
 
-var gaps = new List<HistoryCoverage> { new(query.From, query.To) };
-var merged = new SortedDictionary<DateTimeOffset, HistoryPoint>();
-var truncated = false;
-
-foreach (var store in stores)
+public static async Task<HistorySeries> QueryHistoryAsync(
+    this SubjectRegistry registry, HistoryQuery query, CancellationToken ct)
 {
-    if (gaps.Count == 0) break;
-    foreach (var sub in Intersect(gaps, store.Coverage))
-    {
-        var subSeries = await store.QueryAsync(
-            query with { From = sub.From, To = sub.To }, ct);
-        truncated |= subSeries.Truncated;
-        foreach (var p in subSeries.Points)
-            merged.TryAdd(p.Timestamp, p);
-    }
-    gaps = Subtract(gaps, store.Coverage);
-}
+    var stores = registry.KnownSubjects.OfType<IHistoryStore>()
+        .OrderByDescending(s => s.Priority).ToArray();
 
-return new HistorySeries(query.PropertyPath, merged.Values.ToImmutableArray(), truncated);
+    CheckEligibility(stores, query);
+
+    var plan = query.Bucket is null
+        ? PlanRawDispatch(stores, query)
+        : PlanBucketedDispatch(stores, query);
+
+    return await ExecuteWithBudget(plan, query, ct);
+}
 ```
 
-### Bucketed merge
+### Eligibility check
 
-**Per-bucket dispatch, no cross-store aggregation.** Each bucket in the query range is assigned to a single store; that store computes the bucket's aggregate using only its own samples. No data from two stores is ever combined inside one bucket's aggregate. This sidesteps the "average of averages" problem entirely: every aggregation (`Average`, `Minimum`, `Maximum`, `Sum`, `Count`, `Last`) works trivially per bucket because each bucket has one source of truth.
+For a query to succeed, every part of `[From, To]` must be servable by some store that supports the requested aggregation. The universal aggregations (`Last`, `Count`) are always servable and skip this check.
 
-**Assignment rule per bucket:** the highest-priority store whose `Coverage` fully contains the bucket's *effective range*. If none fully contains, fall back to the lowest-priority store with overlap (typically Timescale).
+```csharp
+static void CheckEligibility(IHistoryStore[] stores, HistoryQuery query)
+{
+    if (HistoryAggregations.Universal.Contains(query.Aggregation)) return;
 
-The *effective range* clips the bucket's logical span to the query bounds:
+    var eligible = stores.Where(s => s.SupportedAggregations.Contains(query.Aggregation));
+    var union = ComputeCoverageUnion(eligible.Select(s => s.Coverage));
+    if (!union.Contains(query.From, query.To))
+    {
+        throw new HistoryAggregationNotSupportedException(
+            query.Aggregation, query.From, query.To,
+            available: stores.SelectMany(s => s.SupportedAggregations).Distinct().ToArray());
+    }
+}
+```
+
+The exception carries the `available` list so MCP errors and UI tooltips can advertise what *would* work for the requested range.
+
+### Raw planner: coverage subtraction
+
+Each store gets a non-overlapping sub-range. Higher-priority stores claim their range first; lower-priority stores fill what remains.
+
+```csharp
+static IReadOnlyList<StoreDispatch> PlanRawDispatch(IHistoryStore[] stores, HistoryQuery query)
+{
+    var gaps = new List<HistoryCoverage> { new(query.From, query.To) };
+    var plan = new List<StoreDispatch>();
+    foreach (var store in stores.Where(s => Supports(s, query.Aggregation)))
+    {
+        var ranges = Intersect(gaps, store.Coverage).ToList();
+        if (ranges.Count > 0) plan.Add(new StoreDispatch(store, ranges));
+        gaps = Subtract(gaps, store.Coverage).ToList();
+        if (gaps.Count == 0) break;
+    }
+    return plan;
+}
+```
+
+### Bucketed planner: per-bucket dispatch
+
+Each bucket in the range is assigned to a single eligible store: the highest-priority store that supports the aggregation and whose `Coverage` fully contains the bucket's *effective range*:
 
 ```
 effective = [max(bucket.From, query.From), min(bucket.To, query.To)]
 ```
 
-This matters at the right edge of live queries: a bucket whose logical end extends past `query.To` (= "now") only needs to contain the truncated portion, so in-memory wins boundary buckets it otherwise would have lost to Timescale by a few seconds.
+Consecutive buckets assigned to the same store are grouped into one ranged sub-query. If no eligible store fully contains a bucket but at least one overlaps, fall back to the lowest-priority eligible overlapping store. Buckets entirely outside every eligible store's coverage are skipped (they appear as gaps in the final response — but eligibility check above ensures at least one store covers each bucket if we got this far).
 
-**SQL economy via grouping.** A naive implementation would issue one SQL per bucket. The merger groups consecutive buckets assigned to the same store into one ranged sub-query, so a typical chart is at most one or two round-trips:
+No data from two stores is ever combined inside one bucket's aggregate. This sidesteps the "average of averages" problem entirely; every aggregation works trivially per bucket because each bucket has one source of truth.
+
+### Shared executor: sequential budget
 
 ```csharp
-var buckets = EnumerateBucketRanges(query);
-var assignments = buckets.Select(b => (Bucket: b, Store: AssignBucket(stores, b, query)));
-var groups = GroupConsecutive(assignments, a => a.Store);
-
-foreach (var group in groups)
+static async Task<HistorySeries> ExecuteWithBudget(
+    IReadOnlyList<StoreDispatch> plan, HistoryQuery query, CancellationToken ct)
 {
-    var subQuery = query with {
-        From = group.First().Bucket.From,
-        To   = group.Last().Bucket.To
-    };
-    var part = await group.Key.QueryAsync(subQuery, ct);
-    truncated |= part.Truncated;
-    foreach (var p in part.Points) allPoints[p.Timestamp] = p;
+    var remaining = query.MaxPoints;
+    var truncated = false;
+    var collected = new SortedDictionary<DateTimeOffset, HistoryPoint>();
+
+    foreach (var (store, ranges) in plan)            // priority order
+    {
+        if (remaining <= 0) { truncated = true; break; }
+
+        // Newest-first within store so we keep the freshest under budget.
+        foreach (var range in ranges.OrderByDescending(r => r.To))
+        {
+            if (remaining <= 0) break;
+            var sub = await store.QueryAsync(
+                query with { From = range.From, To = range.To, MaxPoints = remaining }, ct);
+            truncated |= sub.Truncated;
+            foreach (var point in sub.Points)
+                if (collected.TryAdd(point.Timestamp, point))
+                    remaining--;
+        }
+    }
+
+    return new HistorySeries(query.PropertyPath, collected.Values.ToImmutableArray(), truncated);
 }
 ```
 
-**Bucket alignment invariant.** The in-memory implementation must use the same bucket-boundary computation as Postgres `time_bucket` (epoch-anchored: `floor((ts - epoch).Ticks / bucket.Ticks) * bucket.Ticks + epoch`). If alignment ever drifts, two stores would produce buckets at different timestamps and concatenation would interleave them. This is enforced by a shared helper in `HomeBlaze.History.Abstractions`.
+Properties of the executor:
+
+- **No over-fetching.** Each store receives the *remaining* budget, not the full `MaxPoints`. Higher-priority stores can short-circuit lower-priority queries entirely when they have enough data.
+- **Newest-first.** Sub-queries return the newest N (see "Sub-query 'newest N' contract" above). Combined with priority ordering, this naturally produces "newest MaxPoints overall" across stores.
+- **Truncated honestly.** Set when either a sub-query truncated *or* the budget ran out mid-iteration.
+- **Dedup via TryAdd.** Higher-priority store's value wins for overlapping timestamps (rare but possible for raw queries).
+
+### Live-edge bucket accuracy
+
+The bucketed planner assigns buckets based on `Coverage`. For a bucket larger than `InMemory.MaxAge`, the live-edge bucket (the rightmost bucket whose `To` reaches `query.To`) is never fully contained by InMemory and falls to Timescale. Timescale's `Coverage.To = _lastFlushHighWaterMark` (see TimescaleDB Store below) trails "now" by 0 to `FlushInterval` in steady state, so the live-edge bucket's aggregate omits the last `FlushInterval` of samples.
+
+Relative error is bounded by `FlushInterval / bucket_size`:
+
+| Bucket size (`FlushInterval = 5s`) | Live-edge error |
+|---|---|
+| 30s | covered by InMemory if `MaxAge >= 60s` (default) — perfect |
+| 5min | 1.7% |
+| 10min | 0.83% |
+| 1h | 0.14% |
+| 24h | 0.006% |
+
+For workloads that need pixel-perfect aggregation in the live-edge bucket at chart-typical sizes (5–15 min), increase `MaxAge` to match the smallest bucket size you care about. Most operators won't need to. A combinable-partial-aggregate path (Timescale returns aggregate state, InMemory contributes raw samples past `Coverage.To`, merger combines in-process) is a noted post-MVP refinement when real workloads expose the medium-bucket wobble.
+
+### Cross-store sizing constraint
+
+`InMemory.MaxAge >= 2 * TimescaleDb.FlushInterval`.
+
+Without this, samples can be invisible to queries during the window between InMemory eviction and Timescale commit. The default configs (`MaxAge = 60s`, `FlushInterval = 5s`) satisfy this comfortably. The constraint is documented in the `MaxAge` `[Configuration]` doc comment and surfaced as helper text in the edit component. Runtime validation is a noted fast-follow.
 
 ### Resulting behaviour
 
 | Query | Routing |
 |---|---|
-| `last 30 s`, raw or bucketed | In-memory fully contains every bucket. Timescale never touched. |
-| `last 1 hr`, raw | Split by coverage: in-memory serves the last 60 s, Timescale the rest. Two queries. |
-| `last 5 min`, bucket=10s | Per-bucket dispatch: Timescale serves buckets 1-24 in one SQL, in-memory serves buckets 25-30. Latest data without buffer lag. |
-| `last 1 hr`, bucket=1min | Most buckets don't fit in in-memory (60 s) → Timescale alone. One query. |
-| `last 30 days`, bucket=1hr | Timescale alone. |
-| Timescale offline, `last 30 s`, raw or bucketed | In-memory still answers. The DB outage is invisible for ranges it covers. |
+| `last 30 s`, raw or bucketed | InMemory fully contains every bucket; budget exhausts before Timescale is queried. Timescale never touched. |
+| `last 1 hr`, raw | Split by coverage: InMemory serves the last 60s, Timescale the rest with the remaining budget. Two queries (one per store). |
+| `last 5 min, bucket=10s` | Per-bucket dispatch: Timescale serves buckets 1-24 in one grouped sub-query, InMemory serves buckets 25-30. Latest data without buffer lag. |
+| `last 1 hr, bucket=1min` | Most buckets don't fit in InMemory (60s) → Timescale alone. One query. Live-edge bucket error: ~8.3%. |
+| `last 1 hr, bucket=5min` | Same as above. Live-edge bucket error: ~1.7%. |
+| `last 30 days, bucket=1hr` | Timescale alone. Live-edge bucket error: 0.14%. |
+| Timescale offline, `last 30 s`, raw | InMemory still answers. The DB outage is invisible for ranges it covers. |
+| Timescale offline, `last 1 hr`, raw | InMemory answers the last 60s; Timescale returns from its `Coverage.To` (frozen at last successful flush) for the older sub-range. Gaps between freeze point and `now - 60s` are honest empty buckets/missing samples. |
+| `TimeWeightedAverage` requested, toolkit unavailable | If only InMemory supports TWA and the range exceeds InMemory's coverage: `HistoryAggregationNotSupportedException` with `available` list. UI never showed TWA in the dropdown for this configuration. |
 
 A store that raises an exception during `QueryAsync` propagates that exception. The merger does not silently swallow errors. A misconfigured Timescale must not masquerade as "no data".
 
@@ -353,24 +545,36 @@ A store that raises an exception during `QueryAsync` propagates that exception. 
 ### Schema
 
 ```sql
-create table property_history (
-  ts            timestamptz       not null,
-  path          text              not null,
-  value_long    bigint            null,
-  value_double  double precision  null,
-  value_json    jsonb             null
+CREATE TABLE IF NOT EXISTS property_history (
+  ts            timestamptz       NOT NULL,
+  path          text              NOT NULL,
+  value_long    bigint            NULL,
+  value_double  double precision  NULL,
+  value_json    jsonb             NULL
 );
 
-select create_hypertable('property_history', 'ts', if_not_exists => true);
-create index if not exists ix_property_history_path_ts
-  on property_history (path, ts desc);
+SELECT create_hypertable('property_history', 'ts',
+    chunk_time_interval => INTERVAL '1 day',
+    if_not_exists => true);
+
+CREATE INDEX IF NOT EXISTS ix_property_history_path_ts
+    ON property_history (path, ts DESC);
+
+CREATE TABLE IF NOT EXISTS history_schema_version (
+    version       integer PRIMARY KEY,
+    applied_at    timestamptz NOT NULL DEFAULT now(),
+    description   text NOT NULL
+);
+INSERT INTO history_schema_version (version, description)
+VALUES (1, 'Initial MVP schema')
+ON CONFLICT (version) DO NOTHING;
 ```
 
-Three nullable value columns, dispatched per property type at write and read time. NULL columns in Postgres cost roughly one bit per column per row in the row header; the only payload byte cost is the populated column. Snake_case columns; C# DTOs and parameters remain PascalCase. Schema bootstrap runs idempotently on store start.
+Three nullable value columns, dispatched per property type at write and read time. Daily chunks make future compression (`add_compression_policy`) more granular and queries against compressed ranges more efficient. Snake_case columns; C# DTOs and parameters remain PascalCase. Schema bootstrap runs idempotently on store start.
 
 ### Driver choice
 
-Npgsql native, no ORM. EF Core's migrations fight `create_hypertable`, and change tracking on the hot write path is exactly the overhead to avoid. Dapper offers nothing for bulk writes. Reads are two or three SQL strings and don't earn an abstraction. Writes use `NpgsqlBinaryImporter` (`COPY` binary protocol) per batch.
+Npgsql native, no ORM. EF Core's migrations fight `create_hypertable`, and change tracking on the hot write path is exactly the overhead to avoid. Dapper offers nothing for bulk writes. Reads are a handful of SQL strings and don't earn an abstraction. Writes use `NpgsqlBinaryImporter` (`COPY` binary protocol) per batch.
 
 ### Configuration
 
@@ -378,34 +582,92 @@ Npgsql native, no ORM. EF Core's migrations fight `create_hypertable`, and chang
 |---|---|---|
 | `ConnectionString` | required | Npgsql connection string |
 | `Retention` | 30 days | Timescale `add_retention_policy` chunk delete job |
-| `BufferTime` | 250 ms | `ChangeQueueProcessor` coalesce window. Within one window only the last value per property is kept. Decides sample resolution. Min 50 ms. |
-| `FlushInterval` | 5 s | How often the store actually issues a `COPY`. The store accumulates batches delivered every `BufferTime` and writes them all at once on each flush. Must be `>= BufferTime` (validated at startup; clamped if lower). Larger values reduce DB write frequency at the cost of staleness up to `FlushInterval`. Setting it equal to `BufferTime` means one COPY per delivered batch. |
+| `BufferTime` | 250 ms | `ChangeQueueProcessor` coalesce window. Min 50 ms. |
+| `FlushInterval` | 5 s | How often the store issues a `COPY`. Must be `>= BufferTime` (validated at startup; clamped if lower). |
+| `ShutdownFlushTimeout` | 10 s | Maximum time to wait for the final synchronous COPY during graceful shutdown before giving up. |
 | `MaxJsonSize` | 8 KB | Per-string cap; overflow becomes a placeholder row |
 
-`[State]` properties for operator observability: `Status`, `StatusMessage`, `QueueDepth`, `DropCount`, `OversizeCount`, `RecordedCount`, `IncomingChangesPerSecond`, `RecordedChangesPerSecond`, `LastFlushUtc`, `LastError`. `IncomingChangesPerSecond` and `RecordedChangesPerSecond` are rolling 1-minute averages, same shape and naming as `OpcUaClient.IncomingChangesPerSecond`. The gap between the two surfaces filtering and backpressure.
+### State properties for operator observability
 
-**Shared rate counter.** Both rolling rates reuse the existing `ThroughputCounter` (lock-free 60-second sliding window) currently `internal sealed` in `Namotion.Interceptor.OpcUa`. As part of the MVP work, that file is promoted to `Namotion.Interceptor.Connectors` and made `public` so the OPC UA connectors, the history stores, and future change-pipeline consumers can share one implementation. `Namotion.Interceptor.Connectors` is the natural home: it already hosts `ChangeQueueProcessor` (which both OPC UA and the history stores already depend on), so no new dependency is introduced. The two existing OPC UA usages (`OpcUaSubjectClientSource`, `OpcUaSubjectServer`) update their `using` to the new namespace; the existing `ThroughputCounterTests` move to `Namotion.Interceptor.Connectors.Tests`.
+`Status`, `StatusMessage`, `QueueDepth`, `DropCount`, `OversizeCount`, `RecordedCount`, `IncomingChangesPerSecond`, `RecordedChangesPerSecond`, `LastFlushUtc`, `LastError`, plus:
+
+- `ToolkitAvailable` (bool?) — null until first probe, then true/false.
+- `ToolkitStatus` (string?) — human-readable detail (e.g., `"Available (version 1.18.0)"`, `"Not installed at the cluster level"`, `"Probe failed: connection refused"`).
+- `EstimatedStorageBytes` (long?) — refreshed periodically via `SELECT pg_total_relation_size('property_history')`. Trigger metric for the deferred path-normalisation optimization.
+
+**Shared rate counter.** Both rolling rates reuse the existing `ThroughputCounter` (lock-free 60-second sliding window) currently `internal sealed` in `Namotion.Interceptor.OpcUa`. As part of the MVP work, that file is promoted to `Namotion.Interceptor.Connectors` and made `public` so the OPC UA connectors, the history stores, and future change-pipeline consumers share one implementation. `Namotion.Interceptor.Connectors` already hosts `ChangeQueueProcessor` (referenced by both OPC UA and the history stores), so no new dependency is introduced.
 
 ### Coverage
 
-`Coverage.From = DateTimeOffset.UtcNow - Retention`, `Coverage.To = DateTimeOffset.UtcNow`. Both derived without DB calls.
+`Coverage.From = DateTimeOffset.UtcNow - Retention`. `Coverage.To = _lastFlushHighWaterMark`.
+
+The high-water-mark is the timestamp of the newest sample known to be committed to the DB:
+
+- Pre-first-flush (and pre-bootstrap): `Coverage = (StartTime, StartTime)` — empty range. The merger never assigns work to Timescale until it has actually committed something.
+- Seeded at bootstrap via `SELECT MAX(ts) FROM property_history`. This makes Coverage honest immediately after restart instead of advertising empty coverage until the first post-restart flush.
+- Clamped at startup to `now` if the seed is in the future (clock skew with a previous writer).
+- Advanced after each successful `COPY` to `max(_lastFlushHighWaterMark, batch.Max(s => s.Timestamp))`. Empty flushes don't advance it (sparse ranges between samples are routed to InMemory, which correctly returns empty).
+- Frozen during DB outages: the merger sees the gap and routes that range to InMemory instead of getting silent holes.
+
+If `_lastFlushHighWaterMark` ages past `now - Retention` (e.g., DB has been failing flushes for so long that the high-water-mark predates retention), the Coverage getter returns an empty `(to, to)` range instead of an inverted one.
+
+### Toolkit dependency
+
+Probe via `CREATE EXTENSION IF NOT EXISTS timescaledb_toolkit` during schema bootstrap:
+
+- If toolkit is installed and not yet enabled: enables it. Bootstrap proceeds normally.
+- If toolkit is installed and already enabled: no-op.
+- If toolkit is not installed at the cluster level: catch the exception, set `ToolkitAvailable = false`, log a warning, continue startup.
+
+Re-probe on every successful reconnect (in case the operator installed toolkit during the outage). No periodic polling.
+
+`SupportedAggregations` reflects the current value of `ToolkitAvailable`:
+
+```csharp
+public IReadOnlySet<string> SupportedAggregations
+{
+    get
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal)
+        {
+            HistoryAggregations.Last, HistoryAggregations.First,
+            HistoryAggregations.Average, HistoryAggregations.Minimum,
+            HistoryAggregations.Maximum, HistoryAggregations.Sum,
+            HistoryAggregations.Count, HistoryAggregations.StdDev,
+        };
+        if (ToolkitAvailable == true)
+            set.Add(HistoryAggregations.TimeWeightedAverage);
+        return set;
+    }
+}
+```
+
+### Recommended Docker image
+
+For production deployments, the `timescale/timescaledb-ha:pg16-latest` image bundles `timescaledb_toolkit` along with TimescaleDB core, so all aggregations including `TimeWeightedAverage` work out of the box. The smaller `timescale/timescaledb` image works too; install the toolkit manually (`CREATE EXTENSION timescaledb_toolkit;`) or accept the degraded set. `time_bucket`, `time_bucket_gapfill`, and basic aggregations are in TimescaleDB core and don't require the toolkit.
+
+### Shutdown flush
+
+On `StopAsync`, the store performs a final synchronous `COPY` of any pending batch. Bounded by `ShutdownFlushTimeout` (default 10 s). If the timeout is reached, the pending batch is dropped: `Status = Failed`, `StatusMessage = "Shutdown flush timed out; <N> samples lost"`, and the log records the loss. The store accepts no new writes during the drain.
+
+On process crash (SIGKILL, OOM, etc.), the pending batch is lost regardless. Up to `FlushInterval` of samples can be lost on crash — documented limitation of batched writes.
 
 ## InMemory Store
 
-Top layer: `ConcurrentDictionary<string, PropertyBuffer>` keyed by property path. Inner layer: array-backed ring buffer per path with a per-buffer lock. Buffers are created on first write — properties that never change consume zero memory.
+Top layer: `ConcurrentDictionary<string, PropertyBuffer>` keyed by property path. Inner layer: array-backed ring buffer per path with a per-buffer lock. Buffers are created on first write; properties that never change consume zero memory.
 
 ### Configuration
 
 | Knob | Default | Purpose |
 |---|---|---|
-| `MaxAge` | 60 s | Drop samples older than this. Tuned to cover the Timescale `FlushInterval` plus a generous safety margin and to serve "last 1 min" charts entirely in-memory. |
+| `MaxAge` | 60 s | Drop samples older than this. Must be at least `2 * FlushInterval` of any companion persistent store to guarantee samples remain in-buffer until they're committed. Default satisfies the constraint for the default 5s Timescale flush. |
 | `MaxPointsPerProperty` | 1 000 | Per-property hard cap on the ring buffer. Sized to comfortably hold 16 Hz over a minute; protects against a single runaway property dominating memory. |
-| `BufferTime` | 250 ms | `ChangeQueueProcessor` batch window. Coalesces repeated writes to the same property within the window down to one sample. Larger values dramatically reduce per-property memory at the cost of slightly less granular recent history; users with 100k+ properties may set this to 1 s to halve memory pressure. Min 50 ms. |
+| `BufferTime` | 250 ms | `ChangeQueueProcessor` batch window. Min 50 ms. |
 | `MaxJsonSize` | 8 KB | Same placeholder rule as Timescale |
 
 **Realistic memory at scale:**
 
-Memory tracks actual change rate per property, not the per-property cap. With the defaults and a 250ms coalesce window, ~25% of raw writes survive coalescing.
+Memory tracks actual change rate per property, not the per-property cap. With the defaults and a 250 ms coalesce window, ~25% of raw writes survive coalescing.
 
 | Scenario | Memory |
 |---|---|
@@ -416,11 +678,29 @@ Memory tracks actual change rate per property, not the per-property cap. With th
 
 Operators with extreme scale (well above 100k properties) tune `MaxAge` down (to 30 s or 10 s) or `BufferTime` up (to 1 s) to keep memory bounded.
 
-`[State]` properties for operator observability mirror the Timescale store where applicable, plus memory metrics: `Status`, `StatusMessage`, `RecordedCount`, `OversizeCount`, `EvictedCount` (samples dropped by `MaxAge` or `MaxPointsPerProperty`), `IncomingChangesPerSecond`, `RecordedChangesPerSecond`, `TrackedPropertyCount`, `TotalSampleCount`, `EstimatedMemoryBytes`. `TotalSampleCount × 50` gives a rough byte estimate; the metric is exposed so operators can confirm tuning matches expectations. No queue or flush metrics since writes are synchronous.
+### State properties for operator observability
+
+`Status`, `StatusMessage`, `RecordedCount`, `OversizeCount`, `EvictedCount` (samples dropped by `MaxAge` or `MaxPointsPerProperty`), `IncomingChangesPerSecond`, `RecordedChangesPerSecond`, `TrackedPropertyCount`, `TotalSampleCount`, `EstimatedMemoryBytes`. `TotalSampleCount × 50` gives a rough byte estimate.
 
 ### Coverage
 
-`Coverage.From = max(StartTime, DateTimeOffset.UtcNow - MaxAge)`, `Coverage.To = DateTimeOffset.UtcNow`. The `max(StartTime, …)` clamp matters during the first `MaxAge` window after the store starts: the buffer doesn't actually have samples from before startup, so advertising coverage back to "now − 5 min" would cause the merger to route old-range queries here and get empty results while Timescale (which does have that data) gets skipped.
+`Coverage.From = max(StartTime, DateTimeOffset.UtcNow - MaxAge)`, `Coverage.To = DateTimeOffset.UtcNow`. The `max(StartTime, …)` clamp matters during the first `MaxAge` window after the store starts: the buffer doesn't actually have samples from before startup, so advertising coverage back to "now − MaxAge" would route old-range queries here for empty results while Timescale (which does have that data) gets skipped.
+
+### TimeWeightedAverage with look-back
+
+InMemory implements TWA via trapezoidal integration with look-back semantics matching toolkit's `time_weight('locf', ...)`:
+
+1. For a bucket `[bucket.From, bucket.To]`, query the buffer for in-bucket samples plus call `GetSampleAtOrBeforeAsync(path, bucket.From)` to find the value held entering the bucket.
+2. Integrate value × duration across each segment (look-back start → first in-bucket sample, then each adjacent pair, then last sample → bucket.To).
+3. Divide by total duration to produce TWA.
+
+Empty bucket (no in-bucket samples): TWA = look-back value (held throughout the bucket). If look-back returns null: TWA = null.
+
+This implementation must produce identical numbers to Timescale's `average(time_weight('locf', ts, value))` for the same input data. **An integration test that writes identical samples to both stores and asserts TWA equality across a battery of edge cases (empty bucket, single-sample bucket, boundary-sample bucket, sparse vs dense, look-back-only bucket where no in-bucket samples exist) is load-bearing for the unified-merger design.**
+
+### Shutdown semantics
+
+InMemory has no shutdown flush. Its data is process-local and lost on every restart. This is intentional: InMemory is documented as a hot buffer / dev / test store, not a production substitute. Configurations using only InMemory will lose history on every restart.
 
 ### Use cases
 
@@ -428,19 +708,15 @@ Operators with extreme scale (well above 100k properties) tune `MaxAge` down (to
 2. Default store in unit tests and the dev sample, since it has no external dependency.
 3. Local fallback during a brief Timescale outage for queries that fit its window.
 
-It is documented as not a production substitute for the DB store.
-
 ## UI
 
 ### Edit components
 
 One Blazor project per store, matching the `HomeBlaze.OpcUa.Blazor` convention.
 
-`TimescaleDbHistoryStoreEditComponent.razor`: tabs General (name, enabled, connection string, retention) and Advanced (`BufferTime`, `FlushInterval`, `MaxJsonSize`). Status block at the bottom shows `Status` and `StatusMessage` from the subject, same pattern as `OpcUaServerEditComponent`.
+`TimescaleDbHistoryStoreEditComponent.razor`: tabs General (name, enabled, connection string, retention) and Advanced (`BufferTime`, `FlushInterval`, `ShutdownFlushTimeout`, `MaxJsonSize`). Status block at the bottom shows `Status`, `StatusMessage`, `ToolkitStatus`, and `EstimatedStorageBytes`.
 
-`InMemoryHistoryStoreEditComponent.razor`: name, enabled, `MaxAge`, `MaxPointsPerProperty`, `BufferTime`, `MaxJsonSize`.
-
-No setup component. Neither store has an out-of-band discovery step; the standard "create new subject" flow is sufficient. The browser already renders store `[State]` properties, so no custom status view is needed.
+`InMemoryHistoryStoreEditComponent.razor`: name, enabled, `MaxAge`, `MaxPointsPerProperty`, `BufferTime`, `MaxJsonSize`. The `MaxAge` field has helper text noting the `>= 2 * FlushInterval` constraint.
 
 ### Property history dialog
 
@@ -457,53 +733,108 @@ Bucket: [Auto v]   Aggregation: [Average v]
 [ MudTimeSeriesChart, 400px high ]
 
 3 042 points · Truncated: no · Source: TimescaleDB + InMem
-
                                                        [Close]
 ```
 
-Defaults: 24h, Auto bucket, Average for numerics; 24h, raw, Last for non-numerics. Auto bucket picks `range / 200` rounded to a sane interval (1s, 5s, 30s, 1min, 5min, 15min, 1h, 6h, 1d), keeping the chart near 200 points across zoom levels.
+Defaults: 24h, Auto bucket. The default aggregation for numeric properties is `TimeWeightedAverage` if supported by all registered stores (labelled "Average"), falling through to `Average` (sample mean) if not. For non-numeric properties, default is `Last`. Auto bucket picks `range / 200` rounded to a sane interval (1s, 5s, 30s, 1min, 5min, 15min, 1h, 6h, 1d), keeping the chart near 200 points across zoom levels.
 
-Chart: MudBlazor 9.2's `MudTimeSeriesChart` (built in, no new dependency). Linear interpolation for numeric aggregations. Stepped interpolation when displaying `Last` of a non-numeric property, with hover tooltip showing the JSON value.
+### Aggregation dropdown gating
 
-`Truncated` flag from the response surfaces as a small warning indicator. The "Source" line names the stores that contributed, for trust and debugging.
+The dropdown shows only aggregations available *for the current property*:
+
+- For properties with `IsCumulative = true` (counters): show only `Last`, `First`, `Minimum`, `Maximum`, `Count`. Default: `Last`. Other aggregations are mathematically meaningless for counters (averaging or summing meter readings produces nonsense).
+- For all other properties: filter by `ValueColumnFor(propertyType)` (numeric vs JSON) and intersect with the union of `SupportedAggregations` across all registered stores. If `TimeWeightedAverage` isn't supported by every store with non-empty coverage, hide it entirely ("don't offer what can't be delivered").
+
+When `TimeWeightedAverage` is shown, it is labelled "Average" with a tooltip explaining time-weighted semantics. The sample mean (`Average`) appears as "Sample Average" lower in the dropdown for users who explicitly want it.
+
+Per-range filter refinement (re-evaluating availability as the user changes the time range) is a noted fast-follow.
+
+### Chart rendering
+
+MudBlazor 9.2's `MudTimeSeriesChart` (built in, no new dependency). `ChartPoint<T>` requires non-nullable numeric `Y`; null entries from the response can't be passed directly. The chart layer converts each `HistorySeries` into one or more `ChartSeries`:
+
+- For `Last`-aggregation responses (server-applied LOCF means no nulls in the typical case): one `ChartSeries`, stepped-line interpolation.
+- For other aggregations (gaps present as nulls): split the series at null entries into multiple `ChartSeries`, all with the same color/style, only the first carrying a legend name. Each contiguous run renders as its own line; the breaks between them appear as visual gaps.
+
+Tooltips show the raw value and timestamp.
+
+### Gap-rendering convention (chart layer)
+
+The store's `QueryAsync` returns explicit null entries for empty buckets in the wire format. The convention below describes the chart's visual treatment after the chart-layer split:
+
+| Aggregation | Chart treatment for null/empty buckets |
+|---|---|
+| `Last`, non-numeric | (Server-applied LOCF: no nulls in response.) Stepped line through the carried values. |
+| `TimeWeightedAverage` | (Server-applied integration: no nulls in response unless pre-first-sample.) Smooth line. |
+| `Count` | Server returns 0 for empty buckets. Bar/line shows zero. |
+| `First`, `Average`, `Min`, `Max`, `Sum`, `StdDev` | Nulls in response. Chart splits into sub-series; visual gap between runs. |
+
+The chart never invents data the server didn't return. Server-side gap-fill (LOCF / interpolate) for *other* aggregations beyond what's described here is a Phase 2 opt-in.
 
 ## MCP Tool
 
-Tool `get_property_history` lives in `HomeBlaze.Mcp` (the enriched layer), since it depends on `HomeBlaze.History.Abstractions`. Base `Namotion.Interceptor.Mcp` stays free of history concerns.
+Tool `get_property_history` lives in `HomeBlaze.AI` (the enriched layer), since it depends on `HomeBlaze.History.Abstractions`. Base `Namotion.Interceptor.Mcp` stays free of history concerns.
 
 | Parameter | Type | Required | Default | Notes |
 |---|---|---|---|---|
 | `path` | string | yes | | Subject property path |
-| `from` | string | yes | | ISO 8601 timestamp. Parsed with `DateTimeStyles.AssumeUniversal`: an explicit offset (`Z`, `+02:00`) is honoured, a bare timestamp like `2026-05-19T00:00:00` is treated as UTC. |
-| `to` | string | no | `now` (UTC) | ISO 8601, same parsing rule as `from`. |
+| `from` | string | yes | | ISO 8601 timestamp. Parsed with `DateTimeStyles.AssumeUniversal`: explicit offset (`Z`, `+02:00`) honoured; bare timestamps treated as UTC. |
+| `to` | string | no | `now` (UTC) | ISO 8601, same parsing rule. |
 | `bucket` | string | no | null (raw) | `TimeSpan`-parseable, e.g. `5m` |
-| `aggregation` | string | no | `last` | One of `last`, `average`, `minimum`, `maximum`, `sum`, `count` (case insensitive) |
+| `aggregation` | string | no | `Last` | Case-insensitive match against `HistoryAggregations` constants. |
 
 Response:
 
 ```json
 {
   "path": "Devices/LivingRoomThermostat/Temperature",
-  "from": "2026-05-19T00:00:00Z",
-  "to":   "2026-05-20T00:00:00Z",
+  "from": "2026-05-23T00:00:00Z",
+  "to":   "2026-05-24T00:00:00Z",
   "bucket": "5m",
-  "aggregation": "average",
+  "aggregation": "TimeWeightedAverage",
+  "value_type": "number",
   "points": [
-    { "ts": "2026-05-19T00:00:00Z", "value": 21.3 },
-    { "ts": "2026-05-19T00:05:00Z", "value": 21.4 },
-    { "ts": "2026-05-19T00:10:00Z", "value": null }
+    { "ts": "2026-05-23T00:00:00Z", "value": 21.3 },
+    { "ts": "2026-05-23T00:05:00Z", "value": 21.4 },
+    { "ts": "2026-05-23T00:10:00Z", "value": null }
   ],
   "truncated": false
 }
 ```
 
-`value` is a polymorphic JSON value: number when populated via `value_long` or `value_double`, JSON literal when populated via `value_json`, `null` when no value column is populated (explicit-null sample). Empty `points` and missing paths are not errors; they return successfully with an empty array. Real errors (DB unreachable, malformed parameters) propagate as MCP error responses.
+### `value_type` field
 
-`MaxPoints` is intentionally not exposed as a tool parameter. Callers that need more detail narrow `from`/`to` instead; the cap (10 000 raw, 1 000 bucketed) keeps any single response bounded and the `truncated` flag signals when it was hit.
+Reflects the **response value's type** (what consumers see in `value`), not the property's underlying type. Values:
+
+- `"number"` — `Number` field populated. Includes `Count` regardless of property type.
+- `"string"` — string-valued non-numeric property via `Last`/`First`.
+- `"boolean"` — bool property via `Last`/`First`.
+- `"enum"` — enum property via `Last`/`First` (enum name as JSON string).
+
+The hint helps programmatic consumers parse without inspecting each point's type.
+
+### Error responses
+
+Unknown aggregation, missing path, or aggregation not supported across the requested range:
+
+```json
+{
+  "error": "HistoryAggregationNotSupported",
+  "message": "Aggregation 'TimeWeightedAverage' is not supported. Available: Last, First, Average, Minimum, Maximum, Sum, Count, StdDev.",
+  "requested": "TimeWeightedAverage",
+  "available": ["Last", "First", "Average", "Minimum", "Maximum", "Sum", "Count", "StdDev"]
+}
+```
+
+No silent fallback to a different aggregation. The caller (LLM or otherwise) sees the failure and the available set, and can retry with a supported aggregation.
+
+Empty `points` and missing paths are not errors; they return successfully with an empty array (and `value_type` reflects the property's type if it exists).
+
+`MaxPoints` is not exposed as a tool parameter. Callers that need more detail narrow `from`/`to` instead; the cap (10 000 raw, 1 000 bucketed via the auto-bucket math) keeps any single response bounded and the `truncated` flag signals when it was hit.
 
 ## Configuration Summary
 
-Per store, expressed as `[Configuration]` properties so the registry, edit components, and config persistence all see the same surface.
+Per store, expressed as `[Configuration]` properties.
 
 | Knob | Timescale | InMemory |
 |---|---|---|
@@ -513,6 +844,7 @@ Per store, expressed as `[Configuration]` properties so the registry, edit compo
 | `MaxPointsPerProperty` | n/a | 1 000 |
 | `BufferTime` | 250 ms | 250 ms |
 | `FlushInterval` | 5 s | n/a |
+| `ShutdownFlushTimeout` | 10 s | n/a |
 | `MaxJsonSize` | 8 KB | 8 KB |
 
 ## Tests
@@ -520,51 +852,103 @@ Per store, expressed as `[Configuration]` properties so the registry, edit compo
 ### Unit tests
 
 - `HistoryEligibility.HasHistory` over every recordable and refused type.
-- `InMemoryHistoryStore` recording, retention trimming, raw and bucketed queries, oversize placeholder for long strings, refused types blocked by `HasHistory()`.
-- `HistoryQueryExtensions.QueryHistoryAsync` merge logic with fake `IHistoryStore` implementations covering: single store, two stores with disjoint coverage, two stores with overlapping coverage, store throwing, empty registry.
-- MCP tool: parameter parsing, case-insensitive aggregation, empty result on unknown path.
+- `HistoryColumns.ValueColumnFor` and `IsUlongProperty` over every supported type.
+- `BucketAlignment.BucketStart` correctness; epoch-anchored parity with Postgres `time_bucket`.
+- `InMemoryHistoryStore`: recording, retention trimming, raw and bucketed queries, oversize placeholder for long strings, refused types blocked by `HasHistory()`, TWA computation with look-back.
+- `InMemoryHistoryStore.GetSampleAtOrBeforeAsync` correctness with empty buffer, exact-match, before-buffer-start, after-buffer-end.
+- `HistoryQueryExtensions.QueryHistoryAsync` raw planner: single store, two disjoint, two overlapping, store throwing, empty registry.
+- `HistoryQueryExtensions.QueryHistoryAsync` bucketed planner: per-bucket dispatch, consecutive grouping, effective-range clipping at the right edge, single bucket spanning both stores.
+- `HistoryQueryExtensions.ExecuteWithBudget`: sequential budget exhaustion, newest-first sub-range ordering, dedup via TryAdd, truncated propagation.
+- `HistoryQueryExtensions.CheckEligibility`: store-without-aggregation skipped, throws when no eligible store covers, universal aggregations bypass check.
+- MCP tool: parameter parsing, case-insensitive aggregation, empty result on unknown path, error response shape, `value_type` correctness across response types.
 
 No Docker required for any unit test.
 
 ### Integration tests
 
-`HomeBlaze.History.TimescaleDb.Tests` with `[Trait("Category", "Integration")]`, excluded from the default `dotnet test` filter, matching the existing repo convention.
+`HomeBlaze.History.TimescaleDb.Tests` with `[Trait("Category", "Integration")]`, excluded from the default `dotnet test` filter.
 
-Container management via Testcontainers using the `timescale/timescaledb:latest-pg16` image. One container per test class via `IClassFixture<TimescaleDbFixture>`. Per-test schema (`test_<guid>`) for isolation without container churn.
+Two Testcontainers fixtures:
 
-| Category | Verifies |
-|---|---|
-| Bootstrap | Store starts against empty DB, creates hypertable and index. Second start is a no-op. |
-| Recording (`value_long`) | Integer and bool `[State]` writes land with `value_long` populated. Within-batch coalesce collapses repeated writes. |
-| Recording (`ulong` overflow) | A `ulong`-typed property is written values both below and above `long.MaxValue`. Sub-overflow values land in `value_long`; overflow values land in `value_json`. Bucketed `Average` for the property uses the COALESCE-aware SQL and the result equals the true mean across both columns. |
-| Recording (`value_double`) | `double` and `float` `[State]` writes land with `value_double` populated. |
-| Recording (`value_json`) | String, enum, and decimal `[State]` writes land with `value_json` populated. Enums as name strings, decimals as lossless JSON numbers. |
-| Recording (null) | Null writes produce all-NULL row. Aggregates skip; `count` includes. |
-| Recording ([Configuration] skip) | `[Configuration]` writes are not recorded. |
-| Oversize | Long string value produces placeholder row; `OversizeCount` increments. |
-| Refused types | `byte[]`, records, value objects are refused upstream by `HasHistory()`; verified explicitly. |
-| Raw query | Ordered points within range, capped at `MaxPoints`, `Truncated` flag correct. |
-| Aggregated query | `time_bucket` correctness for each aggregation including `Last`, dispatched to the correct value column per property type. |
-| Unsupported aggregation | `Average` requested on a `value_json`-stored property (decimal, string, enum) raises `HistoryAggregationNotSupportedException`. |
-| Raw coverage merge | In-memory + Timescale populated for the same path; recent samples served by in-memory only, older samples by Timescale only, in-memory wins on overlapping timestamps. |
-| Per-bucket dispatch (small bucket) | Query `last 5min, bucket=10s` with in-memory `MaxAge=60s`: older buckets come from Timescale, newest 6 buckets from in-memory. Effective range clipping verified at the right edge. |
-| Per-bucket dispatch (large bucket) | Query `last 1h, bucket=1min` with in-memory `MaxAge=60s`: only the latest bucket (or none, depending on alignment) fits in-memory; the rest assigned to Timescale. |
-| Per-bucket dispatch (no overlap) | Query fully inside in-memory's coverage: zero Timescale queries. |
-| Bucket alignment | In-memory and Timescale bucket boundaries are epoch-anchored and identical for the same bucket size. Concatenation never produces duplicate-timestamp buckets. |
-| Retention | Synthetic old rows inserted; `add_retention_policy` job removes them. |
-| Backpressure | Throttled DB; queue overflows; oldest dropped; `DropCount` increments. |
-| Reconnect | Container restart mid-run; store reconnects and resumes. |
+- `TimescaleDbHaFixture` uses `timescale/timescaledb-ha:pg16-latest` (toolkit available). Default for happy-path tests.
+- `TimescaleDbBaseFixture` uses `timescale/timescaledb:latest-pg16` (toolkit absent). For the toolkit-absent test class.
 
-The test project's README must note the Docker requirement. The fixture skips with a clear message when the Docker daemon is unreachable, rather than hanging.
+Per-test schema (`test_<guid>`) for isolation without container churn.
 
-## Open Questions
+| Category | Verifies | Fixture |
+|---|---|---|
+| Bootstrap | Schema created idempotently. Second start is a no-op. `history_schema_version` populated. | HA |
+| Toolkit probe (available) | `ToolkitAvailable = true`, version reported in `ToolkitStatus`, `TimeWeightedAverage` in `SupportedAggregations`. | HA |
+| Toolkit probe (absent) | `ToolkitAvailable = false`, message in `ToolkitStatus`, `TimeWeightedAverage` excluded from `SupportedAggregations`. Querying TWA over range with only Timescale coverage raises `HistoryAggregationNotSupportedException`. | Base |
+| Coverage high-water-mark | After flush, `Coverage.To` matches max sample timestamp. Empty flush doesn't advance. DB outage freezes Coverage.To. Restart re-seeds from `MAX(ts)`. | HA |
+| Recording (`value_long`) | Integer and bool `[State]` writes land with `value_long` populated. Within-batch coalesce collapses repeated writes. | HA |
+| Recording (`ulong` overflow) | Sub-overflow values land in `value_long`; overflow values land in `value_json`. Bucketed `Average` for the property uses COALESCE-aware SQL. | HA |
+| Recording (`value_double`) | `double` and `float` `[State]` writes land with `value_double` populated. | HA |
+| Recording (`value_json`) | String, enum, and decimal `[State]` writes land with `value_json` populated. | HA |
+| Recording (null) | Null writes produce all-NULL row. Aggregates skip; `count` includes. | HA |
+| Recording (`[Configuration]` skip) | `[Configuration]` writes are not recorded. | HA |
+| Oversize | Long string value produces placeholder row; `OversizeCount` increments. | HA |
+| Refused types | `byte[]`, records, value objects refused upstream by `HasHistory()`. | HA |
+| Raw query (newest-N semantics) | When samples exceed `MaxPoints`, the newest N are returned in chronological order. `Truncated = true`. | HA |
+| Bucketed query | `time_bucket` correctness for each aggregation, dispatched to the correct value column per property type. | HA |
+| TWA parity | Identical samples written to both stores produce identical TWA values across edge cases (empty bucket, single-sample bucket, boundary-sample bucket, look-back-only bucket). | HA |
+| `Last` LOCF | Empty buckets in `Last`-aggregation responses contain the carried value. Pre-first-sample buckets stay null. | HA |
+| `Count` empty bucket | Returns 0, not null. | HA |
+| `time_bucket_gapfill` integration | Bucketed queries emit explicit entries for empty buckets within the range (null values for gap-leaving aggregations). | HA |
+| Look-back primitive | `GetSampleAtOrBeforeAsync` returns most recent sample at or before timestamp; null when none exists. | Both |
+| Unsupported aggregation | `Average` requested on a `value_json`-stored property raises `HistoryAggregationNotSupportedException`. | HA |
+| Raw coverage merge | InMemory + Timescale populated for the same path; sequential-budget executor produces newest MaxPoints overall. | HA |
+| Per-bucket dispatch (small bucket) | Older buckets from Timescale, newest buckets from InMemory. Effective-range clipping verified at the right edge. | HA |
+| Per-bucket dispatch (large bucket) | `last 1h, bucket=1min` with `MaxAge=60s`: live-edge bucket served by Timescale with bounded error. | HA |
+| Per-bucket dispatch (no overlap) | Query fully inside InMemory's coverage: zero Timescale queries. | HA |
+| Bucket alignment | InMemory and Timescale produce identical bucket timestamps. Concatenation never produces duplicate-timestamp buckets. | HA |
+| Multi-store dedup | Two FakeHistoryStore returning samples at identical timestamps: merge dedups via TryAdd, higher-priority value wins. | Unit |
+| Retention | Synthetic old rows inserted; `add_retention_policy` job removes them. | HA |
+| Backpressure | Throttled DB; queue overflows; oldest dropped; `DropCount` increments. | HA |
+| Reconnect | Container restart mid-run; store reconnects and resumes. Toolkit re-probed. | HA |
+| Shutdown flush | Pending batch flushed on `StopAsync`. Timeout path: pending dropped, status reflects loss. | HA |
 
-- Recording complex types (records, value objects, dictionaries, lists of primitives): deferred. The MVP allow-list is numerics, bool, string, enum, decimal. Adding a structured-type path requires schema thought (one column or per-field expansion?) and an oversize policy that goes beyond a string length cap.
-- Aggregation (`Average`/`Minimum`/`Maximum`/`Sum`) on `value_json`-stored properties: deferred. Decimal aggregation can be added by casting `value_json #>> '{}'` to `numeric` in the bucketed query; the column dispatch already isolates the change to one SQL path. String and enum aggregations stay limited to `Last` and `Count`.
-- `StoreNonNumericValues` toggle to limit a store to numeric/bool history only: dropped from MVP because the tight allow-list makes the runaway-volume scenario it defended against impossible. Add back if a real "this DB is for charts only" use case appears.
-- Per-property opt-in/out attribute (`[Historize]` / `[NoHistory]`): defer to a follow-up unless a concrete need surfaces during MVP use.
-- Store-level include/exclude filter via glob patterns on property paths: deferred to a configuration follow-up.
-- Multi-property compare in the dialog: deferred until the single-property dialog has shaken out.
-- Streaming export of large raw ranges: a separate `ExportAsync` method on `IHistoryStore` is the natural seam, not the existing `QueryAsync`.
-- Continuous aggregates inside Timescale for long-retention downsampling: post-MVP, internal to the Timescale store, transparent to consumers.
-- Global `MaxTotalSamples` cap on the in-memory store with cross-property eviction: deferred. The MVP exposes `TotalSampleCount` and `EstimatedMemoryBytes` so operators can monitor and tune `MaxAge`/`MaxPointsPerProperty`/`BufferTime`. A global cap would need an eviction policy (drop from biggest buffer, oldest globally, LRU) and that decision is worth a separate think once we see real workloads.
+The test project's README must note the Docker requirement. The fixtures skip with a clear message when the Docker daemon is unreachable, rather than hanging.
+
+## Known Limitations
+
+- **Property renames orphan prior history.** A property's `path` is its identity in the history store. Renaming a subject or property creates a new identity; samples recorded under the old path become unreachable through normal queries (they remain in the database under the old path until retention expires).
+- **Type changes hide prior data.** Changing a property's declared type (e.g., `int` to `double`) shifts the read query to a different value column; samples recorded under the old type become invisible to the new query path. Avoid in production deployments.
+- **Crash data loss.** On process crash (SIGKILL, OOM, etc.), the Timescale store's pending batch is lost. Up to `FlushInterval` of samples can be lost. Graceful shutdown via the configured flush timeout drains the batch normally.
+- **InMemory-only data loss on restart.** Configurations using only `InMemoryHistoryStore` lose all history on every restart. InMemory is documented as a hot buffer / dev / test store, not a production substitute.
+- **Live-edge bucket inaccuracy for large buckets.** When `bucket_size > MaxAge`, the rightmost bucket of a bucketed query may be missing up to `FlushInterval` of samples. Relative error is `FlushInterval / bucket_size` (≤1.7% for 5-min buckets, ≤0.14% for 1-h buckets, ≤0.006% for 24-h buckets). Operators who need pixel-perfect live-edge precision raise `MaxAge` accordingly. Post-MVP combinable-partial-aggregate refinement is noted.
+- **Multi-instance store semantics.** Multiple `TimescaleDbHistoryStore` instances may be registered, but each records independently — multiple stores against the same database produce duplicate rows. HA / read-replica failover should be handled at the Npgsql connection layer (host list + failover mode), not by registering multiple store instances.
+- **Cross-instance history sync.** No explicit history sync mechanism beyond what the existing WebSocket topology provides as a side effect.
+
+## Open Questions / Future Work
+
+### Fast follow
+
+- **Runtime cross-store config validation.** Per-store check at `ExecuteAsync` startup that warns when `MaxAge < 2 * FlushInterval` of sibling Timescale stores. Adds a `ConfigurationWarning` `[State]` property.
+- **Median / Percentile aggregations.** Format (`Percentile:p` colon syntax vs preset names like `Percentile95`) decided when implementing. Toolkit-backed `approx_percentile` for scale; native `percentile_cont` for exact.
+- **TimescaleDB compression policy.** `add_compression_policy` typically yields 10× storage reduction on chunks older than the threshold. Requires `[Configuration] EnableCompression` and `CompressionAge` knobs plus bootstrap policy management. MVP already uses daily chunks to make this granular when it lands.
+- **LTTB downsampling.** Toolkit-backed `lttb(value, ts, N)` for visual-shape-preserving sample reduction. Conceptually distinct from statistical aggregation (returns a subset of raw samples, not bucket aggregates). API shape decided at implementation time.
+- **Per-range UI filter for aggregation dropdown.** Re-evaluate `TimeWeightedAverage` availability as the user changes the time range, so it shows for InMemory-only-coverage ranges even when Timescale doesn't support it.
+- **Multi-property compare in the dialog.**
+- **CSV/JSON export from the dialog.**
+
+### Phase 2
+
+- **`Rate` / `Delta` aggregations for cumulative properties.** Uses existing `StateAttribute.IsCumulative`. Toolkit's `counter_agg` for Timescale (handles counter resets); in-process equivalent for InMemory. Look-back infrastructure already in MVP.
+- **`StateDuration` aggregation for discrete properties.** Uses existing `StateAttribute.IsDiscrete`. Open question: result shape (extend `HistoryPoint`, parallel `StructuredHistorySeries` type, or repurpose `HistoryPoint.Json` for per-state durations).
+- **Server-side gap-fill with `Interpolate` mode.** Opt-in via new query field for linearly-varying numeric signals (temperature smoothing). MVP already does LOCF for `Last` automatically.
+- **Recording complex types.** Records, value objects, dictionaries, lists of primitives. Schema thought required (one column or per-field expansion).
+- **Numeric aggregation on `value_json`-stored properties.** Casting `value_json #>> '{}'` to `numeric` would let `Average`/etc. apply to decimal columns.
+- **Streaming export of large raw ranges.** A separate `ExportAsync` method on `IHistoryStore` as the seam.
+- **Continuous aggregates inside Timescale.** For long-retention downsampling, internal to the Timescale store, transparent to consumers.
+- **Global `MaxTotalSamples` cap on InMemory** with cross-property eviction. Needs an eviction policy decision (drop from biggest buffer, oldest globally, LRU).
+
+### Deferred
+
+- **Property path normalisation.** `properties(id, path)` lookup table with smallint/int foreign key. Trigger: when `EstimatedStorageBytes` alarms an operator.
+- **Property rename audit log + on-read column-fallback** to address rename and type-change limitations.
+- **Schema migration framework.** MVP uses idempotent SQL (`CREATE ... IF NOT EXISTS` patterns) plus a seeded `history_schema_version` table. Engine deferred until the first migration requiring data movement or conditional logic.
+- **`Mode`** for discrete properties (PG built-in `mode() within group`); **threshold-crossings** (`CrossingsAbove:N` etc.). Both useful but no concrete demand yet; threshold-crossings additionally blocked on parameterized-aggregation syntax decision.
+- **Per-property opt-in/out attributes (`[Historize]` / `[NoHistory]`).**
+- **Store-level include/exclude filter via glob patterns on property paths.**
+- **`StoreNonNumericValues` toggle** to limit a store to numeric/bool history only.


### PR DESCRIPTION
## Summary

Adds two planning documents for the upcoming time-series history feature in HomeBlaze.

- **`history-mvp.md`** — Design doc. Three packages (`HomeBlaze.History.Abstractions`, `HomeBlaze.History.InMemory`, `HomeBlaze.History.TimescaleDb`) with per-property column dispatch (`value_long` / `value_double` / `value_json`), per-bucket cross-store merge, `get_property_history` MCP tool, and a property history dialog using `MudTimeSeriesChart`. Companion to the architectural target at `architecture/design/history.md`; narrows it to a first shippable slice.
- **`history-mvp-impl-plan.md`** — Implementation plan, 43 TDD-style tasks across 9 phases with exact file paths, code skeletons, and verification steps. Phase 0 promotes `ThroughputCounter` to `Namotion.Interceptor.Connectors` so OPC UA and the history stores share one rate counter.

No code changes in this PR; planning only. Implementation will follow on a separate branch.

## Test plan

- [ ] Docs render correctly in the architecture site (markdown is well-formed).
- [ ] Cross-references to `architecture/design/history.md` resolve.
- [ ] Plan covers all design decisions; review for omitted scope.