### PR TITLE
Add OPC UA client diagnostics and sampling interval config

### DIFF
--- a/src/HomeBlaze/HomeBlaze.OpcUa.Blazor/OpcUaClientEditComponent.razor
+++ b/src/HomeBlaze/HomeBlaze.OpcUa.Blazor/OpcUaClientEditComponent.razor
@@ -45,6 +45,14 @@
                   OnKeyUp="OnFieldChanged"
                   Class="mt-4" />
 
+    <MudNumericField @bind-Value="_samplingInterval"
+                     Label="Sampling Interval (ms)"
+                     HelperText="Leave empty for server default, 0 for exception-based monitoring"
+                     Immediate="true"
+                     OnKeyUp="OnFieldChanged"
+                     Clearable="true"
+                     Class="mt-4" />
+
     <MudCheckBox @bind-Value="_isEnabled"
                  @bind-Value:after="OnFieldChanged"
                  Label="Enabled (auto-start on application startup)"
@@ -78,6 +86,7 @@
     private string? _rootPath;
     private string? _username;
     private string? _password;
+    private int? _samplingInterval;
     private bool _isEnabled = true;
 
     private string _originalName = string.Empty;
@@ -85,6 +94,7 @@
     private string? _originalRootPath;
     private string? _originalUsername;
     private string? _originalPassword;
+    private int? _originalSamplingInterval;
     private bool _originalIsEnabled = true;
 
     public bool IsValid => !string.IsNullOrWhiteSpace(_name) && !string.IsNullOrWhiteSpace(_serverUrl);
@@ -94,6 +104,7 @@
                            _rootPath != _originalRootPath ||
                            _username != _originalUsername ||
                            _password != _originalPassword ||
+                           _samplingInterval != _originalSamplingInterval ||
                            _isEnabled != _originalIsEnabled;
 
     public string PreferredDialogSize => "Medium";
@@ -110,6 +121,7 @@
             _rootPath = ClientSubject.RootPath;
             _username = ClientSubject.Username;
             _password = ClientSubject.Password;
+            _samplingInterval = ClientSubject.SamplingInterval;
             _isEnabled = ClientSubject.IsEnabled;
 
             _originalName = _name;
@@ -117,6 +129,7 @@
             _originalRootPath = _rootPath;
             _originalUsername = _username;
             _originalPassword = _password;
+            _originalSamplingInterval = _samplingInterval;
             _originalIsEnabled = _isEnabled;
         }
     }
@@ -136,6 +149,7 @@
             ClientSubject.RootPath = _rootPath;
             ClientSubject.Username = _username;
             ClientSubject.Password = _password;
+            ClientSubject.SamplingInterval = _samplingInterval;
             ClientSubject.IsEnabled = _isEnabled;
 
             _originalName = _name;
@@ -143,6 +157,7 @@
             _originalRootPath = _rootPath;
             _originalUsername = _username;
             _originalPassword = _password;
+            _originalSamplingInterval = _samplingInterval;
             _originalIsEnabled = _isEnabled;
 
             IsDirtyChanged?.Invoke(false);

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -59,6 +59,13 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     public partial string? Password { get; set; }
 
     /// <summary>
+    /// Default sampling interval in milliseconds for monitored items.
+    /// Null uses the server default. 0 enables exception-based monitoring (immediate reporting).
+    /// </summary>
+    [Configuration]
+    public partial int? SamplingInterval { get; set; }
+
+    /// <summary>
     /// Whether the client is enabled and should auto-start on application startup.
     /// </summary>
     [Configuration]
@@ -102,6 +109,24 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     /// </summary>
     [State]
     public partial double? MonitoredItemCount { get; set; }
+
+    /// <summary>
+    /// Number of items using polling fallback. Null when not running.
+    /// </summary>
+    [State]
+    public partial int? PollingItemCount { get; set; }
+
+    /// <summary>
+    /// Number of writes queued for retry during disconnection. Null when not running.
+    /// </summary>
+    [State]
+    public partial int? WriteQueueCount { get; set; }
+
+    /// <summary>
+    /// Total number of reconnections since start. Null when not running.
+    /// </summary>
+    [State(IsCumulative = true)]
+    public partial long? TotalReconnections { get; set; }
 
     /// <summary>
     /// Dynamic root subject containing discovered OPC UA properties.
@@ -197,6 +222,9 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
             IncomingChangesPerSecond = diagnostics.IncomingChangesPerSecond;
             OutgoingChangesPerSecond = diagnostics.OutgoingChangesPerSecond;
             MonitoredItemCount = diagnostics.MonitoredItemCount;
+            PollingItemCount = diagnostics.PollingItemCount;
+            WriteQueueCount = diagnostics.WriteQueueCount;
+            TotalReconnections = diagnostics.TotalReconnectionAttempts;
         }
     }
 
@@ -222,6 +250,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
             {
                 ServerUrl = ServerUrl,
                 RootPath = rootPathSegments,
+                DefaultSamplingInterval = SamplingInterval,
                 TypeResolver = new HomeBlazeOpcUaTypeResolver(_logger),
                 ValueConverter = new OpcUaValueConverter(),
                 SubjectFactory = new HomeBlazeOpcUaSubjectFactory(),
@@ -264,6 +293,10 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
                 Root = null;
                 Status = ServiceStatus.Stopped;
                 IsConnected = null;
+                MonitoredItemCount = null;
+                PollingItemCount = null;
+                WriteQueueCount = null;
+                TotalReconnections = null;
                 IncomingChangesPerSecond = null;
                 OutgoingChangesPerSecond = null;
             }

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -120,7 +120,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     /// Number of writes queued for retry during disconnection. Null when not running.
     /// </summary>
     [State]
-    public partial int? WriteQueueCount { get; set; }
+    public partial int? PendingWriteCount { get; set; }
 
     /// <summary>
     /// Total number of reconnections since start. Null when not running.
@@ -223,7 +223,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
             OutgoingChangesPerSecond = diagnostics.OutgoingChangesPerSecond;
             MonitoredItemCount = diagnostics.MonitoredItemCount;
             PollingItemCount = diagnostics.PollingItemCount;
-            WriteQueueCount = diagnostics.WriteQueueCount;
+            PendingWriteCount = diagnostics.PendingWriteCount;
             TotalReconnections = diagnostics.TotalReconnectionAttempts;
         }
     }
@@ -295,7 +295,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
                 IsConnected = null;
                 MonitoredItemCount = null;
                 PollingItemCount = null;
-                WriteQueueCount = null;
+                PendingWriteCount = null;
                 TotalReconnections = null;
                 IncomingChangesPerSecond = null;
                 OutgoingChangesPerSecond = null;

--- a/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -85,6 +85,7 @@ namespace Namotion.Interceptor.Connectors
     public abstract class SubjectSourceBase : Microsoft.Extensions.Hosting.BackgroundService, Namotion.Interceptor.Connectors.ISubjectConnector, Namotion.Interceptor.Connectors.ISubjectSource
     {
         protected SubjectSourceBase(Namotion.Interceptor.IInterceptorSubjectContext context, Microsoft.Extensions.Logging.ILogger logger, System.TimeSpan? bufferTime = default, System.TimeSpan? retryTime = default, int writeRetryQueueSize = 1000) { }
+        public int PendingWriteCount { get; }
         public abstract Namotion.Interceptor.IInterceptorSubject RootSubject { get; }
         public virtual int WriteBatchSize { get; }
         public override void Dispose() { }

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -22,6 +22,11 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
 
     internal WriteRetryQueue? WriteRetryQueue { get; }
 
+    /// <summary>
+    /// Gets the number of writes currently queued for retry.
+    /// </summary>
+    public int PendingWriteCount => WriteRetryQueue?.PendingWriteCount ?? 0;
+
     protected SubjectSourceBase(
         IInterceptorSubjectContext context,
         ILogger logger,

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -145,6 +145,7 @@ namespace Namotion.Interceptor.OpcUa.Client
         public int MonitoredItemCount { get; }
         public double OutgoingChangesPerSecond { get; }
         public int? PendingReadAfterWrites { get; }
+        public int PendingWriteCount { get; }
         public Namotion.Interceptor.OpcUa.Client.PollingDiagnostics? Polling { get; }
         public int PollingItemCount { get; }
         public Namotion.Interceptor.OpcUa.Client.ReadAfterWriteDiagnostics? ReadAfterWrite { get; }
@@ -152,7 +153,6 @@ namespace Namotion.Interceptor.OpcUa.Client
         public int SubscriptionCount { get; }
         public long SuccessfulReconnections { get; }
         public long TotalReconnectionAttempts { get; }
-        public int WriteQueueCount { get; }
     }
     public sealed class OpcUaCurrentSessionChangedEventArgs : System.EventArgs
     {

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -152,6 +152,7 @@ namespace Namotion.Interceptor.OpcUa.Client
         public int SubscriptionCount { get; }
         public long SuccessfulReconnections { get; }
         public long TotalReconnectionAttempts { get; }
+        public int WriteQueueCount { get; }
     }
     public sealed class OpcUaCurrentSessionChangedEventArgs : System.EventArgs
     {

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -81,6 +81,11 @@ public class OpcUaClientDiagnostics
     public int? PendingReadAfterWrites => _source.SessionManager?.ReadAfterWriteManager?.PendingReadCount;
 
     /// <summary>
+    /// Gets the number of writes currently queued for retry (buffered during disconnection).
+    /// </summary>
+    public int WriteQueueCount => _source.PendingWriteCount;
+
+    /// <summary>
     /// Gets the most recent error that occurred while establishing or restoring the session,
     /// or null if no error has occurred since the last successful (re)connection.
     /// Cleared on every successful connection or reconnection.

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -83,7 +83,7 @@ public class OpcUaClientDiagnostics
     /// <summary>
     /// Gets the number of writes currently queued for retry (buffered during disconnection).
     /// </summary>
-    public int WriteQueueCount => _source.PendingWriteCount;
+    public int PendingWriteCount => _source.PendingWriteCount;
 
     /// <summary>
     /// Gets the most recent error that occurred while establishing or restoring the session,


### PR DESCRIPTION
## Summary

- Add configurable `SamplingInterval` property to HomeBlaze OPC UA client with Blazor UI support (nullable, clearable for server default)
- Expose new diagnostic state properties: `PollingItemCount`, `PendingWriteCount`, `TotalReconnections` (cumulative)
- Add `PendingWriteCount` to `SubjectSourceBase` public API
- Reset `MonitoredItemCount` and all new diagnostic properties to `null` on stop

## Test plan

- [x] Verify OPC UA tests pass (`dotnet test src/Namotion.Interceptor.OpcUa.Tests --filter "Category!=Integration"`)
- [x] Verify Connectors tests pass (`dotnet test src/Namotion.Interceptor.Connectors.Tests`)
- [x] Verify HomeBlaze OPC UA client builds and sampling interval field appears in edit dialog
- [x] Verify diagnostic state values update every 10s and reset to null on stop