### PR TITLE
fix: Clean up ancestor fallback contexts on subject detach

### DIFF
--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -213,7 +213,7 @@ This goes through the same pipeline as automatic recalculation: the getter is re
 
 ## Context Inheritance
 
-Automatically assigns the parent context to child subjects, ensuring they participate in the same tracking and interception pipeline:
+Automatically assigns the parent context to child subjects when they are attached via properties, ensuring they participate in the same tracking and interception pipeline. On detach, the parent context and all ancestor contexts are removed from the child, fully disconnecting it from the tree.
 
 ```csharp
 var context = InterceptorSubjectContext
@@ -223,10 +223,31 @@ var context = InterceptorSubjectContext
 var car = new Car(context);
 var tire = new Tire(); // No context assigned yet
 
-car.Tire = tire; // tire.Context is automatically set to context
+car.Tire = tire; // tire inherits services from car's context chain
 ```
 
-This ensures that all objects in the subject graph share the same context, enabling consistent tracking, validation, and other interceptor features.
+### Attach behavior
+
+When a subject is assigned to a property (`car.Tire = tire`), the `ContextInheritanceHandler` calls `tire.Context.AddFallbackContext(car.Context)`. This gives the child access to all services registered on the parent and its ancestors.
+
+### Detach behavior
+
+When a subject is removed from a property (`car.Tire = null`), the handler removes the parent context and all ancestor contexts (captured at attach time) from the child's fallback set. After detach, the child has no inherited services and can be garbage collected.
+
+Independently added fallback contexts (those not in the parent's fallback chain) are preserved after detach.
+
+### Manual fallback context management
+
+For advanced scenarios (staging areas, shared contexts without tree membership), you can manage fallback contexts directly:
+
+```csharp
+var subject = new MySubject();
+subject.Context.AddFallbackContext(sharedContext);    // explicit add
+// ... use subject ...
+subject.Context.RemoveFallbackContext(sharedContext);  // explicit cleanup
+```
+
+Manual adds require manual cleanup. The inheritance handler only manages the links it creates.
 
 ## Subject Lifecycle Tracking
 

--- a/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -58,6 +58,7 @@ namespace Namotion.Interceptor
         object? ExecuteInterceptedInvoke(ref Namotion.Interceptor.Interceptors.MethodInvocationContext context, System.Func<Namotion.Interceptor.IInterceptorSubject, object?[], object?> invokeMethod);
         TProperty ExecuteInterceptedRead<TProperty>(ref Namotion.Interceptor.Interceptors.PropertyReadContext context, System.Func<Namotion.Interceptor.IInterceptorSubject, TProperty> readValue);
         void ExecuteInterceptedWrite<TProperty>(ref Namotion.Interceptor.Interceptors.PropertyWriteContext<TProperty> context, System.Action<Namotion.Interceptor.IInterceptorSubject, TProperty> writeValue);
+        System.Collections.Generic.IReadOnlyCollection<Namotion.Interceptor.IInterceptorSubjectContext> GetFallbackContexts();
         System.Collections.Immutable.ImmutableArray<TInterface> GetServices<TInterface>();
         bool RemoveFallbackContext(Namotion.Interceptor.IInterceptorSubjectContext context);
         bool TryAddService<TService>(System.Func<TService> factory, System.Func<TService, bool> exists);
@@ -75,6 +76,7 @@ namespace Namotion.Interceptor
         public object? ExecuteInterceptedInvoke(ref Namotion.Interceptor.Interceptors.MethodInvocationContext context, System.Func<Namotion.Interceptor.IInterceptorSubject, object?[], object?> invokeMethod) { }
         public TProperty ExecuteInterceptedRead<TProperty>(ref Namotion.Interceptor.Interceptors.PropertyReadContext context, System.Func<Namotion.Interceptor.IInterceptorSubject, TProperty> readValue) { }
         public void ExecuteInterceptedWrite<TProperty>(ref Namotion.Interceptor.Interceptors.PropertyWriteContext<TProperty> context, System.Action<Namotion.Interceptor.IInterceptorSubject, TProperty> writeValue) { }
+        public System.Collections.Generic.IReadOnlyCollection<Namotion.Interceptor.IInterceptorSubjectContext> GetFallbackContexts() { }
         public System.Collections.Immutable.ImmutableArray<TInterface> GetServices<TInterface>() { }
         protected bool HasFallbackContext(Namotion.Interceptor.IInterceptorSubjectContext context) { }
         public virtual bool RemoveFallbackContext(Namotion.Interceptor.IInterceptorSubjectContext context) { }

--- a/src/Namotion.Interceptor.Tracking.Tests/ContextInheritanceCleanupTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/ContextInheritanceCleanupTests.cs
@@ -1,0 +1,283 @@
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking.Lifecycle;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests;
+
+public class ContextInheritanceCleanupTests
+{
+    [Fact]
+    public void WhenDetachingChildCreatedWithRootContext_ThenRootContextFallbackIsRemoved()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parent = new Person(rootContext);
+        var child = new Person(rootContext);
+        parent.Mother = child;
+
+        // Act
+        parent.Mother = null;
+
+        // Assert
+        Assert.Empty(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenDetachingChildCreatedWithoutContext_ThenNoServicesRemain()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parent = new Person(rootContext);
+        var child = new Person();
+        parent.Mother = child;
+
+        // Act
+        parent.Mother = null;
+
+        // Assert
+        Assert.Empty(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenDetachingFromDeepTree_ThenAllAncestorContextsAreRemoved()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var grandparent = new Person(rootContext);
+        var parent = new Person();
+        var child = new Person(rootContext);
+
+        grandparent.Mother = parent;
+        parent.Mother = child;
+
+        // Act
+        parent.Mother = null;
+
+        // Assert
+        Assert.Empty(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenDetachingSubtree_ThenAllDescendantsLoseAncestorContexts()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var root = new Person(rootContext);
+        var parent = new Person(rootContext);
+        var child = new Person(rootContext);
+
+        root.Mother = parent;
+        parent.Mother = child;
+
+        // Act
+        root.Mother = null;
+
+        // Assert
+        Assert.Empty(parent.GetServices<ILifecycleInterceptor>());
+        Assert.Empty(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenDetaching_ThenIndependentFallbackContextIsPreserved()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var independentContext = InterceptorSubjectContext.Create();
+        independentContext.AddService(42);
+
+        var parent = new Person(rootContext);
+        var child = new Person();
+        ((IInterceptorSubject)child).Context.AddFallbackContext(independentContext);
+        parent.Mother = child;
+
+        // Act
+        parent.Mother = null;
+
+        // Assert
+        Assert.Empty(child.GetServices<ILifecycleInterceptor>());
+        Assert.Contains(42, child.GetServices<int>());
+    }
+
+    [Fact]
+    public void WhenMovingBetweenParents_ThenChildGetsNewParentServices()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parentA = new Person(rootContext);
+        var parentB = new Person(rootContext);
+        var child = new Person(rootContext);
+
+        parentA.Mother = child;
+
+        // Act
+        parentA.Mother = null;
+        parentB.Mother = child;
+
+        // Assert
+        Assert.NotEmpty(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenMovingBetweenParents_ThenServicesResolveCorrectly()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parentA = new Person(rootContext);
+        var parentB = new Person(rootContext);
+        var child = new Person();
+
+        parentA.Mother = child;
+
+        // Act
+        parentA.Mother = null;
+        parentB.Mother = child;
+
+        // Assert
+        Assert.Equal(
+            rootContext.GetServices<ILifecycleInterceptor>(),
+            child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenDetachingChildWithChildSpecificService_ThenOwnServiceSurvivesButInheritedLost()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parent = new Person(rootContext);
+        var child = new Person();
+        parent.Mother = child;
+
+        ((IInterceptorSubject)child).Context.AddService("child-service");
+
+        // Act
+        parent.Mother = null;
+
+        // Assert
+        Assert.Empty(child.GetServices<ILifecycleInterceptor>());
+        Assert.Contains("child-service", child.GetServices<string>());
+    }
+
+    [Fact]
+    public void WhenDetachingArray_ThenAllChildrenLoseAncestorContexts()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parent = new Person(rootContext);
+        var child1 = new Person(rootContext);
+        var child2 = new Person(rootContext);
+        parent.Children = [child1, child2];
+
+        // Act
+        parent.Children = [];
+
+        // Assert
+        Assert.Empty(child1.GetServices<ILifecycleInterceptor>());
+        Assert.Empty(child2.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenParentHasCustomService_ThenDetachedChildLosesIt()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var parent = new Person(rootContext);
+        ((IInterceptorSubject)parent).Context.AddService("parent-service");
+
+        var child = new Person();
+        parent.Mother = child;
+
+        Assert.Contains("parent-service", child.GetServices<string>());
+
+        // Act
+        parent.Mother = null;
+
+        // Assert
+        Assert.Empty(child.GetServices<string>());
+    }
+
+    [Fact]
+    public void WhenRootSubjectIsNeverDetached_ThenContextRemainsIntact()
+    {
+        // Arrange
+        var rootContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking();
+
+        var root = new Person(rootContext);
+        var child = new Person();
+        root.Mother = child;
+
+        // Act
+        root.Mother = null;
+
+        // Assert
+        Assert.NotEmpty(root.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
+    public void WhenGetFallbackContexts_ThenReturnsDirectFallbacks()
+    {
+        // Arrange
+        var context1 = InterceptorSubjectContext.Create();
+        var context2 = InterceptorSubjectContext.Create();
+        var context3 = InterceptorSubjectContext.Create();
+
+        context1.AddFallbackContext(context2);
+        context1.AddFallbackContext(context3);
+
+        // Act
+        var fallbacks = context1.GetFallbackContexts();
+
+        // Assert
+        Assert.Equal(2, fallbacks.Count);
+        Assert.Contains(context2, fallbacks);
+        Assert.Contains(context3, fallbacks);
+    }
+
+    [Fact]
+    public void WhenGetFallbackContextsAfterRemove_ThenReturnsUpdatedSet()
+    {
+        // Arrange
+        var context1 = InterceptorSubjectContext.Create();
+        var context2 = InterceptorSubjectContext.Create();
+        context1.AddFallbackContext(context2);
+
+        // Act
+        context1.RemoveFallbackContext(context2);
+        var fallbacks = context1.GetFallbackContexts();
+
+        // Assert
+        Assert.Empty(fallbacks);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/ContextInheritanceHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/ContextInheritanceHandler.cs
@@ -1,28 +1,79 @@
-﻿using System.Runtime.CompilerServices;
-
 namespace Namotion.Interceptor.Tracking.Lifecycle;
 
 #pragma warning disable CS0659
 
 /// <summary>
 /// Automatically assigns or removes the parent context as fallback context to attached and detached subjects.
+/// On detach, also removes all ancestor contexts that were reachable through the parent's fallback
+/// chain at attach time, fully disconnecting the subject from the tree it was part of.
+/// Independently added fallback contexts (not in the parent's chain) are preserved.
 /// </summary>
 public class ContextInheritanceHandler : ILifecycleHandler
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Dictionary<IInterceptorSubject, IInterceptorSubjectContext[]>? _ancestorSnapshots;
+
     public void HandleLifecycleChange(SubjectLifecycleChange change)
     {
         if (change.Property.HasValue)
         {
-            // Only add fallback when subject first enters the graph via property reference
-            // (IsContextAttach ensures we don't add fallback for subjects already in graph via context)
             if (change is { ReferenceCount: 1, IsContextAttach: true })
             {
                 change.Subject.Context.AddFallbackContext(change.Property.Value.Subject.Context);
             }
+
+            if (change is { ReferenceCount: 1, IsPropertyReferenceAdded: true })
+            {
+                SnapshotAncestors(change.Subject, change.Property.Value.Subject.Context);
+            }
             else if (change is { ReferenceCount: 0, IsPropertyReferenceRemoved: true })
             {
-                change.Subject.Context.RemoveFallbackContext(change.Property.Value.Subject.Context);
+                var parentContext = change.Property.Value.Subject.Context;
+                change.Subject.Context.RemoveFallbackContext(parentContext);
+
+                if (_ancestorSnapshots is not null &&
+                    _ancestorSnapshots.Remove(change.Subject, out var ancestors))
+                {
+                    var context = (InterceptorSubjectContext)change.Subject.Context;
+                    for (var i = 0; i < ancestors.Length; i++)
+                    {
+                        context.RemoveFallbackContextDirect(ancestors[i]);
+                    }
+                }
+            }
+        }
+    }
+
+    private void SnapshotAncestors(IInterceptorSubject subject, IInterceptorSubjectContext parentContext)
+    {
+        var ancestors = CollectAllAncestors(parentContext);
+        if (ancestors.Length > 0)
+        {
+            _ancestorSnapshots ??= new Dictionary<IInterceptorSubject, IInterceptorSubjectContext[]>();
+            _ancestorSnapshots[subject] = ancestors;
+        }
+    }
+
+    private static IInterceptorSubjectContext[] CollectAllAncestors(IInterceptorSubjectContext context)
+    {
+        HashSet<IInterceptorSubjectContext>? visited = null;
+        CollectAncestorsRecursive(context, ref visited);
+        return visited is not null ? [.. visited] : [];
+    }
+
+    private static void CollectAncestorsRecursive(
+        IInterceptorSubjectContext context,
+        ref HashSet<IInterceptorSubjectContext>? visited)
+    {
+        var fallbacks = context.GetFallbackContexts();
+        if (fallbacks.Count == 0)
+            return;
+
+        visited ??= new HashSet<IInterceptorSubjectContext>();
+        foreach (var fallback in fallbacks)
+        {
+            if (visited!.Add(fallback))
+            {
+                CollectAncestorsRecursive(fallback, ref visited);
             }
         }
     }

--- a/src/Namotion.Interceptor/IInterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/IInterceptorSubjectContext.cs
@@ -81,4 +81,10 @@ public interface IInterceptorSubjectContext
     /// <param name="context">The fallback context to remove.</param>
     /// <returns>True if the fallback context was removed, false if it was not present.</returns>
     bool RemoveFallbackContext(IInterceptorSubjectContext context);
+
+    /// <summary>
+    /// Returns a snapshot of the direct fallback contexts currently registered on this context.
+    /// </summary>
+    /// <returns>A read-only collection of the current fallback contexts.</returns>
+    IReadOnlyCollection<IInterceptorSubjectContext> GetFallbackContexts();
 }

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -130,6 +130,33 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         }
     }
 
+    internal bool RemoveFallbackContextDirect(IInterceptorSubjectContext context)
+    {
+        var contextImpl = (InterceptorSubjectContext)context;
+        lock (_lock)
+        {
+            if (_fallbackContexts.Remove(contextImpl))
+            {
+                lock (UsedByContextsLock) { contextImpl._usedByContexts.Remove(this); }
+                OnContextChanged();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public IReadOnlyCollection<IInterceptorSubjectContext> GetFallbackContexts()
+    {
+        lock (_lock)
+        {
+            if (_fallbackContexts.Count == 0)
+                return [];
+
+            return _fallbackContexts.ToArray<IInterceptorSubjectContext>();
+        }
+    }
+
     public bool TryAddService<TService>(Func<TService> factory, Func<TService, bool> exists)
     {
         lock (_lock)


### PR DESCRIPTION
## Summary

- When subjects are detached from a tree, the `ContextInheritanceHandler` now removes the direct parent context AND all ancestor contexts that were reachable through the parent's chain at attach time
- Prevents memory leaks where constructor-added root context links (from `new Subject(rootCtx)`) kept detached subjects alive via strong back-references in `_usedByContexts`
- Independently added fallback contexts (not in the parent's chain) are preserved after detach

## Implementation

The handler snapshots the parent's ancestor chain at first property attach (`ReferenceCount == 1, IsPropertyReferenceAdded`). On last property detach (`ReferenceCount == 0`), it uses the snapshot to remove ancestors via `RemoveFallbackContextDirect` (internal, non-virtual) which bypasses `InterceptorExecutor` lifecycle callbacks, preserving existing event ordering.

Adds `GetFallbackContexts()` to `IInterceptorSubjectContext` for ancestor chain traversal.

## Known limitation

DAG subjects (referenced by multiple parents simultaneously) only snapshot from the first parent. This mirrors the existing reference-counting model's cycle limitation and is documented in `docs/tracking.md`.

## Test plan

- [x] 13 new tests covering: direct detach, cascade detach, deep trees, independent context preservation, parent moves, arrays, custom services
- [x] All 26 existing test projects pass (zero snapshot changes)
- [x] Lifecycle event ordering preserved (no changes to `LifecycleInterceptor`)
- [x] Benchmarks run without regression