### PR TITLE
Remove transport listener disposal workaround (upstream fix shipped)

### DIFF
--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaStandardServer.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaStandardServer.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Opc.Ua;
 using Opc.Ua.Server;
 
 namespace Namotion.Interceptor.OpcUa.Server;
@@ -12,7 +11,6 @@ internal class OpcUaStandardServer : StandardServer
     private IServerInternal? _server;
     private SessionEventHandler? _sessionCreatedHandler;
     private SessionEventHandler? _sessionClosingHandler;
-    private List<ITransportListener>? _savedTransportListeners;
 
     public OpcUaStandardServer(IInterceptorSubject subject, OpcUaSubjectServer source, OpcUaServerConfiguration configuration, ILogger logger)
     {
@@ -21,51 +19,21 @@ internal class OpcUaStandardServer : StandardServer
         AddNodeManager(_nodeManagerFactory);
     }
 
-    // TODO: Remove saved listener workaround when https://github.com/OPCFoundation/UA-.NETStandard/pull/3561 is released.
-    // Workaround: ServerBase.StopAsync calls Close() then Clear() on the listener list.
-    // TcpTransportListener.Close() only stops listening sockets — it does NOT call Dispose().
-    // ServerBase.Dispose() later iterates TransportListeners to dispose them, but the list is
-    // already empty. So TcpTransportListener.Dispose() never runs, leaking timers, channels,
-    // and buffer managers. We save listener references before StopAsync clears the list,
-    // then manually dispose them after shutdown.
-
     /// <summary>
     /// Closes all transport listeners to stop accepting new connections.
     /// Must be called before closing sessions during shutdown to prevent
     /// clients from reconnecting while the server is shutting down.
-    /// Also saves references so they can be properly disposed later,
-    /// since the SDK's StopAsync clears the TransportListeners list
-    /// before Dispose can process them.
     /// </summary>
+    /// <remarks>
+    /// The SDK's StopAsync disposes the listeners itself (close, dispose, then clear),
+    /// so no manual disposal is needed here. See OPCFoundation/UA-.NETStandard#3561.
+    /// </remarks>
     public void CloseTransportListeners()
     {
-        _savedTransportListeners ??= [.. TransportListeners];
-        foreach (var listener in _savedTransportListeners)
+        foreach (var listener in TransportListeners)
         {
             try { listener.Close(); } catch (Exception ex) { _logger.LogDebug(ex, "Error closing transport listener."); }
         }
-    }
-
-    /// <summary>
-    /// Disposes all saved transport listeners. Must be called after shutdown
-    /// because the SDK's StopAsync clears the TransportListeners list before
-    /// Dispose can process them, causing TcpTransportListener.Dispose() to
-    /// never run (leaking timers, channels, and buffer managers).
-    /// </summary>
-    public void DisposeTransportListeners()
-    {
-        if (_savedTransportListeners is null)
-        {
-            return;
-        }
-
-        foreach (var listener in _savedTransportListeners)
-        {
-            try { (listener as IDisposable)?.Dispose(); }
-            catch (Exception ex) { _logger.LogDebug(ex, "Error disposing transport listener."); }
-        }
-
-        _savedTransportListeners = null;
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
@@ -280,16 +280,6 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
                 {
                     _isForceKill = false;
 
-                    // Dispose transport listeners before server.Dispose().
-                    // The SDK's StopAsync calls Close() on each listener (which only
-                    // stops accepting connections) then clears the TransportListeners list.
-                    // When server.Dispose() later tries to Dispose() listeners, the list
-                    // is empty — so TcpTransportListener.Dispose() never runs, leaving
-                    // per-client channel sockets and inactivity timers alive as GC roots
-                    // that retain the entire server object graph.
-                    try { server.DisposeTransportListeners(); }
-                    catch (Exception ex) { _logger.LogDebug(ex, "Error disposing transport listeners."); }
-
                     try { server.Dispose(); }
                     catch (Exception ex) { _logger.LogDebug(ex, "Error disposing OPC UA server."); }
 


### PR DESCRIPTION
Removes the now-redundant transport listener disposal workaround from the OPC UA server. Addresses #291.

## Background
`OpcUaStandardServer.DisposeTransportListeners` existed because `ServerBase.StopAsync` closed each transport listener and then cleared the `TransportListeners` list before disposal could run. `ServerBase.Dispose` later iterated the (now empty) list, so `TcpTransportListener.Dispose` never executed, leaking inactivity timers, per-client channels, and buffer managers on every server stop or restart.

## Why it is safe to remove now
The upstream fix [OPCFoundation/UA-.NETStandard#3561](https://github.com/OPCFoundation/UA-.NETStandard/pull/3561) makes `StopAsync` dispose each listener: `Close()`, then `Utils.SilentDispose(...)`, then `Clear()`. Verified against the tagged SDK source at `1.5.378.134` (the version this project already references in `Namotion.Interceptor.OpcUa.csproj`): `Stack/Opc.Ua.Core/Stack/Server/ServerBase.cs` now disposes each listener before clearing the list. As a result `server.Dispose()` no longer leaks and the manual workaround is redundant.

## Changes
- Remove `OpcUaStandardServer.DisposeTransportListeners()` and the `_savedTransportListeners` field.
- Remove the manual `DisposeTransportListeners()` call in the shutdown `finally` block of `OpcUaSubjectServer`.
- Simplify `CloseTransportListeners()` to iterate the live `TransportListeners` (the saved snapshot only existed to feed the removed disposal step).

## What is intentionally kept
`CloseTransportListeners()` and its two call sites are not affected by #3561 and stay:
1. Force-kill crash simulation (abrupt listener close).
2. Closing listeners before sessions are closed during a normal shutdown. `StandardServer.OnServerStoppingAsync` runs `ShutDownDelay()` (default `ShutdownDelay` is 5 seconds) while listeners are still open, so without this clients reconnect during the delay and `StopAsync` hangs.

## Testing
259 passed, 0 failed via `dotnet test src/Namotion.Interceptor.OpcUa.Tests`, including the restart and reconnection integration tests that exercise the shutdown and disposal path.
