### PR TITLE
Bump OPC UA SDK to 1.5.378.145

### DIFF
--- a/src/Namotion.Interceptor.OpcUa/Namotion.Interceptor.OpcUa.csproj
+++ b/src/Namotion.Interceptor.OpcUa/Namotion.Interceptor.OpcUa.csproj
@@ -36,8 +36,8 @@
 
   <!-- NuGet package references for production -->
   <ItemGroup Condition="'$(UseLocalOpcUaProjects)' != 'true'">
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.378.134" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.378.134" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.378.145" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.378.145" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Bump the OPC UA SDK NuGet packages from `1.5.378.134` to `1.5.378.145` (the latest released version on NuGet, published 2026-05-21):

- `OPCFoundation.NetStandard.Opc.Ua.Server`
- `OPCFoundation.NetStandard.Opc.Ua.Client`

## Why

`1.5.378.145` is a strict superset of `1.5.378.134` on the release line: same API surface, plus the bug fixes published between the two versions. Notably it includes OPCFoundation/UA-.NETStandard#3734, which fixes a server publish-queue regression where `moreNotifications = false` was set near `MaxMessageQueue` size despite `m_itemsToPublish` still having pending items. This was originally suspected to be the root cause of #285. The overnight soak below disproves that suspicion: #285 reproduces on `1.5.378.145` despite the fix being present. The bump is still worth taking for the other fixes and for staying current, but it is no longer the fix for #285.

## Why this is not #289

PR #289 ports to `upstream/master`, which is ahead of the release line and carries breaking API changes (`NodeId` became a struct, removed collection types, `WrappedValue.AsBoxedObject`, `TelemetryContext` constructor, C# 14 extension syntax) plus an unexplained regression (#290). The released `1.5.378.145` keeps the existing API surface (for example `NodeId` is still a class), so this is a clean two-line version bump with no code changes. This supersedes #289 as the way to pick up the #3734 fix into production.

## Verification

- Clean build of `Namotion.Interceptor.OpcUa` against `1.5.378.145`: 0 warnings, 0 errors
- `Namotion.Interceptor.OpcUa.Tests` (Category != Integration): 232 passed, 0 failed
- `Namotion.Interceptor.ConnectorTester` builds clean
- Overnight `opcua-chaos` soak: 697 cycles clean, FAIL at cycle 698. Failure is the #285 pattern (client-a-only chaos, client-b stale on ~50 properties spanning ROOT and most SUBJ_N nodes, per-property timing gap 25 ms to 1.2 s, re-sync classifier "transient delivery gap"). Heap was flat at 98.8 MB across the run (no master-style drift). See #285 for full repro data.

## How to proceed after merge

`1.5.378.145` is a neutral-or-positive bump: same API as `1.5.378.134`, more fixes layered on top, no observed regressions, no heap drift. Merge stands. The post-merge plan has been revised because `#3734` is no longer a candidate root cause for #285.

Release line:

- **#285**: Keep open. Reproduced on `1.5.378.145` at cycle 698 with the same `client-a-only` chaos profile as the original cycle 318 repro on `1.5.378.134`. One data point per version is not enough to compare rates. `#3734` is ruled out as root cause. Next step is targeted instrumentation of the SDK's subscription/publish path on `1.5.378.145`, not another SDK bump.
- **#287**: Independent root cause (session-transfer `InvalidCastException` after server restart). The soak's cycle 697 hit a similar subscription-stall mode and the health monitor auto-recovered in 95s within the convergence window, demonstrating the mitigation works for stalls of that severity. Keep open; re-run with the server-restart profile separately. This bump is not expected to fix #287.
- **#290**: Keep open. The master-specific heap drift was not reproduced on `1.5.378.145`. The cycle-698 failure here is the broader `#285` pattern (flat heap), so #290's tiny-divergence variant is still likely master-specific. The release-line bug and the master-only drift are now believed to be separate problems on top of a shared underlying notification-loss family.

Master track:

- **#289**: Keep open as the tracker for the larger move to master's newer API. No longer needed to deliver `#3734` (handled here) and remains blocked on #290 plus the unresolved underlying bug shared with #285.
