### PR TITLE
Drop permanent OPC UA write failures from retry queue

### DIFF
--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -518,6 +518,7 @@ For 24/7 production use, the default configuration provides robust resilience:
 | `OperationTimeout` | 30s | Timeout for individual OPC UA operations |
 | `SubscriptionHealthCheckInterval` | 5s | Interval for health checks and post-reconnection state sync |
 | `WriteRetryQueueSize` | 1000 | Updates buffered during disconnection |
+| `DropPermanentWriteFailures` | true | Drop writes that fail with a permanent status code instead of retrying every cycle (see [Write Error Handling](#write-error-handling)) |
 | `SessionDisposalTimeout` | 5s | Max wait for graceful session close |
 | `SubscriptionSequentialPublishing` | false | Process subscription messages in order (see Thread Safety) |
 
@@ -637,6 +638,23 @@ Round-trip identity is preserved for the common cross-parent DAG: if the server-
 ## Write Error Handling
 
 When a batch write to the OPC UA server partially fails, the client throws an `OpcUaWriteException`. The exception distinguishes between transient failures (connectivity issues, timeouts that may succeed on retry) and permanent failures (invalid nodes, access denied; should not be retried). The write retry queue (see [Resilience](#write-retry-queue-during-disconnection)) handles transient failures automatically during disconnection, but writes that fail while connected surface this exception.
+
+### Permanent failure dropping
+
+By default (`OpcUaClientConfiguration.DropPermanentWriteFailures = true`), writes that fail with a permanent OPC UA status code are removed from the retry queue instead of being retried on every write cycle. The following codes are treated as permanent:
+
+| Status code | Cause |
+|-------------|-------|
+| `BadAttributeIdInvalid` | Wrong attribute targeted (configuration error) |
+| `BadTypeMismatch` | Value type does not match the node's `DataType` |
+| `BadWriteNotSupported` | Server does not support writes for this node |
+| `BadNodeIdUnknown` | NodeId not present in the address space |
+| `BadUserAccessDenied` | Current user lacks write permission |
+| `BadNotWritable` | Node's `AccessLevel` does not include `CurrentWrite` |
+
+Each dropped NodeId is logged once per session at warning level. The dropped-set is cleared on every session change (manual reconnect, transferred-subscription failure, stall reset), so a new session re-evaluates each NodeId fresh and operators get a new log line if a previously-broken node is still broken after reconnection. The application is still informed of every failure batch via `OpcUaWriteException`; only the *retry* of dropped writes is suppressed. Subsequent user-initiated writes to the same property retry naturally as fresh writes.
+
+Set `DropPermanentWriteFailures = false` only if the server changes `AccessLevel`, role assignments, or address-space membership at runtime *and* you want the connector to recover automatically without an explicit re-write from the application. With dropping disabled, every permanent failure stays in the retry queue and is re-attempted on every write cycle for the lifetime of the connector.
 
 ## Diagnostics
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/WriteErrorClassificationTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/WriteErrorClassificationTests.cs
@@ -74,32 +74,85 @@ public class WriteErrorClassificationTests
     }
 
     [Theory]
+    [InlineData(StatusCodes.BadNodeIdUnknown)]
     [InlineData(StatusCodes.BadAttributeIdInvalid)]
     [InlineData(StatusCodes.BadTypeMismatch)]
     [InlineData(StatusCodes.BadWriteNotSupported)]
-    public void IsStructurallyPermanentError_WithSchemaLevelCode_ReturnsTrue(uint statusCode)
+    [InlineData(StatusCodes.BadUserAccessDenied)]
+    [InlineData(StatusCodes.BadNotWritable)]
+    public void IsPermanentWriteError_WithPermanentCode_ReturnsTrue(uint statusCode)
     {
         // Arrange
         var status = new StatusCode(statusCode);
 
         // Act
-        var result = OpcUaSubjectClientSource.IsStructurallyPermanentError(status);
+        var result = OpcUaSubjectClientSource.IsPermanentWriteError(status);
 
         // Assert
         Assert.True(result);
     }
 
     [Theory]
-    [InlineData(StatusCodes.BadNodeIdUnknown)]     // address space can change
-    [InlineData(StatusCodes.BadUserAccessDenied)]  // permissions can change
-    [InlineData(StatusCodes.BadNotWritable)]       // AccessLevel can be flipped
-    public void IsStructurallyPermanentError_WithStateDependentCode_ReturnsFalse(uint statusCode)
+    [InlineData(StatusCodes.BadTimeout)]
+    [InlineData(StatusCodes.BadServerNotConnected)]
+    [InlineData(StatusCodes.BadOutOfService)]
+    [InlineData(StatusCodes.BadTooManyOperations)]
+    [InlineData(StatusCodes.BadSessionIdInvalid)]
+    [InlineData(StatusCodes.BadSecureChannelClosed)]
+    public void IsPermanentWriteError_WithTransientCode_ReturnsFalse(uint statusCode)
     {
         // Arrange
         var status = new StatusCode(statusCode);
 
         // Act
-        var result = OpcUaSubjectClientSource.IsStructurallyPermanentError(status);
+        var result = OpcUaSubjectClientSource.IsPermanentWriteError(status);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Good)]
+    [InlineData(StatusCodes.Uncertain)]
+    public void IsPermanentWriteError_WithNonBadStatus_ReturnsFalse(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act
+        var result = OpcUaSubjectClientSource.IsPermanentWriteError(status);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.BadTypeMismatch)]
+    [InlineData(StatusCodes.BadUserAccessDenied)]
+    [InlineData(StatusCodes.BadNotWritable)]
+    public void ShouldDropFailedWrite_WhenConfigEnabledAndPermanentCode_ReturnsTrue(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act
+        var result = OpcUaSubjectClientSource.ShouldDropFailedWrite(status, dropPermanentWriteFailures: true);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.BadTypeMismatch)]
+    [InlineData(StatusCodes.BadUserAccessDenied)]
+    [InlineData(StatusCodes.BadNotWritable)]
+    public void ShouldDropFailedWrite_WhenConfigDisabled_ReturnsFalseEvenForPermanentCode(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act
+        var result = OpcUaSubjectClientSource.ShouldDropFailedWrite(status, dropPermanentWriteFailures: false);
 
         // Assert
         Assert.False(result);
@@ -110,15 +163,30 @@ public class WriteErrorClassificationTests
     [InlineData(StatusCodes.BadServerNotConnected)]
     [InlineData(StatusCodes.Good)]
     [InlineData(StatusCodes.Uncertain)]
-    public void IsStructurallyPermanentError_WithTransientOrNonBadCode_ReturnsFalse(uint statusCode)
+    public void ShouldDropFailedWrite_ForNonPermanentCode_ReturnsFalseRegardlessOfConfig(uint statusCode)
     {
         // Arrange
         var status = new StatusCode(statusCode);
 
         // Act
-        var result = OpcUaSubjectClientSource.IsStructurallyPermanentError(status);
+        var resultEnabled = OpcUaSubjectClientSource.ShouldDropFailedWrite(status, dropPermanentWriteFailures: true);
+        var resultDisabled = OpcUaSubjectClientSource.ShouldDropFailedWrite(status, dropPermanentWriteFailures: false);
 
         // Assert
-        Assert.False(result);
+        Assert.False(resultEnabled);
+        Assert.False(resultDisabled);
+    }
+
+    [Fact]
+    public void DropPermanentWriteFailures_DefaultValue_IsTrue()
+    {
+        // Arrange
+        var configuration = new OpcUaClientConfiguration { ServerUrl = "opc.tcp://localhost:4840" };
+
+        // Act
+        var actual = configuration.DropPermanentWriteFailures;
+
+        // Assert
+        Assert.True(actual);
     }
 }

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/WriteErrorClassificationTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/WriteErrorClassificationTests.cs
@@ -72,4 +72,53 @@ public class WriteErrorClassificationTests
         // Assert
         Assert.False(result); // Uncertain is not "bad"
     }
+
+    [Theory]
+    [InlineData(StatusCodes.BadAttributeIdInvalid)]
+    [InlineData(StatusCodes.BadTypeMismatch)]
+    [InlineData(StatusCodes.BadWriteNotSupported)]
+    public void IsStructurallyPermanentError_WithSchemaLevelCode_ReturnsTrue(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act
+        var result = OpcUaSubjectClientSource.IsStructurallyPermanentError(status);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.BadNodeIdUnknown)]     // address space can change
+    [InlineData(StatusCodes.BadUserAccessDenied)]  // permissions can change
+    [InlineData(StatusCodes.BadNotWritable)]       // AccessLevel can be flipped
+    public void IsStructurallyPermanentError_WithStateDependentCode_ReturnsFalse(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act
+        var result = OpcUaSubjectClientSource.IsStructurallyPermanentError(status);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.BadTimeout)]
+    [InlineData(StatusCodes.BadServerNotConnected)]
+    [InlineData(StatusCodes.Good)]
+    [InlineData(StatusCodes.Uncertain)]
+    public void IsStructurallyPermanentError_WithTransientOrNonBadCode_ReturnsFalse(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act
+        var result = OpcUaSubjectClientSource.IsStructurallyPermanentError(status);
+
+        // Assert
+        Assert.False(result);
+    }
 }

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -93,6 +93,7 @@ namespace Namotion.Interceptor.OpcUa.Client
         public int DefaultPublishingInterval { get; set; }
         public uint? DefaultQueueSize { get; set; }
         public int? DefaultSamplingInterval { get; set; }
+        public bool DropPermanentWriteFailures { get; set; }
         public bool EnablePollingFallback { get; set; }
         public bool EnableReadAfterWrite { get; set; }
         public System.TimeSpan KeepAliveInterval { get; set; }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
@@ -54,6 +54,18 @@ public class OpcUaClientConfiguration
     public int WriteRetryQueueSize { get; set; } = 1000;
 
     /// <summary>
+    /// Gets or sets whether to drop writes that fail with a permanent OPC UA status code
+    /// (BadNodeIdUnknown, BadAttributeIdInvalid, BadTypeMismatch, BadWriteNotSupported,
+    /// BadUserAccessDenied, BadNotWritable) from the retry queue instead of retrying them every cycle.
+    /// Each dropped NodeId is logged once at warning level for the lifetime of the connector instance.
+    /// When false, all failed writes are retried indefinitely (pre-fix behavior). Set this to false
+    /// only if the server changes AccessLevel, role assignments, or address-space membership at runtime
+    /// and you want the connector to recover automatically without an explicit re-write from the application.
+    /// Default is true.
+    /// </summary>
+    public bool DropPermanentWriteFailures { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the interval for subscription health checks and auto-healing attempts. Default is 5 seconds.
     /// Failed monitored items (excluding design-time errors like BadNodeIdUnknown) are retried at this interval.
     /// This also determines how quickly the health check loop picks up work deferred from SDK reconnection.

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
@@ -583,6 +583,8 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
 
     internal static bool IsTransientWriteError(StatusCode statusCode) => OutboundWriter.IsTransientWriteError(statusCode);
 
+    internal static bool IsStructurallyPermanentError(StatusCode statusCode) => OutboundWriter.IsStructurallyPermanentError(statusCode);
+
     /// <inheritdoc />
     async Task IFaultInjectable.InjectFaultAsync(FaultType faultType, CancellationToken cancellationToken)
     {

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
@@ -565,6 +565,8 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
 
     internal void OnCurrentSessionChanged(ISession? previousSession, ISession? currentSession)
     {
+        _writer?.ClearReportedDroppedNodes();
+
         var handler = CurrentSessionChanged;
         if (handler is null)
         {
@@ -583,7 +585,10 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
 
     internal static bool IsTransientWriteError(StatusCode statusCode) => OutboundWriter.IsTransientWriteError(statusCode);
 
-    internal static bool IsStructurallyPermanentError(StatusCode statusCode) => OutboundWriter.IsStructurallyPermanentError(statusCode);
+    internal static bool IsPermanentWriteError(StatusCode statusCode) => OutboundWriter.IsPermanentWriteError(statusCode);
+
+    internal static bool ShouldDropFailedWrite(StatusCode statusCode, bool dropPermanentWriteFailures)
+        => OutboundWriter.ShouldDropFailedWrite(statusCode, dropPermanentWriteFailures);
 
     /// <inheritdoc />
     async Task IFaultInjectable.InjectFaultAsync(FaultType faultType, CancellationToken cancellationToken)

--- a/src/Namotion.Interceptor.OpcUa/Client/OutboundWriter.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OutboundWriter.cs
@@ -16,6 +16,12 @@ internal sealed class OutboundWriter
     private readonly ThroughputCounter _outgoingThroughput;
     private readonly ILogger _logger;
 
+    // Tracks NodeIds already reported as permanently dropped so the warning fires once per node per session.
+    // Cleared on session change via ClearReportedDroppedNodes; lock protects the rare write-path Add against
+    // the session-change clear, which runs from the SessionManager drain loop on a different task.
+    private readonly Lock _reportedDroppedNodeIdsLock = new();
+    private readonly HashSet<NodeId> _reportedDroppedNodeIds = [];
+
     public OutboundWriter(
         SessionManager sessionManager,
         OpcUaClientConfiguration configuration,
@@ -31,6 +37,17 @@ internal sealed class OutboundWriter
     }
 
     public int WriteBatchSize => (int)(_sessionManager.CurrentSession?.OperationLimits?.MaxNodesPerWrite ?? 0);
+
+    // Called by OpcUaSubjectClientSource.OnCurrentSessionChanged. A new session can have different permissions,
+    // address-space membership, and AccessLevel attributes, so previously-dropped NodeIds may now write
+    // successfully (or still fail and deserve a fresh log line for operator visibility).
+    internal void ClearReportedDroppedNodes()
+    {
+        lock (_reportedDroppedNodeIdsLock)
+        {
+            _reportedDroppedNodeIds.Clear();
+        }
+    }
 
     public async ValueTask<WriteResult> WriteChangesAsync(ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken cancellationToken)
     {
@@ -77,13 +94,14 @@ internal sealed class OutboundWriter
         return StatusCode.IsBad(statusCode);
     }
 
-    // Schema-level codes only. State-dependent codes (BadNodeIdUnknown, BadUserAccessDenied, BadNotWritable) can flip at runtime and stay in the retry queue.
-    internal static bool IsStructurallyPermanentError(StatusCode statusCode)
-    {
-        return statusCode == StatusCodes.BadAttributeIdInvalid ||
-               statusCode == StatusCodes.BadTypeMismatch ||
-               statusCode == StatusCodes.BadWriteNotSupported;
-    }
+    // Permanent within a session per OPC UA spec for schema/type codes; spec-allowed but rare in practice
+    // for the state-dependent codes (BadNodeIdUnknown, BadUserAccessDenied, BadNotWritable). All six are
+    // dropped by default; OpcUaClientConfiguration.DropPermanentWriteFailures lets users opt back into retry.
+    internal static bool IsPermanentWriteError(StatusCode statusCode)
+        => StatusCode.IsBad(statusCode) && !IsTransientWriteError(statusCode);
+
+    internal static bool ShouldDropFailedWrite(StatusCode statusCode, bool dropPermanentWriteFailures)
+        => dropPermanentWriteFailures && IsPermanentWriteError(statusCode);
 
     private WriteResult ProcessWriteResults(StatusCodeCollection results, ReadOnlyMemory<SubjectPropertyChange> allChanges)
     {
@@ -103,8 +121,10 @@ internal sealed class OutboundWriter
             return WriteResult.Success;
         }
 
+        var dropPermanent = _configuration.DropPermanentWriteFailures;
         var retryableFailures = new List<SubjectPropertyChange>(failureCount);
-        List<NodeId>? droppedPermanentNodeIds = null;
+        List<NodeId>? newlyDroppedNodeIds = null;
+        var droppedPermanentCount = 0;
         var transientCount = 0;
         var resultIndex = 0;
         var span = allChanges.Span;
@@ -117,10 +137,19 @@ internal sealed class OutboundWriter
             var status = results[resultIndex];
             if (!StatusCode.IsGood(status))
             {
-                if (IsStructurallyPermanentError(status))
+                if (ShouldDropFailedWrite(status, dropPermanent))
                 {
-                    droppedPermanentNodeIds ??= [];
-                    droppedPermanentNodeIds.Add(nodeId);
+                    droppedPermanentCount++;
+                    bool isFirstOccurrence;
+                    lock (_reportedDroppedNodeIdsLock)
+                    {
+                        isFirstOccurrence = _reportedDroppedNodeIds.Add(nodeId);
+                    }
+                    if (isFirstOccurrence)
+                    {
+                        newlyDroppedNodeIds ??= [];
+                        newlyDroppedNodeIds.Add(nodeId);
+                    }
                 }
                 else
                 {
@@ -132,15 +161,14 @@ internal sealed class OutboundWriter
             resultIndex++;
         }
 
-        var droppedPermanentCount = droppedPermanentNodeIds?.Count ?? 0;
         var permanentCount = retryableFailures.Count - transientCount + droppedPermanentCount;
         var successCount = results.Count - (retryableFailures.Count + droppedPermanentCount);
 
-        if (droppedPermanentNodeIds is not null)
+        if (newlyDroppedNodeIds is not null)
         {
             _logger.LogWarning(
-                "OPC UA write: dropping {Count} structurally-permanent failures from retry queue. NodeIds: {NodeIds}.",
-                droppedPermanentCount, droppedPermanentNodeIds);
+                "OPC UA write: dropping {Count} permanently-failing write(s) from retry queue (first occurrence for these NodeIds). NodeIds: {NodeIds}.",
+                newlyDroppedNodeIds.Count, newlyDroppedNodeIds);
         }
 
         _logger.LogWarning(

--- a/src/Namotion.Interceptor.OpcUa/Client/OutboundWriter.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OutboundWriter.cs
@@ -49,14 +49,7 @@ internal sealed class OutboundWriter
             }
 
             var writeResponse = await session.WriteAsync(requestHeader: null, writeValues, cancellationToken).ConfigureAwait(false);
-            var result = ProcessWriteResults(writeResponse.Results, changes);
-            if (result.IsFullySuccessful || result.IsPartialFailure)
-            {
-                _outgoingThroughput.Add(writeValues.Count - (result.FailedChanges.IsDefault ? 0 : result.FailedChanges.Length));
-                NotifyPropertiesWritten(changes);
-            }
-
-            return result;
+            return ProcessWriteResults(writeResponse.Results, changes);
         }
         catch (InvalidCastException ex)
         {
@@ -84,6 +77,14 @@ internal sealed class OutboundWriter
         return StatusCode.IsBad(statusCode);
     }
 
+    // Schema-level codes only. State-dependent codes (BadNodeIdUnknown, BadUserAccessDenied, BadNotWritable) can flip at runtime and stay in the retry queue.
+    internal static bool IsStructurallyPermanentError(StatusCode statusCode)
+    {
+        return statusCode == StatusCodes.BadAttributeIdInvalid ||
+               statusCode == StatusCodes.BadTypeMismatch ||
+               statusCode == StatusCodes.BadWriteNotSupported;
+    }
+
     private WriteResult ProcessWriteResults(StatusCodeCollection results, ReadOnlyMemory<SubjectPropertyChange> allChanges)
     {
         var failureCount = 0;
@@ -97,39 +98,65 @@ internal sealed class OutboundWriter
 
         if (failureCount == 0)
         {
+            _outgoingThroughput.Add(results.Count);
+            NotifyPropertiesWritten(allChanges);
             return WriteResult.Success;
         }
 
-        var failedChanges = new List<SubjectPropertyChange>(failureCount);
+        var retryableFailures = new List<SubjectPropertyChange>(failureCount);
+        List<NodeId>? droppedPermanentNodeIds = null;
         var transientCount = 0;
         var resultIndex = 0;
         var span = allChanges.Span;
         for (var i = 0; i < span.Length && resultIndex < results.Count; i++)
         {
             var change = span[i];
-            if (!TryGetWritableNodeId(change, out _, out _))
+            if (!TryGetWritableNodeId(change, out var nodeId, out _))
                 continue;
 
-            if (!StatusCode.IsGood(results[resultIndex]))
+            var status = results[resultIndex];
+            if (!StatusCode.IsGood(status))
             {
-                failedChanges.Add(change);
-                if (IsTransientWriteError(results[resultIndex]))
-                    transientCount++;
+                if (IsStructurallyPermanentError(status))
+                {
+                    droppedPermanentNodeIds ??= [];
+                    droppedPermanentNodeIds.Add(nodeId);
+                }
+                else
+                {
+                    retryableFailures.Add(change);
+                    if (IsTransientWriteError(status))
+                        transientCount++;
+                }
             }
             resultIndex++;
         }
 
-        var successCount = results.Count - failedChanges.Count;
-        var permanentCount = failedChanges.Count - transientCount;
+        var droppedPermanentCount = droppedPermanentNodeIds?.Count ?? 0;
+        var permanentCount = retryableFailures.Count - transientCount + droppedPermanentCount;
+        var successCount = results.Count - (retryableFailures.Count + droppedPermanentCount);
+
+        if (droppedPermanentNodeIds is not null)
+        {
+            _logger.LogWarning(
+                "OPC UA write: dropping {Count} structurally-permanent failures from retry queue. NodeIds: {NodeIds}.",
+                droppedPermanentCount, droppedPermanentNodeIds);
+        }
 
         _logger.LogWarning(
             "OPC UA write batch partial failure: {SuccessCount} succeeded, {TransientCount} transient, {PermanentCount} permanent out of {TotalCount}.",
             successCount, transientCount, permanentCount, results.Count);
 
+        if (successCount > 0)
+        {
+            _outgoingThroughput.Add(successCount);
+            NotifyPropertiesWritten(allChanges);
+        }
+
         var error = new OpcUaWriteException(transientCount, permanentCount, results.Count);
         return successCount > 0
-            ? WriteResult.PartialFailure(failedChanges.ToArray(), error)
-            : WriteResult.Failure(failedChanges.ToArray(), error);
+            ? WriteResult.PartialFailure(retryableFailures.ToArray(), error)
+            : WriteResult.Failure(retryableFailures.ToArray(), error);
     }
 
     private bool TryGetWritableNodeId(SubjectPropertyChange change, out NodeId nodeId, out RegisteredSubjectProperty registeredProperty)


### PR DESCRIPTION
Fixes #332.

## Summary

- `OutboundWriter.ProcessWriteResults` now drops writes that fail with a permanent OPC UA status code (`BadAttributeIdInvalid`, `BadTypeMismatch`, `BadWriteNotSupported`, `BadNodeIdUnknown`, `BadUserAccessDenied`, `BadNotWritable`) from `WriteResult.FailedChanges`, so they never enter the retry queue. Each dropped NodeId is logged once per session at warning level.
- New `OpcUaClientConfiguration.DropPermanentWriteFailures` (default `true`) gates the behavior. Set to `false` to restore the pre-fix behavior (every failed write is retried forever).
- The reported-NodeIds set is cleared on every session change (`OpcUaSubjectClientSource.OnCurrentSessionChanged`), so a new session re-evaluates each NodeId fresh and operators get a new warning line if a previously-broken node is still broken after reconnection. Memory is bounded by `unique-permanently-failing-NodeIds-per-session` rather than per-process-lifetime.
- Throughput counter and read-after-write notifications were moved into `ProcessWriteResults` so they read the local `successCount` directly, instead of computing it from `result.FailedChanges.Length` which no longer reflects every failure.

## Why all six codes (not just three)

An earlier version of this PR only dropped the three schema/type-level codes and kept the three state-dependent codes (`BadNodeIdUnknown`, `BadUserAccessDenied`, `BadNotWritable`) in the retry queue on the basis that the OPC UA spec allows the underlying server state (address space membership, permissions, `AccessLevel`) to change at runtime.

In practice these state-dependent codes are static for the vast majority of deployments, and the cost of keeping them in the retry queue (one extra round-trip per write cycle for the lifetime of the connector) outweighs the rare benefit of silent auto-recovery. When state legitimately does change, the natural recovery is a fresh user-initiated write, which retries automatically. The application is still informed of every failure batch via `OpcUaWriteException`; only the *automatic re-attempt* of dropped writes is suppressed.

The config flag exists for the minority of deployments with dynamic AccessLevels or permissions that need the old behavior.

## Test plan

- [x] `dotnet build src/Namotion.Interceptor.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test src/Namotion.Interceptor.slnx --filter \"Category!=Integration\"` all green across 26 test projects
- [x] `WriteErrorClassificationTests` covers: `IsPermanentWriteError` for all 6 permanent codes, 6 transient codes, and non-bad codes (Good/Uncertain); `ShouldDropFailedWrite` gated by the config flag in both directions; default value of `DropPermanentWriteFailures` pinned to true
- [x] `VerifyChecksTests.PublicApi` snapshot updated for the new public `DropPermanentWriteFailures` property
- [x] Docs updated: `docs/connectors-opcua-client.md` configuration table and new "Permanent failure dropping" subsection