### PR TITLE
Preserve change context source and timestamps on transaction commit replay

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionPropertyTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionPropertyTests.cs
@@ -135,6 +135,39 @@ public class SubjectTransactionPropertyTests : TransactionTestBase
     }
 
     [Fact]
+    public async Task CommitAsync_PreservesChangeContext_SourceAndTimestamps()
+    {
+        // Arrange
+        var context = CreateContext();
+        var person = new Person(context);
+        var mockSource = Mock.Of<ISubjectSource>();
+        var changedTime = DateTime.UtcNow.AddMinutes(-5);
+        var receivedTime = DateTime.UtcNow;
+
+        var notifications = new List<SubjectPropertyChange>();
+        context.GetPropertyChangeObservable(Scheduler.Immediate)
+            .Subscribe(change => notifications.Add(change));
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            using (SubjectChangeContext.WithState(mockSource, changedTime, receivedTime))
+            {
+                person.FirstName = "John";
+            }
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        var change = notifications.Single(n => n.Property.Metadata.Name == nameof(Person.FirstName));
+        Assert.Same(mockSource, change.Source);
+        Assert.Equal(changedTime, change.ChangedTimestamp);
+        Assert.Equal(receivedTime, change.ReceivedTimestamp);
+        Assert.Equal(changedTime, person.GetPropertyReference(nameof(Person.FirstName)).TryGetWriteTimestamp());
+    }
+
+    [Fact]
     public async Task ReadProperty_WhenTransactionActive_ReturnsPendingValue()
     {
         // Arrange

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeExtensions.cs
@@ -33,7 +33,10 @@ internal static class SubjectPropertyChangeExtensions
         try
         {
             var metadata = change.Property.Metadata;
-            metadata.SetValue?.Invoke(change.Property.Subject, change.GetNewValue<object?>());
+            using (SubjectChangeContext.WithState(change.Source, change.ChangedTimestamp, change.ReceivedTimestamp))
+            {
+                metadata.SetValue?.Invoke(change.Property.Subject, change.GetNewValue<object?>());
+            }
             error = null;
             return true;
         }


### PR DESCRIPTION
## Summary

When a transaction commits (or rolls back), captured changes are replayed into the in-process model via `TryApplyChange`. That replay called `SetValue` directly without restoring the `SubjectChangeContext`, so the resulting in-process change lost its original metadata:

| Field | Captured in the pending change | After commit (old behavior) | After commit (with this fix) |
|---|---|---|---|
| `Source` | original | `null` | original |
| `ChangedTimestamp` | original | commit time (re-captured) | original |
| `ReceivedTimestamp` | original | `null` | original |

The captured `Source` / `ChangedTimestamp` / `ReceivedTimestamp` were already used for the outbound source write and for building rollback changes, but were never reapplied when the value landed in the model. The existing `WriteProperty_PreservesChangeContext_SourceAndTimestamps` test only asserted the pending change, so the replay leg was untested.

This wraps the replay setter in `SubjectChangeContext.WithState(change.Source, change.ChangedTimestamp, change.ReceivedTimestamp)`, so a committed change is indistinguishable from the equivalent immediate write (full transparency). The fix funnels through the single method all four `ApplyAllChanges` callers use, so it covers commit apply, both rollback paths, and the source-transaction apply.

### Why it matters
- Source attribution now survives commit, so source-aware consumers (validators that skip authoritative-source writes, echo suppression) behave correctly on the transaction path.
- Origin timestamps survive commit, so read-after-write ordering and the OPC UA server's exposed source timestamp stay correct for transactionally-applied source values.
- Callers that want a single shared timestamp across a transaction can still wrap the body in a `SubjectChangeContext.WithChangedTimestamp(...)` scope; replay preserves it.

## Test plan
- [x] Added `CommitAsync_PreservesChangeContext_SourceAndTimestamps` (verified it fails before the fix, passes after).
- [x] `Namotion.Interceptor.Tracking.Tests` (332 passed)
- [x] `Namotion.Interceptor.Connectors.Tests` (408 passed)
- [ ] Connector integration suites (OPC UA / MQTT / WebSocket) recommended before merge, since the shared transaction-apply path feeds connector timestamp logic.