### PR TITLE
performance: Reduce transaction allocations

### DIFF
--- a/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Transactions;
+
+namespace Namotion.Interceptor.Benchmark;
+
+#pragma warning disable CS8618
+
+/// <summary>
+/// Measures the cost of committing a transaction that writes a batch of property changes.
+/// The <see cref="WithSource"/> parameter switches between a local-only commit (changes applied
+/// to the in-process model) and a source-bound commit (changes also dispatched to an external
+/// source via the source transaction writer).
+/// </summary>
+[MemoryDiagnoser]
+public class SubjectTransactionBenchmark
+{
+    private const int PropertyCount = 50;
+
+    private IInterceptorSubjectContext _context;
+    private Car _car;
+    private Tire[] _tires;
+    private int _counter;
+
+    [Params(false, true)]
+    public bool WithSource;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking()
+            .WithRegistry()
+            .WithTransactions();
+
+        if (WithSource)
+        {
+            context.WithSourceTransactions();
+        }
+
+        _context = context;
+        _car = new Car(_context);
+
+        _tires = Enumerable.Range(0, PropertyCount).Select(_ => new Tire()).ToArray();
+        _car.Tires = _tires;
+
+        if (WithSource)
+        {
+            var source = new BenchmarkSource(_car);
+            foreach (var tire in _tires)
+            {
+                new PropertyReference(tire, nameof(Tire.Pressure_Minimum)).SetSource(source);
+            }
+        }
+    }
+
+    [Benchmark]
+    public async Task CommitChanges()
+    {
+        var value = Interlocked.Increment(ref _counter);
+
+        using var transaction = await _context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        for (var i = 0; i < _tires.Length; i++)
+        {
+            _tires[i].Pressure_Minimum = value + i;
+        }
+
+        await transaction.CommitAsync(CancellationToken.None);
+    }
+
+    private sealed class BenchmarkSource : ISubjectSource
+    {
+        public BenchmarkSource(IInterceptorSubject rootSubject)
+        {
+            RootSubject = rootSubject;
+        }
+
+        public IInterceptorSubject RootSubject { get; }
+
+        public int WriteBatchSize => 0;
+
+        public ValueTask<WriteResult> WriteChangesAsync(
+            ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken cancellationToken)
+        {
+            return new ValueTask<WriteResult>(WriteResult.Success);
+        }
+
+        public Task<Action?> LoadInitialStateAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<Action?>(null);
+        }
+    }
+}

--- a/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
@@ -33,10 +33,11 @@ public class SubjectTransactionBenchmark
     {
         Local,
         SingleSource,
+        SingleSourceWithLocal,
         MultiSource
     }
 
-    [Params(CommitMode.Local, CommitMode.SingleSource, CommitMode.MultiSource)]
+    [Params(CommitMode.Local, CommitMode.SingleSource, CommitMode.SingleSourceWithLocal, CommitMode.MultiSource)]
     public CommitMode Mode;
 
     [GlobalSetup]
@@ -65,6 +66,19 @@ public class SubjectTransactionBenchmark
             foreach (var tire in _tires)
             {
                 new PropertyReference(tire, nameof(Tire.Pressure_Minimum)).SetSource(source);
+            }
+        }
+        else if (Mode == CommitMode.SingleSourceWithLocal)
+        {
+            // Half the changes target one source, half are local (no source) - exercises the
+            // single-source path's mixed branch where source-bound and local changes are separated.
+            var source = new BenchmarkSource(_car);
+            for (var i = 0; i < _tires.Length; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    new PropertyReference(_tires[i], nameof(Tire.Pressure_Minimum)).SetSource(source);
+                }
             }
         }
         else if (Mode == CommitMode.MultiSource)

--- a/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
@@ -15,22 +15,29 @@ namespace Namotion.Interceptor.Benchmark;
 
 /// <summary>
 /// Measures the cost of committing a transaction that writes a batch of property changes.
-/// The <see cref="WithSource"/> parameter switches between a local-only commit (changes applied
-/// to the in-process model) and a source-bound commit (changes also dispatched to an external
-/// source via the source transaction writer).
+/// The <see cref="Mode"/> parameter selects a local-only commit, a commit where every change is
+/// bound to a single source, or one spread across multiple sources (the grouped fallback path).
 /// </summary>
 [MemoryDiagnoser]
 public class SubjectTransactionBenchmark
 {
     private const int PropertyCount = 50;
+    private const int SourceCount = 2;
 
     private IInterceptorSubjectContext _context;
     private Car _car;
     private Tire[] _tires;
     private int _counter;
 
-    [Params(false, true)]
-    public bool WithSource;
+    public enum CommitMode
+    {
+        Local,
+        SingleSource,
+        MultiSource
+    }
+
+    [Params(CommitMode.Local, CommitMode.SingleSource, CommitMode.MultiSource)]
+    public CommitMode Mode;
 
     [GlobalSetup]
     public void Setup()
@@ -41,7 +48,7 @@ public class SubjectTransactionBenchmark
             .WithRegistry()
             .WithTransactions();
 
-        if (WithSource)
+        if (Mode != CommitMode.Local)
         {
             context.WithSourceTransactions();
         }
@@ -52,12 +59,20 @@ public class SubjectTransactionBenchmark
         _tires = Enumerable.Range(0, PropertyCount).Select(_ => new Tire()).ToArray();
         _car.Tires = _tires;
 
-        if (WithSource)
+        if (Mode == CommitMode.SingleSource)
         {
             var source = new BenchmarkSource(_car);
             foreach (var tire in _tires)
             {
                 new PropertyReference(tire, nameof(Tire.Pressure_Minimum)).SetSource(source);
+            }
+        }
+        else if (Mode == CommitMode.MultiSource)
+        {
+            var sources = Enumerable.Range(0, SourceCount).Select(_ => new BenchmarkSource(_car)).ToArray();
+            for (var i = 0; i < _tires.Length; i++)
+            {
+                new PropertyReference(_tires[i], nameof(Tire.Pressure_Minimum)).SetSource(sources[i % SourceCount]);
             }
         }
     }

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionAsyncTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionAsyncTests.cs
@@ -274,7 +274,7 @@ public class SubjectTransactionAsyncTests
 
         // Act
         // CommitAsync should throw because current value != captured OldValue
-        var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Contains(nameof(Person.FirstName), ex.Message);
@@ -449,7 +449,7 @@ public class SubjectTransactionAsyncTests
 
         // Act: First commit fails due to conflict
         await Assert.ThrowsAsync<SubjectTransactionConflictException>(
-            () => tx.CommitAsync(CancellationToken.None));
+            () => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Pending changes are still intact after conflict failure
         Assert.Single(tx.GetPendingChanges());
@@ -516,7 +516,7 @@ public class SubjectTransactionAsyncTests
 
         // Act: Commit fails due to conflict on FirstName
         var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(
-            () => tx.CommitAsync(CancellationToken.None));
+            () => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert: Both pending changes are still intact
         var pendingChanges = tx.GetPendingChanges();
@@ -545,6 +545,6 @@ public class SubjectTransactionAsyncTests
 
         // Act & Assert: Second commit on already-committed transaction throws
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => tx.CommitAsync(CancellationToken.None));
+            () => tx.CommitAsync(CancellationToken.None).AsTask());
     }
 }

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionFailureHandlingTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionFailureHandlingTests.cs
@@ -28,7 +28,7 @@ public class SubjectTransactionFailureHandlingTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Equal("John", person.FirstName);
@@ -86,7 +86,7 @@ public class SubjectTransactionFailureHandlingTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Null(person.FirstName);
@@ -125,7 +125,7 @@ public class SubjectTransactionFailureHandlingTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Equal(2, ex.FailedChanges.Count);
@@ -150,7 +150,7 @@ public class SubjectTransactionFailureHandlingTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe"; // No source - not applied when source fails in Rollback mode
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // Both changes should be in FailedChanges - FirstName failed to write, LastName wasn't applied
@@ -180,7 +180,7 @@ public class SubjectTransactionFailureHandlingTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe"; // No source
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // In BestEffort, successful changes are applied

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionLifecycleTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionLifecycleTests.cs
@@ -149,7 +149,7 @@ public class SubjectTransactionLifecycleTests : TransactionTestBase
 
             // Act
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
 
             // Assert
             Assert.Contains("already been committed", exception.Message);

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionLocalPropertyTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionLocalPropertyTests.cs
@@ -31,7 +31,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         // Enable throwing just before commit
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - PropertyA should be applied, PropertyB should fail
         Assert.True(device.PropertyA);
@@ -58,7 +58,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         // Enable throwing just before commit
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - Both should be reverted (PropertyA was applied then rolled back)
         Assert.False(device.PropertyA); // Rolled back
@@ -96,7 +96,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         // Enable throwing just before commit
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // External source should have been written and then reverted (2 calls)
@@ -135,7 +135,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         // PropertyA's revert will also fail
         revertPhase = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - Both PropertyA (revert failure) and PropertyB (initial failure) should be reported
         Assert.Equal(2, exception.FailedChanges.Count);
@@ -164,7 +164,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         // Enable throwing just before commit
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.True(device.PropertyA); // Applied
@@ -194,7 +194,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         // Enable throwing just before commit
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - PropertyA should be rolled back
         Assert.False(device.PropertyA); // Rolled back
@@ -243,7 +243,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
         person.FirstName = "John";  // External source - fails
         device.PropertyA = true;     // Local - would succeed but shouldn't be applied
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - Local properties should not be applied when external source fails in rollback mode
         Assert.Null(person.FirstName);
@@ -322,7 +322,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
 
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - External source was written and then reverted (2 calls)
         Assert.Equal(2, writeCount);
@@ -368,7 +368,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
 
         device.ThrowingEnabled = true;
 
-        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // PropertyA: source written (1) + rolled back (2) = 2 calls
@@ -413,7 +413,7 @@ public class SubjectTransactionLocalPropertyTests : TransactionTestBase
 
         device.ThrowingEnabled = true;
 
-        await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert - Source was written with true, then rolled back with false
         Assert.Equal(2, writtenValues.Count);

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionOptimisticLockingTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionOptimisticLockingTests.cs
@@ -51,7 +51,7 @@ public class SubjectTransactionOptimisticLockingTests
 
         // Act & Assert
         // CommitAsync should throw because current value != captured OldValue
-        var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
         Assert.Contains(nameof(Person.FirstName), ex.Message);
     }
 

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionRequirementTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionRequirementTests.cs
@@ -32,7 +32,7 @@ public class SubjectTransactionRequirementTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Equal(2, ex.FailedChanges.Count); // Both changes failed (validation error)
@@ -72,7 +72,7 @@ public class SubjectTransactionRequirementTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe"; // 2 changes > batch size of 1
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Equal(2, ex.FailedChanges.Count); // Both changes failed (validation error)
@@ -245,7 +245,7 @@ public class SubjectTransactionRequirementTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         Assert.Null(person.FirstName);
@@ -282,7 +282,7 @@ public class SubjectTransactionRequirementTests : TransactionTestBase
         person.LastName = "Doe";
         person.Father = father; // No source - should be in successful changes
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // Validation error should be reported - both source-bound changes failed
@@ -336,7 +336,7 @@ public class SubjectTransactionRequirementTests : TransactionTestBase
         person.LastName = "Doe"; // 2 changes > batch size of 1
         person.Father = father; // No source
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // Validation error for batch size - both source-bound changes failed

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionSourceTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionSourceTests.cs
@@ -168,7 +168,7 @@ public class SubjectTransactionSourceTests : TransactionTestBase
             person.FirstName = "John";
 
             var exception = await Assert.ThrowsAsync<SubjectTransactionException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
 
             // Assert
             Assert.Single(exception.FailedChanges);
@@ -199,7 +199,7 @@ public class SubjectTransactionSourceTests : TransactionTestBase
             person.LastName = "Doe";
 
             var exception = await Assert.ThrowsAsync<SubjectTransactionException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
 
             // Assert
             Assert.Single(exception.FailedChanges);
@@ -320,7 +320,7 @@ public class SubjectTransactionSourceTests : TransactionTestBase
             person.FirstName = "John";
 
             var exception = await Assert.ThrowsAsync<SubjectTransactionException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
 
             // Assert
             Assert.Single(exception.FailedChanges);
@@ -472,7 +472,7 @@ public class SubjectTransactionSourceTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // Only FirstName should be in FailedChanges (partial failure)
@@ -527,7 +527,7 @@ public class SubjectTransactionSourceTests : TransactionTestBase
         person.FirstName = "John";
         person.LastName = "Doe";
 
-        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<SubjectTransactionException>(() => tx.CommitAsync(CancellationToken.None).AsTask());
 
         // Assert
         // In Rollback mode, nothing should be applied when there's any failure

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionSourceTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionSourceTests.cs
@@ -257,6 +257,99 @@ public class SubjectTransactionSourceTests : TransactionTestBase
     }
 
     [Fact]
+    public async Task CommitAsync_WithMultipleSourcesAndLocal_WritesSourcesAndAppliesLocal()
+    {
+        // Arrange - two distinct sources plus a local (no-source) change in one transaction;
+        // exercises the grouped path with a non-empty local set.
+        var context = CreateContext();
+        var person = new Person(context);
+
+        var source1Writes = new List<int>();
+        var source1Mock = new Mock<ISubjectSource>();
+        source1Mock.Setup(s => s.WriteBatchSize).Returns(0);
+        source1Mock.Setup(s => s.WriteChangesAsync(It.IsAny<ReadOnlyMemory<SubjectPropertyChange>>(), It.IsAny<CancellationToken>()))
+            .Returns((ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken _) =>
+            {
+                source1Writes.Add(changes.Length);
+                return new ValueTask<WriteResult>(WriteResult.Success);
+            });
+
+        var source2Writes = new List<int>();
+        var source2Mock = new Mock<ISubjectSource>();
+        source2Mock.Setup(s => s.WriteBatchSize).Returns(0);
+        source2Mock.Setup(s => s.WriteChangesAsync(It.IsAny<ReadOnlyMemory<SubjectPropertyChange>>(), It.IsAny<CancellationToken>()))
+            .Returns((ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken _) =>
+            {
+                source2Writes.Add(changes.Length);
+                return new ValueTask<WriteResult>(WriteResult.Success);
+            });
+
+        new PropertyReference(person, nameof(Person.FirstName)).SetSource(source1Mock.Object);
+        new PropertyReference(person, nameof(Person.LastName)).SetSource(source2Mock.Object);
+        // FirstName_MaxLength is left without a source -> local change applied in-process.
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+            person.LastName = "Doe";
+            person.FirstName_MaxLength = 42;
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert - each source written once with its single change; the local change is applied.
+        Assert.Single(source1Writes);
+        Assert.Single(source2Writes);
+        Assert.Equal(1, source1Writes[0]);
+        Assert.Equal(1, source2Writes[0]);
+        Assert.Equal(42, person.FirstName_MaxLength);
+    }
+
+    [Fact]
+    public async Task CommitAsync_WithSingleSourceAndLocal_WritesOnlySourceBoundAndAppliesLocal()
+    {
+        // Arrange - two source-bound changes on one source plus a local change interleaved between
+        // them; directly exercises the single-source path's source/local separation (two-pointer).
+        var context = CreateContext();
+        var person = new Person(context);
+
+        var written = new List<SubjectPropertyChange>();
+        var sourceMock = new Mock<ISubjectSource>();
+        sourceMock.Setup(s => s.WriteBatchSize).Returns(0);
+        sourceMock.Setup(s => s.WriteChangesAsync(It.IsAny<ReadOnlyMemory<SubjectPropertyChange>>(), It.IsAny<CancellationToken>()))
+            .Returns((ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken _) =>
+            {
+                foreach (var change in changes.Span)
+                {
+                    written.Add(change);
+                }
+                return new ValueTask<WriteResult>(WriteResult.Success);
+            });
+
+        new PropertyReference(person, nameof(Person.FirstName)).SetSource(sourceMock.Object);
+        new PropertyReference(person, nameof(Person.LastName)).SetSource(sourceMock.Object);
+        // FirstName_MaxLength is left without a source -> local change.
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+            person.FirstName_MaxLength = 42; // local change interleaved between source-bound changes
+            person.LastName = "Doe";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert - only the two source-bound changes reached the source; the local change was applied.
+        Assert.Equal(2, written.Count);
+        Assert.Contains(written, c => c.Property.Metadata.Name == nameof(Person.FirstName));
+        Assert.Contains(written, c => c.Property.Metadata.Name == nameof(Person.LastName));
+        Assert.DoesNotContain(written, c => c.Property.Metadata.Name == nameof(Person.FirstName_MaxLength));
+        Assert.Equal(42, person.FirstName_MaxLength);
+        Assert.Equal("John", person.FirstName);
+        Assert.Equal("Doe", person.LastName);
+    }
+
+    [Fact]
     public async Task CommitAsync_UserCancellationIsIgnored_CommitSucceeds()
     {
         // Arrange

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -66,7 +66,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         // Partition source-bound vs local changes. The source receives a private array copy (never the
         // transaction's pooled buffer), matching the grouped path, so a source that retains the memory
         // past the call is not exposed to the array being returned to the pool.
-        ReadOnlyMemory<SubjectPropertyChange> sourceChanges;
+        SubjectPropertyChange[] sourceChanges;
         IReadOnlyList<SubjectPropertyChange> localChanges;
         if (!hasLocal)
         {
@@ -99,7 +99,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             {
                 return new TransactionWriteResult(
                     [],
-                    sourceChanges.ToArray(),
+                    sourceChanges,
                     [new InvalidOperationException(
                         $"SingleWrite requirement violated: Transaction contains {sourceChanges.Length} changes for source '{source.GetType().Name}', but WriteBatchSize is {batchSize}.")],
                     localChanges);
@@ -109,22 +109,13 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         var allFailed = new List<SubjectPropertyChange>();
         var allErrors = new List<Exception>();
 
-        // 1. Write to the source.
+        // Write to the source. On a reported error only the non-failed changes reached it; otherwise
+        // the whole array did, so it is reused directly as the written set (no copy).
         var writeResult = await source.WriteChangesInBatchesAsync(sourceChanges, cancellationToken);
-
-        List<SubjectPropertyChange> written;
+        IReadOnlyList<SubjectPropertyChange> written = sourceChanges;
         if (writeResult.Error is not null)
         {
-            var failedSet = new HashSet<SubjectPropertyChange>(writeResult.FailedChanges);
-            written = new List<SubjectPropertyChange>(sourceChanges.Length);
-            foreach (var change in sourceChanges.Span)
-            {
-                if (!failedSet.Contains(change))
-                {
-                    written.Add(change);
-                }
-            }
-
+            written = ExcludeFailed(sourceChanges, writeResult.FailedChanges);
             allFailed.AddRange(writeResult.FailedChanges);
             allErrors.Add(new SourceTransactionWriteException(source, [.. writeResult.FailedChanges], writeResult.Error));
 
@@ -134,16 +125,8 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
                 return new TransactionWriteResult([], allFailed, allErrors, localChanges);
             }
         }
-        else
-        {
-            written = new List<SubjectPropertyChange>(sourceChanges.Length);
-            foreach (var change in sourceChanges.Span)
-            {
-                written.Add(change);
-            }
-        }
 
-        // 2. Apply the written changes to the in-process model.
+        // Apply the changes that reached the source to the in-process model.
         var (applied, applyFailed, applyErrors) = written.ApplyAllChanges();
         allFailed.AddRange(applyFailed);
         allErrors.AddRange(applyErrors);
@@ -164,8 +147,23 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         return new TransactionWriteResult(applied, allFailed, allErrors, localChanges);
     }
 
+    private static List<SubjectPropertyChange> ExcludeFailed(
+        IReadOnlyList<SubjectPropertyChange> changes, IReadOnlyList<SubjectPropertyChange> failed)
+    {
+        var failedSet = new HashSet<SubjectPropertyChange>(failed);
+        var result = new List<SubjectPropertyChange>(changes.Count - failed.Count);
+        foreach (var change in changes)
+        {
+            if (!failedSet.Contains(change))
+            {
+                result.Add(change);
+            }
+        }
+        return result;
+    }
+
     private static Dictionary<ISubjectSource, List<SubjectPropertyChange>> SingleSourceMap(
-        ISubjectSource source, List<SubjectPropertyChange> changes) => new(1) { [source] = changes };
+        ISubjectSource source, IReadOnlyList<SubjectPropertyChange> changes) => new(1) { [source] = [.. changes] };
 
     private async Task<TransactionWriteResult> WriteGroupedAsync(
         ReadOnlyMemory<SubjectPropertyChange> changes,

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -16,6 +16,163 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         TransactionRequirement requirement,
         CancellationToken cancellationToken)
     {
+        // Single pass: detect whether all source-bound changes target one source (the common
+        // single-connector case). That case takes an allocation-light path; everything else
+        // (no source, or multiple sources) falls back to the general grouped path.
+        ISubjectSource? singleSource = null;
+        var multipleSources = false;
+        var hasLocal = false;
+        foreach (var change in changes.Span)
+        {
+            if (change.Property.TryGetSource(out var source))
+            {
+                if (singleSource is null)
+                {
+                    singleSource = source;
+                }
+                else if (!ReferenceEquals(singleSource, source))
+                {
+                    multipleSources = true;
+                    break;
+                }
+            }
+            else
+            {
+                hasLocal = true;
+            }
+        }
+
+        if (singleSource is not null && !multipleSources)
+        {
+            return await WriteSingleSourceAsync(singleSource, changes, hasLocal, failureHandling, requirement, cancellationToken);
+        }
+
+        return await WriteGroupedAsync(changes, failureHandling, requirement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Allocation-light path for the common case where every source-bound change targets the same
+    /// source: writes once (no per-source grouping or parallel dispatch) and applies in-process.
+    /// Failure and rollback semantics mirror <see cref="WriteGroupedAsync"/>.
+    /// </summary>
+    private static async Task<TransactionWriteResult> WriteSingleSourceAsync(
+        ISubjectSource source,
+        ReadOnlyMemory<SubjectPropertyChange> changes,
+        bool hasLocal,
+        TransactionFailureHandling failureHandling,
+        TransactionRequirement requirement,
+        CancellationToken cancellationToken)
+    {
+        // Partition source-bound vs local changes. The source receives a private array copy (never the
+        // transaction's pooled buffer), matching the grouped path, so a source that retains the memory
+        // past the call is not exposed to the array being returned to the pool.
+        ReadOnlyMemory<SubjectPropertyChange> sourceChanges;
+        IReadOnlyList<SubjectPropertyChange> localChanges;
+        if (!hasLocal)
+        {
+            sourceChanges = changes.ToArray();
+            localChanges = [];
+        }
+        else
+        {
+            var sourceList = new List<SubjectPropertyChange>(changes.Length);
+            var localList = new List<SubjectPropertyChange>();
+            foreach (var change in changes.Span)
+            {
+                if (change.Property.TryGetSource(out _))
+                {
+                    sourceList.Add(change);
+                }
+                else
+                {
+                    localList.Add(change);
+                }
+            }
+            sourceChanges = sourceList.ToArray();
+            localChanges = localList;
+        }
+
+        if (requirement == TransactionRequirement.SingleWrite)
+        {
+            var batchSize = source.WriteBatchSize;
+            if (batchSize > 0 && sourceChanges.Length > batchSize)
+            {
+                return new TransactionWriteResult(
+                    [],
+                    sourceChanges.ToArray(),
+                    [new InvalidOperationException(
+                        $"SingleWrite requirement violated: Transaction contains {sourceChanges.Length} changes for source '{source.GetType().Name}', but WriteBatchSize is {batchSize}.")],
+                    localChanges);
+            }
+        }
+
+        var allFailed = new List<SubjectPropertyChange>();
+        var allErrors = new List<Exception>();
+
+        // 1. Write to the source.
+        var writeResult = await source.WriteChangesInBatchesAsync(sourceChanges, cancellationToken);
+
+        List<SubjectPropertyChange> written;
+        if (writeResult.Error is not null)
+        {
+            var failedSet = new HashSet<SubjectPropertyChange>(writeResult.FailedChanges);
+            written = new List<SubjectPropertyChange>(sourceChanges.Length);
+            foreach (var change in sourceChanges.Span)
+            {
+                if (!failedSet.Contains(change))
+                {
+                    written.Add(change);
+                }
+            }
+
+            allFailed.AddRange(writeResult.FailedChanges);
+            allErrors.Add(new SourceTransactionWriteException(source, [.. writeResult.FailedChanges], writeResult.Error));
+
+            if (failureHandling == TransactionFailureHandling.Rollback)
+            {
+                await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken);
+                return new TransactionWriteResult([], allFailed, allErrors, localChanges);
+            }
+        }
+        else
+        {
+            written = new List<SubjectPropertyChange>(sourceChanges.Length);
+            foreach (var change in sourceChanges.Span)
+            {
+                written.Add(change);
+            }
+        }
+
+        // 2. Apply the written changes to the in-process model.
+        var (applied, applyFailed, applyErrors) = written.ApplyAllChanges();
+        allFailed.AddRange(applyFailed);
+        allErrors.AddRange(applyErrors);
+
+        if (applyFailed.Count > 0)
+        {
+            if (failureHandling == TransactionFailureHandling.Rollback)
+            {
+                TryRevertAppliedChanges(applied, allFailed, allErrors);
+                await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken);
+                return new TransactionWriteResult([], allFailed, allErrors, localChanges);
+            }
+
+            // BestEffort: revert only the sources for failed local applies (keep each property in sync).
+            await TryRevertSourceWritesAsync(GroupChangesBySource(applyFailed), allFailed, allErrors, cancellationToken);
+        }
+
+        return new TransactionWriteResult(applied, allFailed, allErrors, localChanges);
+    }
+
+    private static Dictionary<ISubjectSource, List<SubjectPropertyChange>> SingleSourceMap(
+        ISubjectSource source, List<SubjectPropertyChange> changes) => new(1) { [source] = changes };
+
+    private async Task<TransactionWriteResult> WriteGroupedAsync(
+        ReadOnlyMemory<SubjectPropertyChange> changes,
+        TransactionFailureHandling failureHandling,
+        TransactionRequirement requirement,
+        CancellationToken cancellationToken)
+    {
         // 1. Separate source-bound vs local changes
         var (localChanges, externalChangesBySource) = GroupChangesBySourceType(changes.Span);
 

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -338,15 +338,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
 
         if (result.Error is not null)
         {
-            var failedSet = new HashSet<SubjectPropertyChange>(result.FailedChanges);
-            var written = new List<SubjectPropertyChange>(sourceChanges.Count);
-            foreach (var change in sourceChanges)
-            {
-                if (!failedSet.Contains(change))
-                {
-                    written.Add(change);
-                }
-            }
+            var written = ExcludeFailed(sourceChanges, result.FailedChanges);
             var error = new SourceTransactionWriteException(source, [.. result.FailedChanges], result.Error);
             return (written, [.. result.FailedChanges], error);
         }

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -16,9 +16,10 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         TransactionRequirement requirement,
         CancellationToken cancellationToken)
     {
-        // Single pass: detect whether all source-bound changes target one source (the common
-        // single-connector case). That case takes an allocation-light path; everything else
-        // (no source, or multiple sources) falls back to the general grouped path.
+        // Fast path when all source-bound changes target one source (common single-connector case);
+        // 0 sources or multiple sources fall back to the grouped path. A property's source is fixed
+        // for the transaction's lifetime (set at connector attach, cleared at detach, never mid-commit),
+        // so re-reading it in WriteSingleSourceAsync stays consistent with this scan.
         ISubjectSource? singleSource = null;
         var multipleSources = false;
         var hasLocal = false;
@@ -63,9 +64,8 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         TransactionRequirement requirement,
         CancellationToken cancellationToken)
     {
-        // Partition source-bound vs local changes. The source receives a private array copy (never the
-        // transaction's pooled buffer), matching the grouped path, so a source that retains the memory
-        // past the call is not exposed to the array being returned to the pool.
+        // The source gets a private array copy, never the transaction's pooled buffer, so a source that
+        // retains the memory is unaffected when the buffer returns to the pool (matches the grouped path).
         SubjectPropertyChange[] sourceChanges;
         IReadOnlyList<SubjectPropertyChange> localChanges;
         if (!hasLocal)

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -45,10 +45,10 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
 
         if (singleSource is not null && !multipleSources)
         {
-            return await WriteSingleSourceAsync(singleSource, changes, hasLocal, failureHandling, requirement, cancellationToken);
+            return await WriteSingleSourceAsync(singleSource, changes, hasLocal, failureHandling, requirement, cancellationToken).ConfigureAwait(false);
         }
 
-        return await WriteGroupedAsync(changes, failureHandling, requirement, cancellationToken);
+        return await WriteGroupedAsync(changes, failureHandling, requirement, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
 
         // Write to the source. On a reported error only the non-failed changes reached it; otherwise
         // the whole array did, so it is reused directly as the written set (no copy).
-        var writeResult = await source.WriteChangesInBatchesAsync(sourceChanges, cancellationToken);
+        var writeResult = await source.WriteChangesInBatchesAsync(sourceChanges, cancellationToken).ConfigureAwait(false);
         IReadOnlyList<SubjectPropertyChange> written = sourceChanges;
         if (writeResult.Error is not null)
         {
@@ -121,7 +121,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
 
             if (failureHandling == TransactionFailureHandling.Rollback)
             {
-                await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken);
+                await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken).ConfigureAwait(false);
                 return new TransactionWriteResult([], allFailed, allErrors, localChanges);
             }
         }
@@ -136,12 +136,12 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             if (failureHandling == TransactionFailureHandling.Rollback)
             {
                 TryRevertAppliedChanges(applied, allFailed, allErrors);
-                await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken);
+                await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken).ConfigureAwait(false);
                 return new TransactionWriteResult([], allFailed, allErrors, localChanges);
             }
 
             // BestEffort: revert only the sources for failed local applies (keep each property in sync).
-            await TryRevertSourceWritesAsync(GroupChangesBySource(applyFailed), allFailed, allErrors, cancellationToken);
+            await TryRevertSourceWritesAsync(GroupChangesBySource(applyFailed), allFailed, allErrors, cancellationToken).ConfigureAwait(false);
         }
 
         return new TransactionWriteResult(applied, allFailed, allErrors, localChanges);
@@ -196,14 +196,14 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         var allErrors = new List<Exception>();
 
         // 4. Write to external sources in parallel
-        var (successfulBySource, failed, errors) = await WriteToExternalSourcesAsync(externalChangesBySource, cancellationToken);
+        var (successfulBySource, failed, errors) = await WriteToExternalSourcesAsync(externalChangesBySource, cancellationToken).ConfigureAwait(false);
         allFailed.AddRange(failed);
         allErrors.AddRange(errors);
 
         // If any source failed and rollback mode, revert successful sources
         if (failureHandling == TransactionFailureHandling.Rollback && allFailed.Count > 0)
         {
-            await TryRevertSourceWritesAsync(successfulBySource, allFailed, allErrors, cancellationToken);
+            await TryRevertSourceWritesAsync(successfulBySource, allFailed, allErrors, cancellationToken).ConfigureAwait(false);
             return new TransactionWriteResult([], allFailed, allErrors, localChanges);
         }
 
@@ -221,7 +221,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             {
                 // Rollback mode: revert everything (all-or-nothing)
                 TryRevertAppliedChanges(applied, allFailed, allErrors);
-                await TryRevertSourceWritesAsync(successfulBySource, allFailed, allErrors, cancellationToken);
+                await TryRevertSourceWritesAsync(successfulBySource, allFailed, allErrors, cancellationToken).ConfigureAwait(false);
                 return new TransactionWriteResult([], allFailed, allErrors, localChanges);
             }
 
@@ -229,7 +229,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             var sourcesToRollback = GroupChangesBySource(applyFailed);
             if (sourcesToRollback.Count > 0)
             {
-                await TryRevertSourceWritesAsync(sourcesToRollback, allFailed, allErrors, cancellationToken);
+                await TryRevertSourceWritesAsync(sourcesToRollback, allFailed, allErrors, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -306,7 +306,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             writeTasks[taskIndex++] = WriteToSourceWithResultAsync(kvp.Key, kvp.Value, cancellationToken);
         }
 
-        var results = await Task.WhenAll(writeTasks);
+        var results = await Task.WhenAll(writeTasks).ConfigureAwait(false);
 
         foreach (var (source, (successList, failList, error)) in results)
         {
@@ -334,7 +334,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             CancellationToken cancellationToken)
     {
         var memory = new ReadOnlyMemory<SubjectPropertyChange>(sourceChanges.ToArray());
-        var result = await source.WriteChangesInBatchesAsync(memory, cancellationToken);
+        var result = await source.WriteChangesInBatchesAsync(memory, cancellationToken).ConfigureAwait(false);
 
         if (result.Error is not null)
         {
@@ -362,7 +362,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             var rollbackChanges = originalChanges.ToRollbackChanges().ToArray();
 
             var memory = new ReadOnlyMemory<SubjectPropertyChange>(rollbackChanges);
-            var result = await source.WriteChangesInBatchesAsync(memory, cancellationToken);
+            var result = await source.WriteChangesInBatchesAsync(memory, cancellationToken).ConfigureAwait(false);
 
             if (result.Error is not null)
             {
@@ -463,7 +463,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             List<SubjectPropertyChange> sourceChanges,
             CancellationToken cancellationToken)
     {
-        var result = await TryWriteToSourceAsync(source, sourceChanges, cancellationToken);
+        var result = await TryWriteToSourceAsync(source, sourceChanges, cancellationToken).ConfigureAwait(false);
         return (source, result);
     }
 }

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -389,7 +389,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
     /// Attempts to revert in-process model changes by applying rollback changes.
     /// </summary>
     private static void TryRevertAppliedChanges(
-        List<SubjectPropertyChange> successfulChanges,
+        IReadOnlyList<SubjectPropertyChange> successfulChanges,
         List<SubjectPropertyChange> failedChanges,
         List<Exception> errors)
     {

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -16,13 +16,12 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
         TransactionRequirement requirement,
         CancellationToken cancellationToken)
     {
-        // Fast path when all source-bound changes target one source (common single-connector case);
-        // 0 sources or multiple sources fall back to the grouped path. A property's source is fixed
-        // for the transaction's lifetime (set at connector attach, cleared at detach, never mid-commit),
-        // so re-reading it in WriteSingleSourceAsync stays consistent with this scan.
+        // Read each property's source exactly once: classify (single / multiple / none) and collect the
+        // source-less (local) changes in the same pass, so the single-source path never re-reads the
+        // mapping (which a concurrent SetSource/RemoveSource could otherwise change between two reads).
         ISubjectSource? singleSource = null;
         var multipleSources = false;
-        var hasLocal = false;
+        List<SubjectPropertyChange>? localChanges = null;
         foreach (var change in changes.Span)
         {
             if (change.Property.TryGetSource(out var source))
@@ -39,13 +38,13 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             }
             else
             {
-                hasLocal = true;
+                (localChanges ??= []).Add(change);
             }
         }
 
         if (singleSource is not null && !multipleSources)
         {
-            return await WriteSingleSourceAsync(singleSource, changes, hasLocal, failureHandling, requirement, cancellationToken).ConfigureAwait(false);
+            return await WriteSingleSourceAsync(singleSource, changes, localChanges, failureHandling, requirement, cancellationToken).ConfigureAwait(false);
         }
 
         return await WriteGroupedAsync(changes, failureHandling, requirement, cancellationToken).ConfigureAwait(false);
@@ -54,42 +53,45 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
     /// <summary>
     /// Allocation-light path for the common case where every source-bound change targets the same
     /// source: writes once (no per-source grouping or parallel dispatch) and applies in-process.
-    /// Failure and rollback semantics mirror <see cref="WriteGroupedAsync"/>.
+    /// <paramref name="localChanges"/> are the source-less changes already separated by the caller's
+    /// single classification pass. Failure and rollback semantics mirror <see cref="WriteGroupedAsync"/>.
     /// </summary>
     private static async Task<TransactionWriteResult> WriteSingleSourceAsync(
         ISubjectSource source,
         ReadOnlyMemory<SubjectPropertyChange> changes,
-        bool hasLocal,
+        IReadOnlyList<SubjectPropertyChange>? localChanges,
         TransactionFailureHandling failureHandling,
         TransactionRequirement requirement,
         CancellationToken cancellationToken)
     {
         // The source gets a private array copy, never the transaction's pooled buffer, so a source that
         // retains the memory is unaffected when the buffer returns to the pool (matches the grouped path).
+        // Source-bound changes are derived by excluding the already-collected local changes, so the
+        // property source is never read a second time.
+        var local = localChanges ?? (IReadOnlyList<SubjectPropertyChange>)[];
         SubjectPropertyChange[] sourceChanges;
-        IReadOnlyList<SubjectPropertyChange> localChanges;
-        if (!hasLocal)
+        if (local.Count == 0)
         {
             sourceChanges = changes.ToArray();
-            localChanges = [];
         }
         else
         {
-            var sourceList = new List<SubjectPropertyChange>(changes.Length);
-            var localList = new List<SubjectPropertyChange>();
+            // local is an in-order subsequence of changes (both walk changes.Span in the same order),
+            // so a two-pointer walk separates the source-bound changes without an extra set/lookup.
+            var sourceList = new List<SubjectPropertyChange>(changes.Length - local.Count);
+            var localIndex = 0;
             foreach (var change in changes.Span)
             {
-                if (change.Property.TryGetSource(out _))
+                if (localIndex < local.Count && local[localIndex].Equals(change))
                 {
-                    sourceList.Add(change);
+                    localIndex++;
                 }
                 else
                 {
-                    localList.Add(change);
+                    sourceList.Add(change);
                 }
             }
-            sourceChanges = sourceList.ToArray();
-            localChanges = localList;
+            sourceChanges = [.. sourceList];
         }
 
         if (requirement == TransactionRequirement.SingleWrite)
@@ -102,7 +104,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
                     sourceChanges,
                     [new InvalidOperationException(
                         $"SingleWrite requirement violated: Transaction contains {sourceChanges.Length} changes for source '{source.GetType().Name}', but WriteBatchSize is {batchSize}.")],
-                    localChanges);
+                    local);
             }
         }
 
@@ -122,7 +124,7 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             if (failureHandling == TransactionFailureHandling.Rollback)
             {
                 await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken).ConfigureAwait(false);
-                return new TransactionWriteResult([], allFailed, allErrors, localChanges);
+                return new TransactionWriteResult([], allFailed, allErrors, local);
             }
         }
 
@@ -137,14 +139,14 @@ internal sealed class SourceTransactionWriter : ITransactionWriter
             {
                 TryRevertAppliedChanges(applied, allFailed, allErrors);
                 await TryRevertSourceWritesAsync(SingleSourceMap(source, written), allFailed, allErrors, cancellationToken).ConfigureAwait(false);
-                return new TransactionWriteResult([], allFailed, allErrors, localChanges);
+                return new TransactionWriteResult([], allFailed, allErrors, local);
             }
 
             // BestEffort: revert only the sources for failed local applies (keep each property in sync).
             await TryRevertSourceWritesAsync(GroupChangesBySource(applyFailed), allFailed, allErrors, cancellationToken).ConfigureAwait(false);
         }
 
-        return new TransactionWriteResult(applied, allFailed, allErrors, localChanges);
+        return new TransactionWriteResult(applied, allFailed, allErrors, local);
     }
 
     private static List<SubjectPropertyChange> ExcludeFailed(

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -156,7 +156,7 @@ public class SubjectTransactionTests
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
 
             Assert.Single(ex.ConflictingProperties);
             Assert.Equal(nameof(Person.FirstName), ex.ConflictingProperties[0].Name);
@@ -201,7 +201,7 @@ public class SubjectTransactionTests
 
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
         }
     }
 
@@ -215,7 +215,7 @@ public class SubjectTransactionTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ObjectDisposedException>(
-            () => transaction.CommitAsync(CancellationToken.None));
+            () => transaction.CommitAsync(CancellationToken.None).AsTask());
     }
 
     [Fact]
@@ -488,7 +488,7 @@ public class SubjectTransactionTests
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<SubjectTransactionConflictException>(
-                () => transaction.CommitAsync(CancellationToken.None));
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
 
             Assert.Equal(2, ex.ConflictingProperties.Count);
             Assert.Contains(ex.ConflictingProperties, p => p.Name == nameof(Person.FirstName));

--- a/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -213,7 +213,7 @@ namespace Namotion.Interceptor.Tracking.Transactions
         public Namotion.Interceptor.IInterceptorSubjectContext Context { get; }
         public Namotion.Interceptor.Tracking.Transactions.TransactionLocking Locking { get; }
         public static Namotion.Interceptor.Tracking.Transactions.SubjectTransaction? Current { get; }
-        public System.Threading.Tasks.Task CommitAsync(System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.ValueTask CommitAsync(System.Threading.CancellationToken cancellationToken) { }
         public void Dispose() { }
         public System.Collections.Generic.IReadOnlyList<Namotion.Interceptor.Tracking.Change.SubjectPropertyChange> GetPendingChanges() { }
     }

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeExtensions.cs
@@ -12,7 +12,7 @@ internal static class SubjectPropertyChangeExtensions
     /// </summary>
     /// <param name="changes">The changes to create rollbacks for.</param>
     /// <returns>Rollback changes in reverse order.</returns>
-    public static IEnumerable<SubjectPropertyChange> ToRollbackChanges(
+    public static List<SubjectPropertyChange> ToRollbackChanges(
         this IEnumerable<SubjectPropertyChange> changes) =>
         changes.Reverse().Select(c => SubjectPropertyChange.Create(
             c.Property,
@@ -20,7 +20,7 @@ internal static class SubjectPropertyChangeExtensions
             changedTimestamp: c.ChangedTimestamp,
             receivedTimestamp: c.ReceivedTimestamp,
             oldValue: c.GetNewValue<object?>(),
-            newValue: c.GetOldValue<object?>()));
+            newValue: c.GetOldValue<object?>())).ToList();
 
     /// <summary>
     /// Applies a single property change to the in-process model.
@@ -48,33 +48,49 @@ internal static class SubjectPropertyChangeExtensions
     }
 
     /// <summary>
-    /// Applies multiple property changes, collecting successes and failures.
+    /// Applies multiple property changes, collecting successes and failures. On full success the input
+    /// is returned as the successful set (no copy); the failure/error lists are allocated only if a
+    /// change actually fails.
     /// </summary>
     /// <param name="changes">The changes to apply.</param>
-    /// <returns>Lists of successful changes, failed changes, and errors.</returns>
-    public static (List<SubjectPropertyChange> Successful, List<SubjectPropertyChange> Failed, List<Exception> Errors)
-        ApplyAllChanges(this IEnumerable<SubjectPropertyChange> changes)
+    /// <returns>The successful changes, failed changes, and errors.</returns>
+    public static (IReadOnlyList<SubjectPropertyChange> Successful, IReadOnlyList<SubjectPropertyChange> Failed, IReadOnlyList<Exception> Errors)
+        ApplyAllChanges(this IReadOnlyList<SubjectPropertyChange> changes)
     {
-        var successful = new List<SubjectPropertyChange>();
-        var failed = new List<SubjectPropertyChange>();
-        var errors = new List<Exception>();
+        List<SubjectPropertyChange>? successful = null;
+        List<SubjectPropertyChange>? failed = null;
+        List<Exception>? errors = null;
 
-        foreach (var change in changes)
+        for (var i = 0; i < changes.Count; i++)
         {
+            var change = changes[i];
             if (change.TryApplyChange(out var error))
             {
-                successful.Add(change);
+                successful?.Add(change);
             }
             else
             {
+                if (failed is null)
+                {
+                    // First failure: materialize the successes seen so far.
+                    successful = new List<SubjectPropertyChange>(i);
+                    for (var j = 0; j < i; j++)
+                    {
+                        successful.Add(changes[j]);
+                    }
+                    failed = [];
+                }
+
                 failed.Add(change);
                 if (error != null)
                 {
-                    errors.Add(error);
+                    (errors ??= []).Add(error);
                 }
             }
         }
 
-        return (successful, failed, errors);
+        return failed is null
+            ? (changes, [], [])
+            : (successful!, failed, errors ?? []);
     }
 }

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeExtensions.cs
@@ -48,12 +48,9 @@ internal static class SubjectPropertyChangeExtensions
     }
 
     /// <summary>
-    /// Applies multiple property changes, collecting successes and failures. On full success the input
-    /// is returned as the successful set (no copy); the failure/error lists are allocated only if a
-    /// change actually fails.
+    /// Applies all changes. On full success returns the input as the successful set (no copy); the
+    /// failed/error lists are allocated only when a change fails.
     /// </summary>
-    /// <param name="changes">The changes to apply.</param>
-    /// <returns>The successful changes, failed changes, and errors.</returns>
     public static (IReadOnlyList<SubjectPropertyChange> Successful, IReadOnlyList<SubjectPropertyChange> Failed, IReadOnlyList<Exception> Errors)
         ApplyAllChanges(this IReadOnlyList<SubjectPropertyChange> changes)
     {

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -242,7 +242,7 @@ public sealed class SubjectTransaction : IDisposable
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the transaction has been disposed.</exception>
     /// <exception cref="SubjectTransactionException">Thrown when one or more external source writes failed.</exception>
-    public async Task CommitAsync(CancellationToken cancellationToken)
+    public async ValueTask CommitAsync(CancellationToken cancellationToken)
     {
         ValidateCanCommit();
 
@@ -255,17 +255,39 @@ public sealed class SubjectTransaction : IDisposable
             }
         }
 
-        var commitLock = await AcquireOptimisticLockIfNeededAsync(cancellationToken);
+        var commitLock = await AcquireOptimisticLockIfNeededAsync(cancellationToken).ConfigureAwait(false);
         var (rentedArray, changes) = StartCommitAndSnapshotChanges();
 
         try
         {
             ThrowIfConflictsDetected(changes.Span);
 
+            var writeHandler = Context.TryGetService<ITransactionWriter>();
+            if (writeHandler is null)
+            {
+                // Fast path: in-memory only. No source writer, no async work, no CTS.
+                var failure = TryApplyChangesInMemory(changes.Span);
+
+                // Clear pending changes and mark committed BEFORE throwing so subsequent
+                // property reads do not return stale captured values via TryGetPendingValue.
+                lock (_pendingChangesLock)
+                {
+                    _pendingChanges.Clear();
+                }
+
+                _isCommitted = true;
+
+                if (failure is not null)
+                {
+                    throw failure;
+                }
+                return;
+            }
+
             using var timeoutCts = CreateCommitTimeoutCts();
             var commitToken = timeoutCts?.Token ?? CancellationToken.None;
 
-            var (successful, failed, errors) = await ExecuteWritesAsync(changes, commitToken);
+            var sourceFailure = await TryExecuteWritesWithSourceAsync(writeHandler, changes, commitToken).ConfigureAwait(false);
 
             lock (_pendingChangesLock)
             {
@@ -274,7 +296,10 @@ public sealed class SubjectTransaction : IDisposable
 
             _isCommitted = true;
 
-            ThrowIfFailed(successful, failed, errors);
+            if (sourceFailure is not null)
+            {
+                throw sourceFailure;
+            }
         }
         finally
         {
@@ -292,6 +317,80 @@ public sealed class SubjectTransaction : IDisposable
         }
     }
 
+    /// <summary>
+    /// Synchronous in-memory commit. Used when no <see cref="ITransactionWriter"/> is registered.
+    /// Avoids CTS allocation, state-machine boxing, and eagerly-allocated tracking lists.
+    /// </summary>
+    /// <summary>
+    /// Applies all changes in-process. Returns null on success, or a populated exception when one or more
+    /// changes (or their rollbacks) failed. The caller is responsible for clearing pending changes and
+    /// marking the transaction committed before re-throwing — otherwise, subsequent reads would return
+    /// stale pending values via <see cref="TryGetPendingValue"/>.
+    /// </summary>
+    private SubjectTransactionException? TryApplyChangesInMemory(ReadOnlySpan<SubjectPropertyChange> changes)
+    {
+        List<SubjectPropertyChange>? successful = null;
+        List<SubjectPropertyChange>? failed = null;
+        List<Exception>? errors = null;
+
+        foreach (var change in changes)
+        {
+            if (change.TryApplyChange(out var error))
+            {
+                // Track applied changes when rollback is possible (we may need to revert them)
+                // or when a failure has already occurred (we need them for the exception).
+                if (_failureHandling == TransactionFailureHandling.Rollback || failed is not null)
+                {
+                    (successful ??= new List<SubjectPropertyChange>(changes.Length)).Add(change);
+                }
+            }
+            else
+            {
+                (failed ??= []).Add(change);
+                if (error != null)
+                {
+                    (errors ??= []).Add(error);
+                }
+            }
+        }
+
+        if (failed is null) return null;
+
+        if (_failureHandling == TransactionFailureHandling.Rollback && successful is { Count: > 0 })
+        {
+            for (var i = successful.Count - 1; i >= 0; i--)
+            {
+                var applied = successful[i];
+                var rollback = SubjectPropertyChange.Create(
+                    applied.Property,
+                    source: applied.Source,
+                    changedTimestamp: applied.ChangedTimestamp,
+                    receivedTimestamp: applied.ReceivedTimestamp,
+                    oldValue: applied.GetNewValue<object?>(),
+                    newValue: applied.GetOldValue<object?>());
+
+                if (!rollback.TryApplyChange(out var revertError))
+                {
+                    failed.Add(rollback);
+                    if (revertError != null)
+                    {
+                        (errors ??= []).Add(revertError);
+                    }
+                }
+            }
+            successful.Clear();
+        }
+
+        var message = _failureHandling switch
+        {
+            TransactionFailureHandling.BestEffort => "One or more changes failed. Successfully written changes have been applied.",
+            TransactionFailureHandling.Rollback => "One or more changes failed. Rollback was attempted. No changes have been applied to the in-process model.",
+            _ => "One or more changes failed."
+        };
+
+        return new SubjectTransactionException(message, successful ?? [], failed, errors ?? []);
+    }
+
     private void ValidateCanCommit()
     {
         if (Volatile.Read(ref _isDisposed) != 0)
@@ -304,13 +403,20 @@ public sealed class SubjectTransaction : IDisposable
             throw new InvalidOperationException("CommitAsync is already in progress.");
     }
 
-    private async ValueTask<IDisposable?> AcquireOptimisticLockIfNeededAsync(CancellationToken cancellationToken)
+    private ValueTask<IDisposable?> AcquireOptimisticLockIfNeededAsync(CancellationToken cancellationToken)
     {
-        if (_locking == TransactionLocking.Optimistic)
+        // Sync fast path for the default (Exclusive) locking mode: lock was already
+        // acquired in BeginTransactionAsync, so commit needs no lock here.
+        if (_locking != TransactionLocking.Optimistic)
         {
-            return await Interceptor.AcquireTransactionLockAsync(cancellationToken).ConfigureAwait(false);
+            return default;
         }
-        return null;
+        return AcquireOptimisticLockSlowAsync(cancellationToken);
+    }
+
+    private async ValueTask<IDisposable?> AcquireOptimisticLockSlowAsync(CancellationToken cancellationToken)
+    {
+        return await Interceptor.AcquireTransactionLockAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private (SubjectPropertyChange[] RentedArray, Memory<SubjectPropertyChange> Changes) StartCommitAndSnapshotChanges()
@@ -353,43 +459,34 @@ public sealed class SubjectTransaction : IDisposable
             : new CancellationTokenSource(_commitTimeout);
     }
 
-    private async Task<(List<SubjectPropertyChange> Successful, List<SubjectPropertyChange> Failed, List<Exception> Errors)>
-        ExecuteWritesAsync(Memory<SubjectPropertyChange> changes, CancellationToken cancellationToken)
+    private async ValueTask<SubjectTransactionException?> TryExecuteWritesWithSourceAsync(
+        ITransactionWriter writeHandler,
+        Memory<SubjectPropertyChange> changes,
+        CancellationToken cancellationToken)
     {
         var changeCount = changes.Length;
-        
+
         var allSuccessfulChanges = new List<SubjectPropertyChange>(changeCount);
-        var allFailedChanges = new List<SubjectPropertyChange>();  // Rare, keep small initial capacity
-        var allErrors = new List<Exception>();  // Rare, keep small initial capacity
+        var allFailedChanges = new List<SubjectPropertyChange>();
+        var allErrors = new List<Exception>();
 
         var localChangesToApply = new List<SubjectPropertyChange>(changeCount);
 
-        var writeHandler = Context.TryGetService<ITransactionWriter>();
-        if (writeHandler != null)
-        {
-            await WriteToSourcesAsync(
-                writeHandler, changes,
-                allSuccessfulChanges, allFailedChanges, allErrors, localChangesToApply, cancellationToken);
-        }
-        else
-        {
-            foreach (var change in changes.Span)
-            {
-                localChangesToApply.Add(change);
-            }
-        }
+        await WriteToSourcesAsync(
+            writeHandler, changes,
+            allSuccessfulChanges, allFailedChanges, allErrors, localChangesToApply, cancellationToken).ConfigureAwait(false);
 
         if (localChangesToApply.Count > 0)
         {
             await ApplyLocalChangesAsync(
                 writeHandler,
-                allSuccessfulChanges, allFailedChanges, allErrors, localChangesToApply, cancellationToken);
+                allSuccessfulChanges, allFailedChanges, allErrors, localChangesToApply, cancellationToken).ConfigureAwait(false);
         }
 
-        return (allSuccessfulChanges, allFailedChanges, allErrors);
+        return TryBuildFailureException(allSuccessfulChanges, allFailedChanges, allErrors);
     }
 
-    private async Task WriteToSourcesAsync(ITransactionWriter writeHandler,
+    private async ValueTask WriteToSourcesAsync(ITransactionWriter writeHandler,
         Memory<SubjectPropertyChange> changes,
         List<SubjectPropertyChange> allSuccessfulChanges,
         List<SubjectPropertyChange> allFailedChanges,
@@ -397,7 +494,7 @@ public sealed class SubjectTransaction : IDisposable
         List<SubjectPropertyChange> localChangesToApply,
         CancellationToken cancellationToken)
     {
-        var result = await writeHandler.WriteChangesAsync(changes, _failureHandling, _requirement, cancellationToken);
+        var result = await writeHandler.WriteChangesAsync(changes, _failureHandling, _requirement, cancellationToken).ConfigureAwait(false);
         allSuccessfulChanges.AddRange(result.SuccessfulChanges);
         allFailedChanges.AddRange(result.FailedChanges);
         allErrors.AddRange(result.Errors);
@@ -410,7 +507,7 @@ public sealed class SubjectTransaction : IDisposable
         }
     }
 
-    private async Task ApplyLocalChangesAsync(ITransactionWriter? writeHandler,
+    private async ValueTask ApplyLocalChangesAsync(ITransactionWriter? writeHandler,
         List<SubjectPropertyChange> allSuccessfulChanges,
         List<SubjectPropertyChange> allFailedChanges,
         List<Exception> allErrors,
@@ -426,11 +523,11 @@ public sealed class SubjectTransaction : IDisposable
         {
             await RollbackOnLocalFailureAsync(
                 writeHandler,
-                allSuccessfulChanges, allFailedChanges, allErrors, applied, cancellationToken);
+                allSuccessfulChanges, allFailedChanges, allErrors, applied, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private async Task RollbackOnLocalFailureAsync(ITransactionWriter? writeHandler,
+    private async ValueTask RollbackOnLocalFailureAsync(ITransactionWriter? writeHandler,
         List<SubjectPropertyChange> allSuccessfulChanges,
         List<SubjectPropertyChange> allFailedChanges,
         List<Exception> allErrors,
@@ -450,7 +547,7 @@ public sealed class SubjectTransaction : IDisposable
                 rollbackChanges.AsMemory(),
                 TransactionFailureHandling.BestEffort,
                 TransactionRequirement.None,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             allFailedChanges.AddRange(rollbackResult.FailedChanges);
             allErrors.AddRange(rollbackResult.Errors);
@@ -459,22 +556,21 @@ public sealed class SubjectTransaction : IDisposable
         allSuccessfulChanges.Clear();
     }
 
-    private void ThrowIfFailed(
+    private SubjectTransactionException? TryBuildFailureException(
         List<SubjectPropertyChange> successful,
         List<SubjectPropertyChange> failed,
         List<Exception> errors)
     {
-        if (failed.Count > 0)
-        {
-            var message = _failureHandling switch
-            {
-                TransactionFailureHandling.BestEffort => "One or more changes failed. Successfully written changes have been applied.",
-                TransactionFailureHandling.Rollback => "One or more changes failed. Rollback was attempted. No changes have been applied to the in-process model.",
-                _ => "One or more changes failed."
-            };
+        if (failed.Count == 0) return null;
 
-            throw new SubjectTransactionException(message, successful, failed, errors);
-        }
+        var message = _failureHandling switch
+        {
+            TransactionFailureHandling.BestEffort => "One or more changes failed. Successfully written changes have been applied.",
+            TransactionFailureHandling.Rollback => "One or more changes failed. Rollback was attempted. No changes have been applied to the in-process model.",
+            _ => "One or more changes failed."
+        };
+
+        return new SubjectTransactionException(message, successful, failed, errors);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -356,25 +356,11 @@ public sealed class SubjectTransaction : IDisposable
 
         if (_failureHandling == TransactionFailureHandling.Rollback && successful is { Count: > 0 })
         {
-            for (var i = successful.Count - 1; i >= 0; i--)
+            var (_, revertFailed, revertErrors) = successful.ToRollbackChanges().ApplyAllChanges();
+            failed.AddRange(revertFailed);
+            if (revertErrors.Count > 0)
             {
-                var applied = successful[i];
-                var rollback = SubjectPropertyChange.Create(
-                    applied.Property,
-                    source: applied.Source,
-                    changedTimestamp: applied.ChangedTimestamp,
-                    receivedTimestamp: applied.ReceivedTimestamp,
-                    oldValue: applied.GetNewValue<object?>(),
-                    newValue: applied.GetOldValue<object?>());
-
-                if (!rollback.TryApplyChange(out var revertError))
-                {
-                    failed.Add(rollback);
-                    if (revertError != null)
-                    {
-                        (errors ??= []).Add(revertError);
-                    }
-                }
+                (errors ??= []).AddRange(revertErrors);
             }
             successful.Clear();
         }

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -318,14 +318,12 @@ public sealed class SubjectTransaction : IDisposable
     }
 
     /// <summary>
-    /// Synchronous in-memory commit. Used when no <see cref="ITransactionWriter"/> is registered.
-    /// Avoids CTS allocation, state-machine boxing, and eagerly-allocated tracking lists.
-    /// </summary>
-    /// <summary>
-    /// Applies all changes in-process. Returns null on success, or a populated exception when one or more
-    /// changes (or their rollbacks) failed. The caller is responsible for clearing pending changes and
-    /// marking the transaction committed before re-throwing — otherwise, subsequent reads would return
-    /// stale pending values via <see cref="TryGetPendingValue"/>.
+    /// Synchronous in-memory commit used when no <see cref="ITransactionWriter"/> is registered.
+    /// Avoids CTS allocation, state-machine boxing, and eagerly-allocated tracking lists by applying
+    /// changes in-process directly. Returns null on success, or a populated exception when one or more
+    /// changes (or their rollbacks) failed. The caller must clear pending changes and mark the
+    /// transaction committed before re-throwing, otherwise subsequent reads would return stale pending
+    /// values via <see cref="TryGetPendingValue"/>.
     /// </summary>
     private SubjectTransactionException? TryApplyChangesInMemory(ReadOnlySpan<SubjectPropertyChange> changes)
     {
@@ -381,14 +379,7 @@ public sealed class SubjectTransaction : IDisposable
             successful.Clear();
         }
 
-        var message = _failureHandling switch
-        {
-            TransactionFailureHandling.BestEffort => "One or more changes failed. Successfully written changes have been applied.",
-            TransactionFailureHandling.Rollback => "One or more changes failed. Rollback was attempted. No changes have been applied to the in-process model.",
-            _ => "One or more changes failed."
-        };
-
-        return new SubjectTransactionException(message, successful ?? [], failed, errors ?? []);
+        return CreateFailureException(successful ?? [], failed, errors ?? []);
     }
 
     private void ValidateCanCommit()
@@ -563,6 +554,14 @@ public sealed class SubjectTransaction : IDisposable
     {
         if (failed.Count == 0) return null;
 
+        return CreateFailureException(successful, failed, errors);
+    }
+
+    private SubjectTransactionException CreateFailureException(
+        IReadOnlyList<SubjectPropertyChange> successful,
+        IReadOnlyList<SubjectPropertyChange> failed,
+        IReadOnlyList<Exception> errors)
+    {
         var message = _failureHandling switch
         {
             TransactionFailureHandling.BestEffort => "One or more changes failed. Successfully written changes have been applied.",

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -512,7 +512,7 @@ public sealed class SubjectTransaction : IDisposable
         List<SubjectPropertyChange> allSuccessfulChanges,
         List<SubjectPropertyChange> allFailedChanges,
         List<Exception> allErrors,
-        List<SubjectPropertyChange> applied,
+        IReadOnlyList<SubjectPropertyChange> applied,
         CancellationToken cancellationToken)
     {
         // Revert successful local applies

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -471,7 +471,9 @@ public sealed class SubjectTransaction : IDisposable
                 allSuccessfulChanges, allFailedChanges, allErrors, localChangesToApply, cancellationToken).ConfigureAwait(false);
         }
 
-        return TryBuildFailureException(allSuccessfulChanges, allFailedChanges, allErrors);
+        return allFailedChanges.Count == 0
+            ? null
+            : CreateFailureException(allSuccessfulChanges, allFailedChanges, allErrors);
     }
 
     private async ValueTask ApplyLocalChangesAsync(ITransactionWriter? writeHandler,
@@ -521,16 +523,6 @@ public sealed class SubjectTransaction : IDisposable
         }
 
         allSuccessfulChanges.Clear();
-    }
-
-    private SubjectTransactionException? TryBuildFailureException(
-        List<SubjectPropertyChange> successful,
-        List<SubjectPropertyChange> failed,
-        List<Exception> errors)
-    {
-        if (failed.Count == 0) return null;
-
-        return CreateFailureException(successful, failed, errors);
     }
 
     private SubjectTransactionException CreateFailureException(

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -241,7 +241,7 @@ public sealed class SubjectTransaction : IDisposable
     /// </remarks>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the transaction has been disposed.</exception>
-    /// <exception cref="SubjectTransactionException">Thrown when one or more external source writes failed.</exception>
+    /// <exception cref="SubjectTransactionException">Thrown when one or more changes failed to commit.</exception>
     public async ValueTask CommitAsync(CancellationToken cancellationToken)
     {
         ValidateCanCommit();
@@ -262,33 +262,22 @@ public sealed class SubjectTransaction : IDisposable
         {
             ThrowIfConflictsDetected(changes.Span);
 
+            SubjectTransactionException? failure;
             var writeHandler = Context.TryGetService<ITransactionWriter>();
             if (writeHandler is null)
             {
                 // Fast path: in-memory only. No source writer, no async work, no CTS.
-                var failure = TryApplyChangesInMemory(changes.Span);
-
-                // Clear pending changes and mark committed BEFORE throwing so subsequent
-                // property reads do not return stale captured values via TryGetPendingValue.
-                lock (_pendingChangesLock)
-                {
-                    _pendingChanges.Clear();
-                }
-
-                _isCommitted = true;
-
-                if (failure is not null)
-                {
-                    throw failure;
-                }
-                return;
+                failure = TryApplyChangesInMemory(changes.Span);
+            }
+            else
+            {
+                using var timeoutCts = CreateCommitTimeoutCts();
+                var commitToken = timeoutCts?.Token ?? CancellationToken.None;
+                failure = await TryExecuteWritesWithSourceAsync(writeHandler, changes, commitToken).ConfigureAwait(false);
             }
 
-            using var timeoutCts = CreateCommitTimeoutCts();
-            var commitToken = timeoutCts?.Token ?? CancellationToken.None;
-
-            var sourceFailure = await TryExecuteWritesWithSourceAsync(writeHandler, changes, commitToken).ConfigureAwait(false);
-
+            // Clear pending changes and mark committed BEFORE throwing so subsequent
+            // property reads do not return stale captured values via TryGetPendingValue.
             lock (_pendingChangesLock)
             {
                 _pendingChanges.Clear();
@@ -296,9 +285,9 @@ public sealed class SubjectTransaction : IDisposable
 
             _isCommitted = true;
 
-            if (sourceFailure is not null)
+            if (failure is not null)
             {
-                throw sourceFailure;
+                throw failure;
             }
         }
         finally
@@ -472,7 +461,7 @@ public sealed class SubjectTransaction : IDisposable
             : CreateFailureException(allSuccessfulChanges, allFailedChanges, allErrors);
     }
 
-    private async ValueTask ApplyLocalChangesAsync(ITransactionWriter? writeHandler,
+    private async ValueTask ApplyLocalChangesAsync(ITransactionWriter writeHandler,
         List<SubjectPropertyChange> allSuccessfulChanges,
         List<SubjectPropertyChange> allFailedChanges,
         List<Exception> allErrors,
@@ -492,7 +481,7 @@ public sealed class SubjectTransaction : IDisposable
         }
     }
 
-    private async ValueTask RollbackOnLocalFailureAsync(ITransactionWriter? writeHandler,
+    private async ValueTask RollbackOnLocalFailureAsync(ITransactionWriter writeHandler,
         List<SubjectPropertyChange> allSuccessfulChanges,
         List<SubjectPropertyChange> allFailedChanges,
         List<Exception> allErrors,
@@ -505,7 +494,7 @@ public sealed class SubjectTransaction : IDisposable
         allErrors.AddRange(localRevertErrors);
 
         // Revert source-bound changes by calling writer with rollback changes
-        if (writeHandler != null && allSuccessfulChanges.Count > 0)
+        if (allSuccessfulChanges.Count > 0)
         {
             var rollbackChanges = allSuccessfulChanges.ToRollbackChanges().ToArray();
             var rollbackResult = await writeHandler.WriteChangesAsync(

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -318,12 +318,9 @@ public sealed class SubjectTransaction : IDisposable
     }
 
     /// <summary>
-    /// Synchronous in-memory commit used when no <see cref="ITransactionWriter"/> is registered.
-    /// Avoids CTS allocation, state-machine boxing, and eagerly-allocated tracking lists by applying
-    /// changes in-process directly. Returns null on success, or a populated exception when one or more
-    /// changes (or their rollbacks) failed. The caller must clear pending changes and mark the
-    /// transaction committed before re-throwing, otherwise subsequent reads would return stale pending
-    /// values via <see cref="TryGetPendingValue"/>.
+    /// Synchronous in-memory commit (no <see cref="ITransactionWriter"/>): applies changes directly,
+    /// avoiding CTS, async state-machine, and eager tracking-list allocations. Returns null on success
+    /// or a populated exception on failure (the caller clears pending state before re-throwing).
     /// </summary>
     private SubjectTransactionException? TryApplyChangesInMemory(ReadOnlySpan<SubjectPropertyChange> changes)
     {
@@ -445,8 +442,7 @@ public sealed class SubjectTransaction : IDisposable
 
         var localChanges = result.LocalChanges;
 
-        // Fast path: source writes all succeeded and there are no local changes to apply,
-        // so there is nothing to aggregate and no failure to report.
+        // Fast path: all source writes succeeded and nothing local to apply, so no aggregation needed.
         if (result.FailedChanges.Count == 0 && localChanges.Count == 0)
         {
             return null;

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -455,17 +455,28 @@ public sealed class SubjectTransaction : IDisposable
         Memory<SubjectPropertyChange> changes,
         CancellationToken cancellationToken)
     {
-        var changeCount = changes.Length;
+        var result = await writeHandler.WriteChangesAsync(changes, _failureHandling, _requirement, cancellationToken).ConfigureAwait(false);
 
-        var allSuccessfulChanges = new List<SubjectPropertyChange>(changeCount);
-        var allFailedChanges = new List<SubjectPropertyChange>();
-        var allErrors = new List<Exception>();
+        var localChanges = result.LocalChanges;
 
-        var localChangesToApply = new List<SubjectPropertyChange>(changeCount);
+        // Fast path: source writes all succeeded and there are no local changes to apply,
+        // so there is nothing to aggregate and no failure to report.
+        if (result.FailedChanges.Count == 0 && localChanges.Count == 0)
+        {
+            return null;
+        }
 
-        await WriteToSourcesAsync(
-            writeHandler, changes,
-            allSuccessfulChanges, allFailedChanges, allErrors, localChangesToApply, cancellationToken).ConfigureAwait(false);
+        var allSuccessfulChanges = new List<SubjectPropertyChange>(result.SuccessfulChanges);
+        var allFailedChanges = new List<SubjectPropertyChange>(result.FailedChanges);
+        var allErrors = new List<Exception>(result.Errors);
+
+        var localChangesToApply = new List<SubjectPropertyChange>(localChanges);
+
+        if (_failureHandling == TransactionFailureHandling.Rollback && allFailedChanges.Count > 0)
+        {
+            allFailedChanges.AddRange(localChangesToApply);
+            localChangesToApply.Clear();
+        }
 
         if (localChangesToApply.Count > 0)
         {
@@ -475,27 +486,6 @@ public sealed class SubjectTransaction : IDisposable
         }
 
         return TryBuildFailureException(allSuccessfulChanges, allFailedChanges, allErrors);
-    }
-
-    private async ValueTask WriteToSourcesAsync(ITransactionWriter writeHandler,
-        Memory<SubjectPropertyChange> changes,
-        List<SubjectPropertyChange> allSuccessfulChanges,
-        List<SubjectPropertyChange> allFailedChanges,
-        List<Exception> allErrors,
-        List<SubjectPropertyChange> localChangesToApply,
-        CancellationToken cancellationToken)
-    {
-        var result = await writeHandler.WriteChangesAsync(changes, _failureHandling, _requirement, cancellationToken).ConfigureAwait(false);
-        allSuccessfulChanges.AddRange(result.SuccessfulChanges);
-        allFailedChanges.AddRange(result.FailedChanges);
-        allErrors.AddRange(result.Errors);
-        localChangesToApply.AddRange(result.LocalChanges);
-
-        if (_failureHandling == TransactionFailureHandling.Rollback && allFailedChanges.Count > 0)
-        {
-            allFailedChanges.AddRange(localChangesToApply);
-            localChangesToApply.Clear();
-        }
     }
 
     private async ValueTask ApplyLocalChangesAsync(ITransactionWriter? writeHandler,


### PR DESCRIPTION
## Summary

Rebases the transaction-allocation work from #276 onto master (that PR was stacked on the unmerged `feature/registry-with-methods-and-refactor` branch, so it could not target master directly), then simplifies the commit path and extends the allocation reductions to the source-bound path.

Commits:
1. **Reduce transaction allocations** (cherry-picked from #276) - in-memory (no source writer) commit fast path; `CommitAsync` returns `ValueTask`.
2. **Adapt tests and public API snapshot** to the `ValueTask` return type.
3. **Add transaction commit benchmark** (`SubjectTransactionBenchmark`, local / single-source / single-source-with-local / multi-source modes).
4. **Deduplicate** the failure-exception construction.
5. **Source commit fast path** - skip aggregate-list allocation when source writes succeed and there are no local changes.
6. **Single-source fast path** in `SourceTransactionWriter` - the common single-connector case writes once (no per-source dictionary, parallel-task dispatch, or flatten) and applies in-process; multi-source falls back to the original grouped path.
7. **Zero-copy `ApplyAllChanges`** - returns the input as the successful set on full success, allocating failure lists only when a change fails.
8. **Read property source once** in the single-source path - collect local changes during the single classification pass and derive source-bound changes by exclusion, closing a TOCTOU window where a concurrent `SetSource`/`RemoveSource` could change a mapping between two reads.

## Note on public API

`SubjectTransaction.CommitAsync` changes from `Task` to `ValueTask`. Source-compatible for `await`; callers needing a `Task` use `.AsTask()`.

## Benchmark results

`SubjectTransactionBenchmark` commits 50 property changes, compared against a baseline branch with the benchmark but not these changes (full job, CPU pinned at 2.0 GHz, StdDev ~0.1-0.4 us):

| Mode | master | this branch | Allocated | Time |
|---|---|---|---|---|
| Local | 90.56 KB / 98.7 us | 47.73 KB / 87.1 us | **-47%** | **-12%** |
| SingleSource | 143.41 KB / 116.0 us | 57.52 KB / 96.2 us | **-60%** | **-17%** |
| SingleSourceWithLocal | 128.30 KB / 113.5 us | 87.90 KB / 103.1 us | **-31%** | **-9%** |
| MultiSource | 143.05 KB / 115.0 us | 100.45 KB / 106.4 us | **-30%** | **-7%** |

## Test plan
- [x] `Namotion.Interceptor.Tracking.Tests` (332 passed)
- [x] `Namotion.Interceptor.Connectors.Tests` (410 passed)
- [x] Before/after allocation + time comparison vs master baseline (all four modes)