### PR TITLE
HomeBlaze: Extract ISubjectPathResolver into Abstractions

### DIFF
--- a/src/HomeBlaze/HomeBlaze.Abstractions/ISubjectPathResolver.cs
+++ b/src/HomeBlaze/HomeBlaze.Abstractions/ISubjectPathResolver.cs
@@ -1,0 +1,18 @@
+using Namotion.Interceptor;
+
+namespace HomeBlaze.Abstractions;
+
+/// <summary>
+/// Resolves subjects from paths and builds paths from subjects.
+/// </summary>
+public interface ISubjectPathResolver
+{
+    /// <summary>Gets the first path to the subject, or null if the subject has no path.</summary>
+    string? GetPath(IInterceptorSubject subject, PathStyle style);
+
+    /// <summary>Gets all paths to the subject (a subject can have multiple parents).</summary>
+    IReadOnlyList<string> GetPaths(IInterceptorSubject subject, PathStyle style);
+
+    /// <summary>Resolves a subject from a path, or null if not found.</summary>
+    IInterceptorSubject? ResolveSubject(string path, PathStyle style, IInterceptorSubject? relativeTo = null);
+}

--- a/src/HomeBlaze/HomeBlaze.Abstractions/PathStyle.cs
+++ b/src/HomeBlaze/HomeBlaze.Abstractions/PathStyle.cs
@@ -1,4 +1,4 @@
-namespace HomeBlaze.Services;
+namespace HomeBlaze.Abstractions;
 
 /// <summary>
 /// Path style for subject paths.

--- a/src/HomeBlaze/HomeBlaze.Host.Services/Navigation/NavigationItemResolver.cs
+++ b/src/HomeBlaze/HomeBlaze.Host.Services/Navigation/NavigationItemResolver.cs
@@ -1,3 +1,4 @@
+using HomeBlaze.Abstractions;
 using HomeBlaze.Components.Abstractions.Attributes;
 using HomeBlaze.Host.Services.Display;
 using HomeBlaze.Services;

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverCacheTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverCacheTests.cs
@@ -1,3 +1,4 @@
+using HomeBlaze.Abstractions;
 using HomeBlaze.Services.Tests.Models;
 
 namespace HomeBlaze.Services.Tests;

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverGetPathTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverGetPathTests.cs
@@ -1,3 +1,4 @@
+using HomeBlaze.Abstractions;
 using HomeBlaze.Services.Tests.Models;
 
 namespace HomeBlaze.Services.Tests;

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverInterfaceTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverInterfaceTests.cs
@@ -1,0 +1,29 @@
+using HomeBlaze.Abstractions;
+using HomeBlaze.Services.Tests.Models;
+
+namespace HomeBlaze.Services.Tests;
+
+/// <summary>
+/// Tests that SubjectPathResolver is consumable through the ISubjectPathResolver seam.
+/// </summary>
+public class SubjectPathResolverInterfaceTests : SubjectPathResolverTestBase
+{
+    [Fact]
+    public void WhenUsedThroughInterface_ThenAllMembersDispatchToConcreteResolver()
+    {
+        // Arrange
+        var root = new TestContainer(Context) { Name = "Root" };
+        RootManager.Root = root;
+        ISubjectPathResolver seam = Resolver;
+
+        // Act
+        var path = seam.GetPath(root, PathStyle.Canonical);
+        var paths = seam.GetPaths(root, PathStyle.Canonical);
+        var resolved = seam.ResolveSubject("/", PathStyle.Canonical);
+
+        // Assert
+        Assert.Equal("/", path);
+        Assert.Equal(new[] { "/" }, paths);
+        Assert.Same(root, resolved);
+    }
+}

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverResolveSubjectTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverResolveSubjectTests.cs
@@ -1,3 +1,4 @@
+using HomeBlaze.Abstractions;
 using HomeBlaze.Services.Tests.Models;
 
 namespace HomeBlaze.Services.Tests;

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverResolveValueTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/SubjectPathResolverResolveValueTests.cs
@@ -1,3 +1,4 @@
+using HomeBlaze.Abstractions;
 using HomeBlaze.Services.Tests.Models;
 
 namespace HomeBlaze.Services.Tests;

--- a/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolver.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text;
+using HomeBlaze.Abstractions;
 using Namotion.Interceptor;
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Registry.Abstractions;
@@ -14,7 +15,7 @@ namespace HomeBlaze.Services;
 /// Supports canonical notation (/Items[0]/Name) and route notation (/Items/0/Name).
 /// Implements lifecycle handling to invalidate caches when subjects are attached/detached.
 /// </summary>
-public class SubjectPathResolver : ILifecycleHandler
+public class SubjectPathResolver : ILifecycleHandler, ISubjectPathResolver
 {
     private readonly RootManager _rootManager;
 

--- a/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolverExtensions.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/SubjectPathResolverExtensions.cs
@@ -1,3 +1,4 @@
+using HomeBlaze.Abstractions;
 using Namotion.Interceptor;
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Registry.Abstractions;


### PR DESCRIPTION
## Summary

Phase 0 prerequisite for the upcoming HomeBlaze time-series history feature: introduce a lean path-resolution seam so future packages (the history stores) can resolve paths by depending only on the lightweight `HomeBlaze.Abstractions`, not the heavy `HomeBlaze.Services` layer.

- Define `ISubjectPathResolver` (`GetPath`, `GetPaths`, `ResolveSubject`) in `HomeBlaze.Abstractions`. It references only `Namotion.Interceptor`.
- Move the `PathStyle` enum from `HomeBlaze.Services` to `HomeBlaze.Abstractions` (namespace-only change) and add the resulting `using HomeBlaze.Abstractions;` to the consumers the compiler flagged.
- `SubjectPathResolver` (in `HomeBlaze.Services`) now implements `ISubjectPathResolver`. Its three method signatures already matched the interface, so no method bodies change. Existing call sites keep using the concrete class.

## Notes for the follow-on history PR

The `WithPathResolver()` DI registration and the `ResolveValue` extension are still keyed to the concrete `SubjectPathResolver`. The first history-store consumer that depends only on `HomeBlaze.Abstractions` will need `ISubjectPathResolver` resolvable from the context (and `ResolveValue` reachable through the interface if it uses it); that is intentionally deferred to that PR to keep this change a pure, behavior-preserving extraction.

## Test plan

- `dotnet build src/Namotion.Interceptor.slnx` clean (warnings as errors).
- `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"` passes; the full existing `SubjectPathResolver*Tests` suite stays green (behavior unchanged).
- New seam test exercises all three interface members through an `ISubjectPathResolver` reference.
- No PublicApiGenerator snapshot exists for `HomeBlaze.Abstractions`, so none was added.