### PR TITLE
HomeBlaze architecture docs: reflection/control planes, records model, control-plane hardening

### DIFF
--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/history.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/history.md
@@ -8,7 +8,7 @@ status: Planned
 
 ## Overview
 
-The time-series store records property changes over time, enabling historical queries, trend analysis, and AI-driven insights. It is implemented as a plugin using the standard abstractions + implementation pattern.
+The time-series store records property changes over time, enabling historical queries, trend analysis, and AI-driven insights. It is implemented as a plugin using the standard abstractions + implementation pattern. History is originated data on the reflection plane: once recorded it is its own source of truth and cannot be recovered from the device, so its durability model is store-and-forward (see below and the [Architecture Overview](../overview.md)).
 
 ## Architecture
 
@@ -46,11 +46,11 @@ Multiple sinks can run simultaneously (e.g., local SQLite for edge analytics + c
 
 Configurable at the plugin level. In HomeBlaze, `[State]` marks runtime properties (sensor readings, device status) as distinct from `[Configuration]` properties (persisted settings). The history plugin naturally targets `[State]` properties by default — these are the values that change over time and are worth tracking. An industrial plugin might apply a more selective filter (e.g., only numeric values, or only properties explicitly marked with a custom `[Historize]` attribute).
 
-### Central UNS Has Complete History
+### Central History Is Best-Effort, Not Complete
 
-Since the central UNS receives all property changes from all satellites via WebSocket, it naturally accumulates a full history of the entire graph. No explicit history sync needed — it is a side effect of the topology.
+The central instance records history for changes it receives over WebSocket, so during connected periods it accumulates history for the whole topology. It is not automatically complete: a satellite that is disconnected is invisible to central (no changes flow), and sink backpressure can drop changes under load. Central history therefore has gaps for every offline window and every overload burst.
 
-Each satellite can also install the history plugin independently for local history (useful for offline operation or edge analytics).
+Completeness on the reflection plane requires **store-and-forward at the edge**: each satellite buffers its own history durably while central is unreachable, and backfills the gap to central on reconnect. This makes the satellite, not the transient WebSocket stream, the source of truth for its own history. Each satellite installs the history plugin for this local buffer (also useful for offline operation and edge analytics).
 
 ### Querying History
 
@@ -90,7 +90,7 @@ For event and command history, see `get_event_history` and `get_command_history`
 | Sink architecture | Each sink is a standalone `BackgroundService` with its own `ChangeQueueProcessor` | No central orchestrator. Same pattern as connectors. Sinks are fully independent |
 | Query abstraction | `IHistoryStore` interface in abstractions package | Multiple storage backends without coupling. MCP `get_property_history` tool queries available stores |
 | Recording scope | Configurable at plugin level | Different domains have different needs |
-| History locality | Local per instance, central accumulates naturally | No explicit history sync protocol needed |
+| History locality | Local per instance; satellites store-and-forward to central | Satellite is the source of truth for its own history and backfills central after a disconnect. Central alone is best-effort |
 | Retention | Configurable per instance | Edge nodes may keep days, central may keep years |
 
 ## Open Questions
@@ -99,19 +99,24 @@ For event and command history, see `get_event_history` and `get_command_history`
 - Downsampling strategy for long-term storage
 - History export/import for backup and migration
 - `IHistoryStore` query interface design (sync vs async, streaming for large ranges, aggregation push-down to sink)
+- Edge store-and-forward buffer: durable local format, size bound, and backfill protocol to central on reconnect
+- Gap-marker representation in query results (how a consumer sees "data was dropped here")
 
 ## Implementation Notes
 
-### Backpressure and Overload
+### Backpressure, Overload, and Loss
 
-Since each sink has its own `ChangeQueueProcessor`, backpressure is handled per-sink with the same bounded queue semantics as connectors. When a sink's queue overflows (sink is slower than the change rate), the oldest unprocessed entries are dropped.
+Each sink has its own `ChangeQueueProcessor`, so backpressure is handled per-sink with bounded-queue semantics, the same as connectors. The change pipeline (the reflection-plane hot path) must never block for a slow sink: property writes, connector sync, and UI updates cannot stall because history is behind. The central UNS sees all changes from all satellites and therefore has the highest aggregate change rate, so it is the most exposed to overload.
 
-This is especially relevant for the central UNS, which sees all changes from all satellites and therefore has the highest aggregate change rate.
+Because the pipeline cannot block, a sink that falls behind must absorb or account for the overflow rather than silently dropping it. History is originated data: once lost it cannot be recovered from the device. The required behavior:
+
+- **Spill to a durable local buffer** rather than dropping. A bounded in-memory queue drains into local durable storage (the edge store-and-forward buffer) when the sink or its backend is slow or unreachable.
+- **Mark gaps when data is genuinely lost.** If the durable buffer itself is exhausted (sustained overload beyond local capacity), the sink records an explicit gap marker for the affected range, so a later query can distinguish "no change" from "data was dropped". A query result must never silently present a gap as continuity.
+- **Expose queue depth, buffer size, and drop/gap counts as metrics** so operators can detect and address overload (for example by increasing sink throughput, reducing property filter scope, or adding retention limits).
 
 | Alternative | Why not |
 |-------------|---------|
 | Unbounded in-memory buffering | OOM risk under sustained load, especially on central UNS |
-| Backpressure the change pipeline | Would block the hot path — property writes, connector sync, and UI updates would stall because a history sink is slow |
+| Backpressure the change pipeline | Would block the hot path: property writes, connector sync, and UI updates would stall because a history sink is slow |
+| Silently drop oldest on overflow | Loses originated data that cannot be recovered, and hides the loss from queries. Replaced by spill-to-durable-buffer plus explicit gap markers |
 | Central orchestrator dispatching to sinks | Adds a single point of failure and coupling between sinks. If the orchestrator is slow, all sinks suffer |
-
-Queue depth and drop count should be exposed as metrics so operators can detect and address overload (e.g., by increasing sink throughput, reducing property filter scope, or adding retention limits).

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/methods.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/methods.md
@@ -8,7 +8,7 @@ status: Partial
 
 ## Overview [Implemented] / [Planned]
 
-Subjects expose executable behavior through methods marked with `[Operation]` (state-changing) or `[Query]` (read-only). These are first-class citizens of the knowledge graph — discoverable via registry, invocable from the UI, MCP tools, and protocol methods (e.g., OPC UA).
+Subjects expose executable behavior through methods marked with `[Operation]` (state-changing) or `[Query]` (read-only). These are first-class citizens of the knowledge graph: discoverable via registry, invocable from the UI, MCP tools, and protocol methods (for example OPC UA). Operations are the platform's control plane. Unlike property sync (the reflection plane, last-writer-wins), a command is an intent to act: it must not be silently dropped or resolved by last-writer-wins. See the reflection-plane vs control-plane framing in the [Architecture Overview](../overview.md).
 
 ## Current State [Implemented]
 
@@ -40,19 +40,30 @@ Operations invoked on a remote instance (e.g., operator on central UNS invokes a
 
 ### Design Goals
 
-- **Every invocation executes.** Operations are not deduplicated or last-writer-wins like property sync. Two operators invoking the same operation from different UNS instances must both execute — they are separate commands, not conflicting state.
+- **Distinct invocations all execute.** Operations are commands, not state. Two operators invoking the same operation from different UNS instances are two separate commands and both execute. They are never deduplicated or resolved by last-writer-wins the way property values are.
+- **A single command executes once, even across a retry.** "Distinct invocations all execute" is about different commands. It does not mean a dropped-and-retried command should run twice. Delivery reliability is handled separately (below).
 - **Results flow back to the caller.** The invoking instance receives the return value or error from the owning instance.
-- **Operations map to protocol methods.** OPC UA methods on server subjects should proxy to the underlying operation.
+- **Operations map to protocol methods.** OPC UA methods on server subjects proxy to the underlying operation.
 
-### Idempotency
+### Delivery Semantics [Decided]
 
-Operations proxied via WebSocket have no defined idempotency semantics yet. If the WebSocket drops mid-RPC:
+The owning node is authoritative for a command: it is the single place the command is authorized and executed. The contract:
 
-- Does the caller retry automatically?
-- Can the callee detect duplicate invocations?
-- What are the at-least-once vs. at-most-once guarantees?
+- **At-least-once transport with an idempotency key.** Each invocation carries a caller-generated idempotency key. The callee keeps a bounded dedup window keyed by it, so a transport retry after a dropped connection executes the command exactly once. This is the default for operations that actuate.
+- **At-most-once fallback.** An invocation without an idempotency key is at-most-once: on a mid-RPC disconnect it may not have executed, and the caller cannot assume it did. Acceptable only for safe-to-lose operations.
+- **Authorize and execute on the owner.** Authorization is re-validated on the owning node using the propagated caller identity, never trusted from the calling node alone (see [Security](security.md)).
+- **Confirmation is via read-back, not the RPC result.** A command's effect appears on the reflection plane as normal property changes. The RPC result and the resulting state changes travel on different paths and are not ordered relative to each other, so a caller must treat the confirmed state, not the return value, as proof the action took effect.
 
-For most operations, at-most-once (fail on disconnect) is acceptable. For critical operations (e.g., physical actuator commands), stronger guarantees may be needed. An optional idempotency key per invocation could enable callers to safely retry.
+In-flight commands are not durable. A command whose owner fails over mid-execution has no persisted record on the promoted node. With an idempotency key the caller can safely retry against the new owner; without one the outcome is unknown. This is why actuation should use keys.
+
+### Control Authority [Planned]
+
+Being allowed to execute a command is not the same as being the one node currently allowed to drive a device. Exclusive control (one writer at a time for a given subject or device) is a separate concern from delivery:
+
+- Who currently holds write authority over a subject (an operator, a satellite, an agent) needs to be explicit, so a second writer cannot silently contend.
+- The mechanism (a write-ownership token or lock on the subject, or reliance on device-side exclusivity where the protocol supports it) is not yet designed. It connects to the HA single-writer problem in [Resilience](resilience.md).
+
+Cross-instance operation proxying also carries record reads: a database-backed subject's `[Query]` methods are proxied to the owning node rather than replicating record state. See [Records and Persistence](records-and-persistence.md).
 
 ## Key Decisions
 
@@ -60,12 +71,15 @@ For most operations, at-most-once (fail on disconnect) is acceptable. For critic
 |----------|--------|-----------|
 | Method attributes | `[Operation]` (state-changing) and `[Query]` (read-only) | Clear semantic distinction enables different authorization defaults and UI treatment |
 | Migration to Namotion.Interceptor.Reflection | Planned — attributes and discovery to move into dedicated package | Enables OPC UA method mapping, MCP tool support, and reuse outside HomeBlaze |
-| RPC semantics | Execute-all, not last-writer-wins | Operations are commands, not state — every invocation matters |
+| RPC semantics | Distinct invocations all execute, never last-writer-wins | Operations are commands, not state. Different commands must all run |
+| RPC delivery | At-least-once with idempotency key and callee-side dedup; at-most-once without a key | A retried command runs once. Actuation uses keys; safe-to-lose operations may skip them |
+| RPC authorization | Re-validated and executed on the owning node with propagated caller identity | The calling node is not trusted to have authorized the command (see Security) |
+| Command confirmation | Via read-back of resulting state, not the RPC return value | Result and state travel on different paths and are not mutually ordered |
 
 ## Open Questions
 
-- Wire format for operation proxying (request/response message structure)
+- Wire format for operation proxying (request/response message structure, idempotency key field)
+- Idempotency dedup window size and eviction policy on the callee
 - Timeout and cancellation semantics for cross-instance RPC
 - How to handle long-running operations (async progress reporting?)
-- Should operations be queueable (invoke later, retry on failure)?
-- Authorization for cross-instance operation invocation (see [Security](security.md))
+- Control-authority mechanism: write-ownership token/lock vs device-side exclusivity (see [Resilience](resilience.md))

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/records-and-persistence.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/records-and-persistence.md
@@ -1,0 +1,84 @@
+---
+title: Records and Persistence
+navTitle: Records and Persistence
+status: Design
+---
+
+# Records and Persistence Design
+
+## Overview
+
+HomeBlaze has two kinds of state, and they follow different rules. Naming the difference is the point of this document.
+
+- **Reflected state** mirrors an external source of truth. The subject graph is a live projection that is recovered from the source on restart. A field device is one source of truth. A database is another.
+- **Originated state** is created inside the platform and is its own source of truth. Production orders, batch records, genealogy, quality results, the audit trail, and the alarm journal are not recoverable from the field. They must be durably persisted with transactional guarantees.
+
+Decision #16 ("no external database for reflected live state") applies only to reflected state. Originated state may, and often must, live in a database. This document defines how originated state fits the subject model without duplicating the live graph or replicating large record sets across instances. See the reflection-plane vs control-plane framing in the [Architecture Overview](../overview.md).
+
+## A database is just another source of truth
+
+A database-backed subject is a connector to a database, conceptually identical to the OPC UA or MQTT connector:
+
+- The database holds the durable, transactional truth.
+- The subject is a reactive projection over it. Its tracked properties are a view of database state, refreshed on read or via change notification, not the authoritative copy.
+- Recovery works the same as for a device: on restart, re-read from the database.
+
+This keeps one mental model (the graph mirrors a source of truth) and avoids a separate, bolted-on persistence pillar.
+
+## When to model data as a subject
+
+A subject is the right abstraction only when the thing needs to be **live, addressable, and actionable**. Otherwise it is plain data.
+
+| Expose as | Use for | Why |
+|-----------|---------|-----|
+| Subject / property | The active working set: current tag values, the order running now, the batch in progress, an active alarm, a device | Live change tracking, path addressability in the UNS, reactive subscription, and its own operations (Pause, Abort, Acknowledge) |
+| DTO from a `[Query]` method | Historical or bulk records: closed batches, completed orders, quality history, the audit log, the cleared-alarm journal, time-series history | Immutable, queried on demand, displayed, never live. No benefit from being a graph node, and materializing millions of them would not scale |
+
+Rule of thumb: if the UI or an agent needs to subscribe to it changing, it is a subject. If it is read, filtered, and displayed, it is a DTO.
+
+The historian already follows this rule: `get_property_history` returns data, not subjects. Records, audit, and the alarm journal generalize the same pattern.
+
+## Records as DTOs from query methods
+
+Historical and bulk records are returned as plain, serializable POCOs from `[Query]` operations on a database-backed subject. They never enter the subject graph. Consequences:
+
+- They are point-in-time snapshots, not reactive. Anything that must update live belongs in a subject or property instead.
+- They are not addressable by a UNS path. Cross-instance references and "watch this record" only work for records promoted to subjects, which should be the small active set.
+- AI agents reach them through `invoke_method` / `list_methods`, not through `query` / graph traversal.
+
+## Cross-instance access: replicate vs proxy
+
+Every subject is one of two kinds for synchronization, and this must be explicit:
+
+| Kind | Example | Cross-instance behavior |
+|------|---------|-------------------------|
+| Materialized and replicated | Live device state, active working set | Full subject state syncs over WebSocket (Welcome snapshot plus incremental updates) |
+| Virtual and proxied | Database-backed record subjects | State is not replicated. Query operations are proxied (RPC) to the owning node, which runs them against its database and returns DTOs over the wire |
+
+This makes the cross-instance RPC contract load-bearing for records, not just for commands (see [Methods](methods.md)). It also means record data never inflates the Welcome snapshot or the central node's memory.
+
+## Transaction boundaries
+
+- The ACID boundary is the subject, treated as an aggregate. A transaction lives inside one subject's operation, against that subject's database.
+- The subject graph itself has no multi-subject transaction, and none should be added. Cross-aggregate consistency uses events or sagas, not two-phase commit across subjects.
+- Practical guidance: model each aggregate (order, batch, lot) as one database-backed subject that owns its transaction boundary.
+
+## Query surface
+
+Record queries are exposed through the specific `[Query]` methods the subject author writes (for example `GetBatches(from, to, status)`), not through generic graph traversal or arbitrary query strings. This is a deliberate, bounded, injection-safe API surface. The tradeoff is that record discoverability is author-driven rather than schema-driven, which is normal for this kind of system.
+
+## Relationship to the decisions table
+
+- Decision #16 is scoped to reflected live state. A database for originated records is explicitly in scope.
+- Decision #17 (records and system of record) records this model. See the [Architecture Overview](../overview.md).
+
+## Open questions
+
+- How a database-backed subject declares itself virtual/proxied vs materialized (attribute, base class, or configuration).
+- Refresh and staleness policy for the projected properties of a database-backed subject (read-through, change-notification, or polling).
+- Whether a small set of generic record-query shapes (paging, time-range, status filter) should be standardized so every author does not reinvent them.
+- Interaction with lazy or windowed subjects for the rare case of a very large active working set that must stay live and addressable.
+
+## Status
+
+Design. The model is decided. Database-backed subjects and DTO-returning `[Query]` methods are partially achievable today. The explicit materialized-vs-proxied classification and record-query proxying over WebSocket depend on the planned cross-instance RPC (message types 5-6, see [Methods](methods.md)).

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/resilience.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/resilience.md
@@ -8,17 +8,18 @@ status: Partial
 
 ## Overview
 
-HomeBlaze has a solid resilience foundation: external devices are the source of truth, live state is not persisted (recovered on restart), and the active-standby HA pattern uses fencing checks to prevent false promotion. This document captures known gaps and open questions for future hardening.
+HomeBlaze has a partial resilience foundation. On the reflection plane it is solid: external devices (or a database) are the source of truth, reflected live state is not persisted (recovered on restart), and the WebSocket connector already provides per-connection sequence numbers, gap detection, state digests, and resync (see the WebSocket connector documentation). On the control plane it is not: active-standby HA and its fencing check are not built, and fencing alone does not guarantee a single device-writer. This document captures known gaps and open questions for future hardening. See the reflection-plane vs control-plane framing in the [Architecture Overview](../overview.md).
 
 ## What's Already Covered [Implemented]
 
 | Mechanism | Status | Description |
 |-----------|--------|-------------|
 | Recovery from source of truth | Implemented | Satellites reconnect to devices, central receives Welcome snapshots — no stale state |
-| Fencing check | Planned (with HA) | Standby verifies device reachability before promoting, preventing false promotion during network partitions |
+| Fencing check | Planned (with HA) | Standby verifies device reachability before promoting, reducing false promotion during network partitions. Does not guarantee a single device-writer (see section 3) |
+| Sequence, gap detection, digests, resync | Implemented | The WebSocket connector numbers updates per connection, detects gaps, compares state digests, and resyncs on divergence. Reconnect recovery is not a naive re-send. See the WebSocket connector documentation |
 | Source tagging | Implemented | Prevents feedback loops in bidirectional connector sync |
 | Write retry queue | Implemented | Per-source ring buffer for outbound writes during disconnection |
-| Per-connector independence | Implemented | Each connector has its own `ChangeQueueProcessor` with independent buffering and deduplication — a slow or failed connector does not block others |
+| Per-connector independence | Implemented | Each connector has its own `ChangeQueueProcessor` with independent buffering and deduplication, so a slow or failed connector does not block others |
 
 ## Open Areas [Planned]
 
@@ -37,20 +38,23 @@ See [Methods and Operations — Idempotency](methods.md#idempotency) for the ful
 
 ### 3. Split-Brain Beyond Fencing
 
-The fencing check prevents false promotion when the standby cannot reach devices. But additional split-brain scenarios exist:
-- Primary is alive but partitioned from central — both primary and standby can still reach devices
+**Invariant required:** exactly one node writes to a given device (or holds write authority over a given subject) at a time. This is a control-plane guarantee. It does not follow from the reflection-plane rule that devices are the source of truth: last-writer-wins is safe for reflecting a device's state, but two primaries issuing conflicting setpoints or commands drive real, ordered physical action, and re-reading the device afterward does not undo it.
+
+**Interim constraint (until an arbiter exists):** a single primary, with no automatic failover, using manual or operator-gated promotion. Automatic active-standby failover must not be enabled until single-writer mutual exclusion is guaranteed.
+
+The fencing check reduces false promotion when the standby cannot reach devices, but additional split-brain scenarios remain:
+- Primary is alive but partitioned from central; both primary and standby can still reach devices
 - No leader election protocol or external arbiter is described
 - If both nodes believe they are primary, both write to devices simultaneously
+
+**Candidate arbiters (mechanism deferred, not yet chosen):**
+- Device-side exclusivity where the protocol supports it. Note that OPC UA session exclusivity is not sufficient: most OPC UA servers allow multiple writing sessions.
+- A lease/lock on shared storage: the primary periodically renews a lease, and the standby only promotes if the lease has expired. A mild coordination primitive, not full consensus.
+- An external arbiter (a lease/lock service such as etcd, a shared database row lock, or a cloud-native equivalent).
 
 **Failover detection:**
 - How does the standby decide the primary is truly dead vs. a transient network blip? (heartbeat timeout? miss count? external health check?)
 - What is the detection latency vs. false-positive trade-off? Too fast = false promotion, too slow = extended downtime
-
-**Preventing dual-primary:**
-- OPC UA session exclusivity is not sufficient — most OPC UA servers allow multiple connections
-- An external arbiter (lease/lock service, e.g., etcd, a shared database row lock, or a cloud-native equivalent) may be needed for reliable consensus
-- Without an arbiter, both nodes may write to devices simultaneously — is last-writer-wins acceptable given that devices are the source of truth?
-- Could a simpler approach work? E.g., primary periodically renews a lease on shared storage; standby only promotes if the lease expires
 
 **Consumer redirection after failover:**
 - When the standby becomes primary, how do consumers (satellites, central, operator UIs, AI agents) discover the new endpoint?

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/security.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/security.md
@@ -8,7 +8,7 @@ status: In Progress
 
 ## Overview
 
-Security in HomeBlaze covers graph-level authorization (who can read/write which properties and invoke which operations), inter-node authentication, and MCP access control. Graph authorization is in progress ([PR #137](https://github.com/RicoSuter/Namotion.Interceptor/pull/137)); other aspects are planned.
+Security in HomeBlaze covers graph-level authorization (who can read/write which properties and invoke which operations), the inter-node trust boundary, secrets handling, trust-zone segmentation, and MCP access control. Graph authorization is in progress ([PR #137](https://github.com/RicoSuter/Namotion.Interceptor/pull/137)); the other aspects are planned.
 
 ## Graph Authorization [In Progress]
 
@@ -43,15 +43,31 @@ Properties and operations are categorized by their nature, each with different d
 
 Authorization is role-based with OR logic — any matching role grants access. Roles are managed through the Blazor UI (user management, role assignment).
 
-## Inter-Node Authentication [Planned]
+## Inter-Node Trust Boundary [Planned]
 
-Planned. WebSocket connections between instances (satellite-to-central, primary-to-standby) need authentication to prevent unauthorized nodes from joining the topology.
+WebSocket connections between instances (satellite-to-central, primary-to-standby) need authentication to prevent unauthorized nodes from joining the topology. Likely approach: mutual TLS or token-based authentication on WebSocket connections.
 
-Likely approach: mutual TLS or token-based authentication on WebSocket connections.
+Node authentication proves *node* identity only. It does not prove that a per-request *user* authorization was honored upstream. Because every instance runs the same binary and its role is only configuration, a receiving node must not trust that a peer already authorized a write or an operation.
+
+**Principle:** the node that owns a subject re-validates user-level authorization on every inbound write and operation, using the caller identity propagated with the request. A peer's assertion of a role or identity is never accepted on trust. Control-plane requests (operations, setpoints) are authorized and executed on the owning node (see [Methods](methods.md)). This is the security half of the reflection-plane vs control-plane split in the [Architecture Overview](../overview.md).
 
 ## MCP Access Control [Planned]
 
-Planned. When an external agent connects via MCP, the authorization context determines which subjects, properties, and operations are accessible. The same graph authorization model applies — the MCP session carries a role/identity.
+Planned. When an external agent connects via MCP, the authorization context determines which subjects, properties, and operations are accessible. The same graph authorization model applies: the MCP session carries a role/identity.
+
+## Secrets [Planned]
+
+Device credentials, broker passwords, TLS keys, and LLM provider API keys must not be treated as ordinary `[Configuration]` properties. Configuration is serialized to storage and replicated across instances (a database-backed or proxied subject can carry configuration on the wire), so a secret stored as a plain configuration string would propagate to every peer and to disk in clear form.
+
+Required handling:
+- A distinct secret property kind (or marker) that is excluded from wire serialization and cross-instance replication, and redacted in logs, the UI, and MCP output.
+- Secret *values* held in an external secret store (environment, key vault, or platform secret manager); the subject holds only a reference, not the value.
+
+Until this exists, secrets should not be placed in synced or proxied subjects.
+
+## Trust Zones [Planned]
+
+The "same binary, config-driven role" model is coherent *within* a single trust zone. Across zones (for example the field/control, supervisory/UNS, and MES/ERP levels of an ISA-95 or IEC 62443 layout), the boundary needs real segmentation: authenticated nodes, re-validated authorization at the boundary, and no implicit trust that a lower zone enforced policy. The same-binary simplicity is kept inside a zone; the hardened, re-validating boundary sits between zones.
 
 ## Key Decisions
 
@@ -60,10 +76,14 @@ Planned. When an external agent connects via MCP, the authorization context dete
 | Authorization model | Role-based, attribute-driven, three levels | Matches the subject model; overrides flow from broad to specific |
 | Entity categories | State, Configuration, Query, Operation | Different sensitivity levels need different defaults |
 | Inter-node auth | Deferred | Focus on graph authorization first |
+| Inter-node trust | Owning node re-validates user authz; node auth proves node identity only | Same binary and config-driven role means a peer cannot be trusted to have authorized a request |
+| Secrets | Not ordinary `[Configuration]`; external store plus a non-replicated reference | Configuration is serialized and replicated, so a plain secret would leak to peers and disk |
+| Trust zones | Same binary within a zone; hardened re-validating boundary between zones | Cross-zone segmentation for ISA-95 / IEC 62443 layouts |
 
 ## Open Questions
 
 - Inter-node authentication mechanism (TLS, tokens, certificates)
-- MCP session identity model
-- Authorization for cross-instance operation proxying
-- Audit integration — logging authorization decisions (see [Audit](audit.md))
+- Caller-identity propagation format in the WebSocket/RPC protocol
+- MCP session identity model, and whether in-process built-in agents bypass attribute authorization
+- Secret property mechanism and choice of external secret store
+- Audit integration: logging authorization decisions (see [Audit](audit.md))

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/storage.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/storage.md
@@ -8,7 +8,7 @@ status: Implemented
 
 ## Overview
 
-HomeBlaze persists several categories of data through a pluggable storage layer. Live state is NOT persisted — it recovers from the source of truth (devices, peers) on restart. Everything else flows through `IStorageContainer`.
+HomeBlaze persists several categories of data through a pluggable storage layer. This layer holds *originated* state that HomeBlaze owns: configuration, knowledge files, documents, and metadata. *Reflected* live state (property values mirrored from a device or a database) is NOT persisted here; it recovers from its source of truth on restart. Records held by database-backed subjects (orders, batches, audit, alarm journal) are originated state too, but they live in their own database rather than in `IStorageContainer`. See [Records and Persistence](records-and-persistence.md). Everything in the categories below flows through `IStorageContainer`.
 
 ## What Is Stored
 
@@ -19,8 +19,9 @@ HomeBlaze persists several categories of data through a pluggable storage layer.
 | Documents | PDFs, images, data files linked to subjects | Binary blobs | Yes |
 | Dynamic metadata | Annotations, tags, links between subjects | JSON (separate from subject config) | Yes |
 | Plugin configuration | NuGet feed URLs, package list | JSON | Yes |
-| Property values (live state) | Sensor readings, device status | — | No — recovers from field devices (satellites), peers via WebSocket Welcome snapshot (central/standby) |
-| Time-series history | Property change history | Via history sink (see [History](history.md)) | Yes (separate concern) |
+| Property values (reflected live state) | Sensor readings, device status | — | No: recovers from field devices (satellites) or peers via WebSocket Welcome snapshot (central/standby) |
+| Time-series history | Property change history | Via history sink (see [History](history.md)); satellites keep a durable store-and-forward buffer | Yes (separate concern) |
+| Originated records | Orders, batches, genealogy, audit, alarm journal | Database, via a database-backed subject (see [Records and Persistence](records-and-persistence.md)) | Yes (in its own database, not `IStorageContainer`) |
 
 ### Recovery on Restart
 
@@ -29,8 +30,9 @@ Each layer recovers from its source of truth:
 | Instance | Recovers from | Mechanism |
 |----------|--------------|-----------|
 | Satellite | Field devices | Connectors reconnect, read current values |
-| Central UNS | Satellites | Satellites reconnect, send Welcome snapshot with full state. Disconnected satellites are not visible — central only shows live-connected data |
+| Central UNS | Satellites | Satellites reconnect, send Welcome snapshot with full state. Disconnected satellites are not visible, so central only shows live-connected data |
 | Standby | Primary | Reconnects, receives Welcome snapshot |
+| Database-backed subject | Its database | Re-reads records on startup; the database is its source of truth, exactly as a device is for a device-backed subject |
 
 ## Storage Abstraction [Implemented]
 
@@ -149,6 +151,7 @@ The "recover from source of truth" model means most data does NOT need backup fo
 | Time-series history | **No — this is the critical one** | Historical data is generated locally and cannot be recovered from devices. Once lost, it is gone |
 | Live state (property values) | **Yes** — recovers from devices/peers | No backup needed |
 | Audit trail (when implemented) | No | Compliance and debugging history lost |
+| Originated records (database-backed subjects) | No, but backed up by the database itself | Orders, batches, genealogy lost. Backup is the database's own responsibility, not `IStorageContainer` |
 
 ### What Does NOT Need Backup
 
@@ -198,7 +201,7 @@ Live state has zero data loss — it recovers to the current device state, not t
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| No live state persistence | Recover from source of truth | External world (devices, peers) is authoritative. Avoids stale state. Individual subjects may cache last known state locally as an implementation detail (e.g., restore from history or file in `ExecuteAsync` before device reconnects), but the platform does not prescribe or automate this |
+| No *reflected* live state persistence | Recover from source of truth | For reflected state, the external world (devices, peers) is authoritative, which avoids stale state. Originated records are different: they are their own source of truth and persist in a database-backed subject's database (see [Records and Persistence](records-and-persistence.md)). Individual subjects may cache last known state locally as an implementation detail (for example restore from history or file in `ExecuteAsync` before device reconnects), but the platform does not prescribe or automate this |
 | Storage abstraction | `IStorageContainer` with FluentStorage backends | Pluggable without code changes; local filesystem for dev, cloud storage for production |
 | File format | JSON for configuration, Markdown for knowledge | Human-readable, diffable, version-controllable |
 | Configuration vs state | `[Configuration]` (persisted) vs `[State]` (runtime-only) | Clear developer intent, explicit persistence boundary |

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/overview.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/overview.md
@@ -125,6 +125,15 @@ It does not currently own:
 
 ## 4. Building Block View
 
+### Consistency Model: Reflection and Control Planes
+
+HomeBlaze operates in two planes, and most correctness decisions come down to which plane a flow belongs to.
+
+- **Reflection plane.** The subject graph mirrors an external source of truth (a device, or a database). State converges by last-writer-wins on arrival order, is eventually consistent, and is recovered from the source on restart. Property sync, the Unified Namespace, and the historian live here. Last-writer-wins is safe here because it only reflects a truth that lives elsewhere.
+- **Control plane.** Commands and actuation: writing a setpoint, invoking an operation, promoting a standby. These need a single authoritative writer, exclusive control, confirmation, at-least-once delivery with idempotency, and authorization re-validated at each node boundary. Operations and cross-instance RPC live here. Last-writer-wins is not sufficient here, because two conflicting commands drive real physical action.
+
+The design docs are organized around this split. Reflection-plane concerns: [Storage](design/storage.md), [History](design/history.md), [Records and Persistence](design/records-and-persistence.md), [Scalability](design/scalability.md). Control-plane concerns: [Methods](design/methods.md), [Resilience](design/resilience.md), [Security](design/security.md).
+
 ### Level 1 — Top-Level Building Blocks
 
 ```
@@ -251,7 +260,7 @@ Horizontal scaling and resilience use two complementary channels. **State sync**
 | Satellite to Central | WebSocket client on satellite, server on central | State flows up, writes and operations flow down |
 | Primary to Standby | WebSocket server on primary, client on standby | Full state replication |
 
-On failover, the standby detects the primary is unreachable and performs a **fencing check** — it verifies it can still reach the field devices. This prevents false promotion during network partitions (if both primary and devices are unreachable, the standby assumes a network partition and does not promote). If fencing passes, the standby activates device connections, reads current device state to close any sync gap, and becomes the new primary. State converges because external devices are the authoritative source of truth — no distributed consensus is needed.
+On failover, the standby detects the primary is unreachable and performs a **fencing check**: it verifies it can still reach the field devices. This reduces false promotion during network partitions (if both primary and devices are unreachable, the standby assumes a network partition and does not promote). If fencing passes, the standby activates device connections, reads current device state to close any sync gap, and becomes the new primary. Reflected state converges because external devices are the authoritative source of truth. Fencing does not by itself guarantee that only one node writes to a device, however: single-writer mutual exclusion for actuation is an open control-plane problem, so automatic failover stays disabled until it is solved. See [Resilience](design/resilience.md).
 
 ---
 
@@ -467,7 +476,7 @@ These are potential bottlenecks identified from code analysis. Actual limits dep
 
 For containerized environments, each HA pair maps to a StatefulSet with 2 replicas. Pod ordinal determines role (0 = primary, 1 = standby). Services route traffic to the primary pod via role labels. Headless services provide stable DNS for standby-to-primary connections.
 
-**Persistence model.** HomeBlaze does not persist live state — each instance recovers from its source of truth on restart. Satellites reconnect to field devices and re-read current values. Central instances receive Welcome snapshots from reconnecting satellites. Standbys receive Welcome snapshots from their primary. Only subject configuration (settings, topology) and time-series history are locally persisted. See [Storage](design/storage.md) for details.
+**Persistence model.** HomeBlaze does not persist *reflected* live state. Each instance recovers it from its source of truth on restart: satellites reconnect to field devices and re-read current values, central instances receive Welcome snapshots from reconnecting satellites, and standbys receive Welcome snapshots from their primary. *Originated* state is different. Subject configuration (settings, topology), time-series history, and records held by database-backed subjects (orders, batches, audit, alarm journal) are their own source of truth and are durably persisted. A database-backed subject recovers by re-reading its database, exactly as a device-backed subject recovers by re-reading its device. See [Storage](design/storage.md) and [Records and Persistence](design/records-and-persistence.md) for details.
 
 ---
 
@@ -479,18 +488,19 @@ For containerized environments, each HA pair maps to a StatefulSet with 2 replic
 | 2 | Inter-node protocol | WebSocket (SubjectUpdate) | Atomic snapshots, structural graph sync, sequence-based consistency. Already built into Namotion.Interceptor |
 | 3 | Device connection ownership | Satellites, not central | Failure isolation, independent deployment per domain |
 | 4 | HA pattern | Active-standby (2 nodes per pair) | External devices are the source of truth. No need for distributed consensus |
-| 5 | Failover mechanism | Standby promotes by activating device connections | Self-contained, fencing check prevents false promotion |
+| 5 | Failover mechanism | Standby promotes by activating device connections | Self-contained. A fencing check reduces false promotion but does not by itself guarantee single-writer mutual exclusion. Ensuring exactly one device-writer per pair is an open control-plane problem. See [Resilience](design/resilience.md) |
 | 6 | Knowledge graph foundation | Namotion.Interceptor subject graph with registry | Typed properties, metadata, change tracking, and queryability with no impedance mismatch |
 | 7 | Operations | First-class on subjects, migrating to Namotion.Interceptor registry | Natural extension: subjects have properties (nouns) and operations (verbs). Enables OPC UA method mapping |
 | 8 | AI integration | Built-in agents (subjects) + external agents (MCP) | Two-mode model: in-process for automation, MCP for ad-hoc copilots |
 | 9 | MCP tool layering | `Namotion.Interceptor.Mcp` (base) + `HomeBlaze.Mcp` (rich) | Interceptor library stays usable independently; HomeBlaze adds domain-specific tools |
-| 10 | History | Plugin-based: abstractions (sink interface) + implementation (collector) | Any instance can optionally record history. Central UNS accumulates full history naturally via topology |
+| 10 | History | Plugin-based: abstractions (sink interface) + implementation (collector) | Any instance can optionally record history. Central accumulates history for periods when satellites are connected; it is best-effort, not guaranteed complete (disconnected windows and sink backpressure cause gaps). Lossless capture needs edge store-and-forward. See [History](design/history.md) |
 | 11 | Documents | Subjects with Read/Write operations, linked via dynamic attributes | No special infrastructure — standard subject model |
 | 12 | Plugin contract | Subject types only (NuGet packages) | Everything is a subject. No separate plugin interfaces |
 | 13 | Persistence | None for live state — recover from source of truth | External world is the persistence layer. Only configuration and history are locally persisted |
 | 14 | Observability | OpenTelemetry + health subjects | Ops teams get standard tooling, AI agents can monitor the system itself |
 | 15 | Versioning | Plugins depend on stable abstractions packages, not host versions | Independent upgradeability |
-| 16 | No external database for live state | In-memory subject graph only; no graph DB or SQL DB | The in-memory graph is already the knowledge graph — reactive, typed, queryable. An external DB would duplicate state, add sync complexity, and introduce latency on the hot path. Recovery from source of truth eliminates the need for persistent live state. SQL/time-series databases are used only for history sinks |
+| 16 | No external database for *reflected* live state | In-memory subject graph only for state mirrored from a source of truth; no graph DB or SQL DB duplicating the live device graph | The in-memory graph is already the knowledge graph: reactive, typed, queryable. Duplicating reflected state in an external DB would add sync complexity and hot-path latency, and recovery from source of truth removes the need for it. This does not restrict *originated* records (orders, batches, audit, alarm journal), which are their own source of truth and belong in a database via a database-backed subject. See [Records and Persistence](design/records-and-persistence.md) |
+| 17 | Records and system of record | Database-backed subjects; historical and bulk records exposed as DTOs from `[Query]` methods, not as graph nodes | A database is just another source of truth. Live, addressable, actionable data is a subject; historical or bulk data is a DTO from a query method, proxied across instances via RPC rather than replicated. Keeps records out of the live graph and the Welcome snapshot. See [Records and Persistence](design/records-and-persistence.md) |
 
 ---
 
@@ -508,6 +518,11 @@ For containerized environments, each HA pair maps to a StatefulSet with 2 replic
 | Central Instance | A HomeBlaze instance that aggregates state from multiple satellites into a unified namespace |
 | Primary | The active node in an HA pair. Owns device connections (satellites) or receives satellite sync (central) |
 | Standby | The passive node in an HA pair. Maintains a full replica via WebSocket. Promotes to primary on failover |
-| Fencing | Safety check before promotion: standby verifies it can reach devices. Prevents false promotion during network partitions |
+| Fencing | Safety check before promotion: standby verifies it can reach devices. Reduces false promotion during network partitions, but does not by itself guarantee that only one node writes to a device. See [Resilience](design/resilience.md) |
 | MCP | Model Context Protocol. The standard protocol through which external AI agents access the knowledge graph |
 | Connector | A protocol integration bridging external systems into the knowledge graph. Core connectors live in Namotion.Interceptor; HomeBlaze wraps them as manageable subjects |
+| Reflection plane | State flows where the graph mirrors an external source of truth (device or database): eventually consistent, last-writer-wins, recovered from source |
+| Control plane | Commands and actuation flows (setpoints, operation invocation, failover): require a single authoritative writer, confirmation, and idempotent at-least-once delivery |
+| System of record | The durable, authoritative store for originated data (orders, batches, audit, alarm journal), held by a database-backed subject rather than the in-memory graph |
+| Reflected state | State mirrored from an external source of truth; ephemeral, recovered on restart |
+| Originated state | State created inside the platform that is its own source of truth; durably persisted |


### PR DESCRIPTION
## Summary

Refines the HomeBlaze architecture docs around one organizing idea: the split between the reflection plane (the subject graph mirrors a source of truth, so last-writer-wins is fine) and the control plane (commands and actuation, which need a single authoritative writer, confirmation, and idempotent delivery). It also pins how originated/transactional data (records, audit, alarm journal) fits the subject model, and corrects several claims that overstated what is implemented.

Docs only, no code changes.

## What changed

- **overview.md**: added the two-plane framing; scoped decision 16 (no external database) to reflected live state; added decision 17 (records / system of record); corrected the fencing and "complete history" overclaims in the decision table, the runtime prose, and the glossary.
- **records-and-persistence.md (new)**: a database is just another source of truth; database-backed subjects; historical and bulk records exposed as DTOs from `[Query]` methods rather than graph nodes; materialized-and-replicated vs virtual-and-proxied subjects; ACID boundary at the subject aggregate; method-defined query surface.
- **methods.md**: operations framed as the control plane; RPC delivery semantics pinned (at-least-once with an idempotency key and callee-side dedup, at-most-once only without a key, authorize-and-execute on the owning node, confirm via state read-back); control-authority concept added, mechanism deferred.
- **resilience.md**: corrected the fencing overclaim; documented the existing per-connection sequence, gap detection, digest, and resync machinery; stated the single-device-writer invariant and the interim single-primary constraint with candidate arbiters.
- **history.md**: replaced drop-on-overflow with store-and-forward plus explicit gap-marking; downgraded the central "complete history" claim to best-effort.
- **security.md**: added the inter-node trust boundary (owning node re-validates user authz; node auth proves node identity only), a secrets section, and the trust-zone model.
- **storage.md**: reconciled the persistence model with originated records and the edge history buffer.

## Decided vs open

Decided: RPC delivery semantics, authorization re-validation at the owning node, secrets kept off the wire, store-and-forward for history, and the single-writer invariant. Left explicitly open: the HA arbiter mechanism, the control-authority lock, the secret-store choice, and the history buffer format.
