### PR TITLE
Fix OPC UA reconnect: retry transient item failures and buffer during session abandon

### DIFF
--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -441,10 +441,10 @@ builder.Services.AddOpcUaSubjectClientSource(
 - Nodes that do not support subscriptions (`BadNotSupported`, `BadMonitoredItemFilterUnsupported`) fall back to polling immediately when enabled.
 - Skips permanent design-time errors (`BadNodeIdUnknown`, `BadAttributeIdInvalid`, `BadIndexRangeInvalid`).
 - Reconnect re-attempts a real subscription for every item, so escalation to polling is not permanent.
-- Health checks run at configurable intervals (minimum: 5 seconds).
+- Health checks run at configurable intervals (minimum: 1 second, default: 5 seconds).
 
 **Configuration validation:**
-- `SubscriptionHealthCheckInterval` minimum of 5 seconds enforced
+- `SubscriptionHealthCheckInterval` minimum of 1 second enforced
 - `PollingInterval` minimum of 100 milliseconds enforced
 - Fail-fast with clear error messages on invalid configuration
 

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -422,7 +422,7 @@ builder.Services.AddOpcUaSubjectClientSource(
 
 ### Auto-Healing of Failed Monitored Items
 
-The library automatically retries failed subscription items that may succeed later, such as when server resources become available.
+The library retries failed subscription items that may succeed later (for example when server resources free up), bounded so a persistently failing item escalates rather than retrying forever.
 
 ```csharp
 builder.Services.AddOpcUaSubjectClientSource(
@@ -434,11 +434,14 @@ builder.Services.AddOpcUaSubjectClientSource(
     });
 ```
 
-**Smart retry logic:**
-- Retries transient errors: `BadTooManyMonitoredItems`, `BadOutOfService`, `BadMonitoringModeUnsupported`
-- Skips permanent errors: `BadNodeIdUnknown`
-- Health checks run at configurable intervals (minimum: 5 seconds)
-- Items that permanently don't support subscriptions automatically fall back to polling
+**Retry and escalation logic:**
+- Retries transient errors (for example `BadTooManyMonitoredItems`, `BadOutOfService`) for up to three consecutive health checks (roughly 15 seconds at the default interval), so a genuinely transient failure recovers on its own.
+- If an item keeps failing past that bound and `EnablePollingFallback` is enabled (the default), it escalates to polling rather than retrying the subscription forever.
+- With polling disabled there is nothing better to escalate to, so the item keeps being retried and recovers on its own once the node returns; it is never dropped.
+- Nodes that do not support subscriptions (`BadNotSupported`, `BadMonitoredItemFilterUnsupported`) fall back to polling immediately when enabled.
+- Skips permanent design-time errors (`BadNodeIdUnknown`, `BadAttributeIdInvalid`, `BadIndexRangeInvalid`).
+- Reconnect re-attempts a real subscription for every item, so escalation to polling is not permanent.
+- Health checks run at configurable intervals (minimum: 5 seconds).
 
 **Configuration validation:**
 - `SubscriptionHealthCheckInterval` minimum of 5 seconds enforced
@@ -470,7 +473,7 @@ When the connection drops, the OPC UA SDK's `SessionReconnectHandler` attempts t
 
 If the SDK handler cannot transfer subscriptions (e.g., server restarted and old subscriptions are gone), or if it returns the same session object ("preserved session"), the client abandons the session entirely:
 
-1. `OnReconnectComplete` calls `AbandonCurrentSession()` (session nulled, transport killed)
+1. `OnReconnectComplete` calls `AbandonCurrentSession()` (session nulled, transport killed, and incoming notifications buffered so stale values from the abandoned subscription are not applied during the gap before manual reconnection)
 2. The health check loop detects the dead session and triggers manual reconnection
 3. Manual reconnection creates a fresh session, new subscriptions, and performs a full state read
 4. Full consistency is restored

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/FailedMonitoredItemDispositionTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/FailedMonitoredItemDispositionTests.cs
@@ -34,4 +34,24 @@ public class FailedMonitoredItemDispositionTests
         // Assert
         Assert.Equal(expected, disposition.ToString());
     }
+
+    [Theory]
+    // Within the retry bound: keep letting the health monitor retry.
+    [InlineData(1, nameof(HealDecision.KeepRetrying))]
+    [InlineData(2, nameof(HealDecision.KeepRetrying))]
+    // Bound reached: escalate to polling instead of retrying the subscription forever.
+    [InlineData(3, nameof(HealDecision.EscalateToPolling))]
+    [InlineData(4, nameof(HealDecision.EscalateToPolling))]
+    public void WhenRetryableItemKeepsFailing_ThenItEscalatesToPollingAfterTheBound(
+        int consecutiveFailures, string expected)
+    {
+        // Arrange
+        const int maxAttempts = 3;
+
+        // Act
+        var decision = SubscriptionManager.DecideHealAction(consecutiveFailures, maxAttempts);
+
+        // Assert
+        Assert.Equal(expected, decision.ToString());
+    }
 }

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/FailedMonitoredItemDispositionTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/FailedMonitoredItemDispositionTests.cs
@@ -37,21 +37,18 @@ public class FailedMonitoredItemDispositionTests
 
     [Theory]
     // Within the retry bound: keep letting the health monitor retry.
-    [InlineData(1, nameof(HealDecision.KeepRetrying))]
-    [InlineData(2, nameof(HealDecision.KeepRetrying))]
+    [InlineData(1, false)]
+    [InlineData(2, false)]
     // Bound reached: escalate to polling instead of retrying the subscription forever.
-    [InlineData(3, nameof(HealDecision.EscalateToPolling))]
-    [InlineData(4, nameof(HealDecision.EscalateToPolling))]
+    [InlineData(3, true)]
+    [InlineData(4, true)]
     public void WhenRetryableItemKeepsFailing_ThenItEscalatesToPollingAfterTheBound(
-        int consecutiveFailures, string expected)
+        int consecutiveFailures, bool shouldEscalate)
     {
         // Arrange
         const int maxAttempts = 3;
 
-        // Act
-        var decision = SubscriptionManager.DecideHealAction(consecutiveFailures, maxAttempts);
-
-        // Assert
-        Assert.Equal(expected, decision.ToString());
+        // Act & Assert
+        Assert.Equal(shouldEscalate, SubscriptionManager.ShouldEscalateToPolling(consecutiveFailures, maxAttempts));
     }
 }

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/FailedMonitoredItemDispositionTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/FailedMonitoredItemDispositionTests.cs
@@ -1,0 +1,37 @@
+using Namotion.Interceptor.OpcUa.Client.Connection;
+using Opc.Ua;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+/// <summary>
+/// A monitored item that fails to (re-)create during subscription setup must be disposed of
+/// consistently with the health monitor's retry classification: transient failures are kept in
+/// the subscription so the health monitor can heal them, subscription-unsupported nodes fall back
+/// to polling when enabled, and permanent design-time errors are dropped. Previously every failure
+/// was dropped, which silently orphaned transiently-failed items until an unrelated full reconnect.
+/// </summary>
+public class FailedMonitoredItemDispositionTests
+{
+    [Theory]
+    // Transient failures the health monitor intends to retry: keep them so it can.
+    [InlineData(StatusCodes.BadOutOfService, true, nameof(FailedMonitoredItemDisposition.KeepForRetry))]
+    [InlineData(StatusCodes.BadTooManyMonitoredItems, true, nameof(FailedMonitoredItemDisposition.KeepForRetry))]
+    [InlineData(StatusCodes.BadTimeout, true, nameof(FailedMonitoredItemDisposition.KeepForRetry))]
+    // Subscription-unsupported nodes: poll when enabled, drop when not (retrying cannot help).
+    [InlineData(StatusCodes.BadNotSupported, true, nameof(FailedMonitoredItemDisposition.FallbackToPolling))]
+    [InlineData(StatusCodes.BadMonitoredItemFilterUnsupported, true, nameof(FailedMonitoredItemDisposition.FallbackToPolling))]
+    [InlineData(StatusCodes.BadNotSupported, false, nameof(FailedMonitoredItemDisposition.Drop))]
+    // Permanent design-time errors: dropping is correct, retrying never succeeds.
+    [InlineData(StatusCodes.BadNodeIdUnknown, true, nameof(FailedMonitoredItemDisposition.Drop))]
+    [InlineData(StatusCodes.BadAttributeIdInvalid, true, nameof(FailedMonitoredItemDisposition.Drop))]
+    [InlineData(StatusCodes.BadIndexRangeInvalid, true, nameof(FailedMonitoredItemDisposition.Drop))]
+    public void WhenItemFailsToCreate_ThenDispositionMatchesRetryability(
+        uint statusCode, bool pollingEnabled, string expected)
+    {
+        // Act
+        var disposition = SubscriptionManager.ClassifyFailedItem(statusCode, pollingEnabled);
+
+        // Assert
+        Assert.Equal(expected, disposition.ToString());
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
@@ -606,10 +606,8 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
     {
         Debug.Assert(Monitor.IsEntered(_reconnectingLock), "AbandonCurrentSession must be called inside _reconnectingLock.");
 
-        // Buffer notifications from now until the manual reconnect reloads state and resumes.
-        // The abandoned subscription's callback stays attached, so without this the writer would
-        // apply stale notifications directly during the abandon-to-reconnect window. The subsequent
-        // full state reload is authoritative, so discarding these buffered updates is safe.
+        // The abandoned subscription's callback stays attached, so buffer until the manual reconnect
+        // reloads and replays state; the authoritative reload makes discarding these updates safe.
         _propertyWriter.StartBuffering();
 
         var oldSession = Volatile.Read(ref _session);

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
@@ -606,6 +606,12 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
     {
         Debug.Assert(Monitor.IsEntered(_reconnectingLock), "AbandonCurrentSession must be called inside _reconnectingLock.");
 
+        // Buffer notifications from now until the manual reconnect reloads state and resumes.
+        // The abandoned subscription's callback stays attached, so without this the writer would
+        // apply stale notifications directly during the abandon-to-reconnect window. The subsequent
+        // full state reload is authoritative, so discarding these buffered updates is safe.
+        _propertyWriter.StartBuffering();
+
         var oldSession = Volatile.Read(ref _session);
         if (oldSession is not null)
         {

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -12,6 +12,22 @@ using Opc.Ua.Client;
 
 namespace Namotion.Interceptor.OpcUa.Client.Connection;
 
+/// <summary>
+/// How a monitored item that failed to (re-)create should be handled, aligned with
+/// <see cref="SubscriptionHealthMonitor.IsRetryable(Opc.Ua.Client.MonitoredItem)"/>.
+/// </summary>
+internal enum FailedMonitoredItemDisposition
+{
+    /// <summary>Transient failure: leave the item in the subscription so the health monitor retries it.</summary>
+    KeepForRetry,
+
+    /// <summary>Node does not support subscriptions: move it to the polling fallback.</summary>
+    FallbackToPolling,
+
+    /// <summary>Permanent failure: remove the item; retrying cannot succeed.</summary>
+    Drop
+}
+
 internal class SubscriptionManager : IAsyncDisposable
 {
     private static readonly ObjectPool<List<PropertyUpdate>> ChangesPool
@@ -248,41 +264,54 @@ internal class SubscriptionManager : IAsyncDisposable
 
     private async Task FilterOutFailedMonitoredItemsAsync(Subscription subscription, CancellationToken cancellationToken)
     {
-        List<MonitoredItem>? failedItems = null;
+        List<MonitoredItem>? removedItems = null;
         List<MonitoredItem>? polledItems = null;
+        var keptForRetry = 0;
+
+        var pollingEnabled = _configuration.EnablePollingFallback && _pollingManager != null;
 
         foreach (var monitoredItem in subscription.MonitoredItems)
         {
-            if (SubscriptionHealthMonitor.IsUnhealthy(monitoredItem))
+            if (!SubscriptionHealthMonitor.IsUnhealthy(monitoredItem))
             {
-                failedItems ??= [];
-                failedItems.Add(monitoredItem);
+                continue;
+            }
 
-                _monitoredItems.TryRemove(monitoredItem.ClientHandle, out _);
+            var statusCode = monitoredItem.Status.Error?.StatusCode ?? StatusCodes.Good;
 
-                var statusCode = monitoredItem.Status.Error?.StatusCode ?? StatusCodes.Good;
+            switch (ClassifyFailedItem(statusCode, pollingEnabled))
+            {
+                case FailedMonitoredItemDisposition.KeepForRetry:
+                    // Leave it in the subscription and in _monitoredItems so the health monitor
+                    // heals it. Removing it here silently orphaned transiently-failed items.
+                    keptForRetry++;
+                    _logger.LogWarning("OPC UA monitored item {DisplayName} failed transiently ({Status}); keeping it for the health monitor to retry.",
+                        monitoredItem.DisplayName, statusCode);
+                    break;
 
-                // Check if we should fall back to polling for this item
-                if (_configuration.EnablePollingFallback &&
-                    _pollingManager != null &&
-                    IsSubscriptionUnsupported(statusCode))
-                {
+                case FailedMonitoredItemDisposition.FallbackToPolling:
+                    removedItems ??= [];
+                    removedItems.Add(monitoredItem);
+                    _monitoredItems.TryRemove(monitoredItem.ClientHandle, out _);
                     polledItems ??= [];
                     polledItems.Add(monitoredItem);
                     _logger.LogWarning("Monitored item {DisplayName} does not support subscriptions ({Status}), falling back to polling",
                         monitoredItem.DisplayName, statusCode);
-                }
-                else
-                {
-                    _logger.LogError("OPC UA monitored item creation failed for {DisplayName} (Handle={Handle}): {Status}",
+                    break;
+
+                case FailedMonitoredItemDisposition.Drop:
+                    removedItems ??= [];
+                    removedItems.Add(monitoredItem);
+                    _monitoredItems.TryRemove(monitoredItem.ClientHandle, out _);
+                    _logger.LogError("OPC UA monitored item creation failed permanently for {DisplayName} (Handle={Handle}): {Status}",
                         monitoredItem.DisplayName, monitoredItem.ClientHandle, statusCode);
-                }
+                    break;
             }
         }
 
-        if (failedItems?.Count > 0)
+        if (removedItems?.Count > 0)
         {
-            foreach (var monitoredItem in failedItems)
+            foreach (var monitoredItem in removedItems)
             {
                 subscription.RemoveItem(monitoredItem);
             }
@@ -296,7 +325,6 @@ internal class SubscriptionManager : IAsyncDisposable
                 _logger.LogWarning(ex, "ApplyChanges after removing failed items still failed. Continuing with remaining OPC UA monitored items.");
             }
 
-            // Add items that support polling to polling manager
             if (polledItems?.Count > 0 && _pollingManager != null)
             {
                 foreach (var item in polledItems)
@@ -304,23 +332,14 @@ internal class SubscriptionManager : IAsyncDisposable
                     _pollingManager.AddItem(item);
                 }
             }
+        }
 
-            var failedCount = failedItems.Count;
-            var polledCount = polledItems?.Count;
-            if (polledCount > 0)
-            {
-                _logger.LogWarning(
-                    "Removed {Removed} failed monitored items from subscription " +
-                    "{SubscriptionId}. {Polled} items switched to polling fallback.",
-                    failedCount, subscription.Id, polledCount);
-            }
-            else
-            {
-                _logger.LogWarning(
-                    "Removed {Removed} failed monitored items " +
-                    "from subscription {SubscriptionId}.",
-                    failedCount, subscription.Id);
-            }
+        if (removedItems?.Count > 0 || keptForRetry > 0)
+        {
+            _logger.LogWarning(
+                "Subscription {SubscriptionId}: removed {Removed} failed monitored items " +
+                "({Polled} switched to polling), kept {Kept} for the health monitor to retry.",
+                subscription.Id, removedItems?.Count ?? 0, polledItems?.Count ?? 0, keptForRetry);
         }
     }
 
@@ -335,6 +354,25 @@ internal class SubscriptionManager : IAsyncDisposable
         // Note: BadAttributeIdInvalid is a permanent error - polling won't work either, so excluded
         return statusCode == StatusCodes.BadNotSupported ||
                statusCode == StatusCodes.BadMonitoredItemFilterUnsupported;
+    }
+
+    /// <summary>
+    /// Decides how a failed monitored item should be handled. Transient failures are kept in the
+    /// subscription so <see cref="SubscriptionHealthMonitor"/> can heal them (previously they were
+    /// dropped, which silently orphaned the item until an unrelated full reconnect).
+    /// </summary>
+    internal static FailedMonitoredItemDisposition ClassifyFailedItem(StatusCode statusCode, bool pollingEnabled)
+    {
+        if (IsSubscriptionUnsupported(statusCode))
+        {
+            return pollingEnabled
+                ? FailedMonitoredItemDisposition.FallbackToPolling
+                : FailedMonitoredItemDisposition.Drop;
+        }
+
+        return SubscriptionHealthMonitor.IsRetryable(statusCode)
+            ? FailedMonitoredItemDisposition.KeepForRetry
+            : FailedMonitoredItemDisposition.Drop;
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -436,7 +436,13 @@ internal class SubscriptionManager : IAsyncDisposable
 
                 if (!SubscriptionHealthMonitor.IsRetryable(monitoredItem))
                 {
-                    continue; // permanent errors are dropped at creation; a runtime transition to permanent-bad is left in place until reconnect
+                    // A runtime transition to permanent-bad is left in the subscription until reconnect,
+                    // but drop any heal counter so the map only tracks currently-retryable failing items.
+                    if (!_healAttempts.IsEmpty)
+                    {
+                        _healAttempts.TryRemove(monitoredItem.ClientHandle, out _);
+                    }
+                    continue;
                 }
 
                 var attempts = _healAttempts.AddOrUpdate(monitoredItem.ClientHandle, 1, static (_, current) => current + 1);

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -28,18 +28,6 @@ internal enum FailedMonitoredItemDisposition
     Drop
 }
 
-/// <summary>
-/// What to do with a retryable monitored item that keeps failing to heal.
-/// </summary>
-internal enum HealDecision
-{
-    /// <summary>Still within the retry bound: let the health monitor keep retrying.</summary>
-    KeepRetrying,
-
-    /// <summary>Retry bound exceeded and polling available: move the item to the polling fallback.</summary>
-    EscalateToPolling
-}
-
 internal class SubscriptionManager : IAsyncDisposable
 {
     private static readonly ObjectPool<List<PropertyUpdate>> ChangesPool
@@ -328,29 +316,9 @@ internal class SubscriptionManager : IAsyncDisposable
             }
         }
 
-        if (removedItems?.Count > 0)
+        if (removedItems is { Count: > 0 })
         {
-            foreach (var monitoredItem in removedItems)
-            {
-                subscription.RemoveItem(monitoredItem);
-            }
-
-            try
-            {
-                await subscription.ApplyChangesAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "ApplyChanges after removing failed items still failed. Continuing with remaining OPC UA monitored items.");
-            }
-
-            if (polledItems?.Count > 0 && _pollingManager != null)
-            {
-                foreach (var item in polledItems)
-                {
-                    _pollingManager.AddItem(item);
-                }
-            }
+            await RemoveAndFallBackToPollingAsync(subscription, removedItems, polledItems ?? [], cancellationToken).ConfigureAwait(false);
         }
 
         if (removedItems?.Count > 0 || keptForRetry > 0)
@@ -395,30 +363,56 @@ internal class SubscriptionManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Decides what to do with a retryable item that keeps failing to heal, once polling fallback
-    /// is available: keep retrying within the bound, then escalate to polling. With polling disabled
-    /// the caller never escalates, so the health monitor keeps retrying and the item self-heals.
+    /// Whether a retryable item that keeps failing should be escalated to polling (its retry bound
+    /// was exceeded) rather than kept for the health monitor to retry.
     /// </summary>
-    internal static HealDecision DecideHealAction(int consecutiveFailures, int maxAttempts)
+    internal static bool ShouldEscalateToPolling(int consecutiveFailures, int maxAttempts)
     {
-        return consecutiveFailures < maxAttempts
-            ? HealDecision.KeepRetrying
-            : HealDecision.EscalateToPolling;
+        return consecutiveFailures >= maxAttempts;
+    }
+
+    /// <summary>
+    /// Removes the given items from the SDK subscription and applies the change (tolerating an
+    /// ApplyChanges failure), then hands the polled items to the polling manager.
+    /// </summary>
+    private async Task RemoveAndFallBackToPollingAsync(
+        Subscription subscription,
+        IReadOnlyList<MonitoredItem> toRemove,
+        IReadOnlyList<MonitoredItem> toPoll,
+        CancellationToken cancellationToken)
+    {
+        foreach (var monitoredItem in toRemove)
+        {
+            subscription.RemoveItem(monitoredItem);
+        }
+
+        try
+        {
+            await subscription.ApplyChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "ApplyChanges after removing failed OPC UA monitored items failed. Continuing with the remaining items.");
+        }
+
+        if (_pollingManager is not null)
+        {
+            foreach (var monitoredItem in toPoll)
+            {
+                _pollingManager.AddItem(monitoredItem);
+            }
+        }
     }
 
     /// <summary>
     /// Escalates retryable monitored items that keep failing after the health monitor has retried
-    /// them. An item that exceeds <see cref="MaxHealAttemptsBeforeEscalation"/> consecutive failed
-    /// heals falls back to polling instead of being retried forever. With polling disabled there is
-    /// no better target, so the item is never dropped: the health monitor keeps retrying and it
-    /// self-heals once the node recovers. Items that recover reset their attempt count, and reconnect
-    /// re-attempts a real subscription for every owned item, so escalation is not permanent.
+    /// them: once an item exceeds <see cref="MaxHealAttemptsBeforeEscalation"/> it falls back to
+    /// polling. Items that recover reset their attempt count, and reconnect re-attempts a real
+    /// subscription for every owned item, so escalation is not permanent. Only runs when polling is
+    /// enabled; see <see cref="MaxHealAttemptsBeforeEscalation"/> for the polling-disabled case.
     /// </summary>
     public async Task EscalatePersistentlyFailedItemsAsync(CancellationToken cancellationToken)
     {
-        // Escalation only has a target when polling is available. With polling disabled there is
-        // nothing better than letting the health monitor keep retrying, which self-heals once the
-        // node recovers, so a retryable item is never dropped.
         if (!_configuration.EnablePollingFallback || _pollingManager is null)
         {
             return;
@@ -446,7 +440,7 @@ internal class SubscriptionManager : IAsyncDisposable
 
                 var attempts = _healAttempts.AddOrUpdate(monitoredItem.ClientHandle, 1, static (_, current) => current + 1);
 
-                if (DecideHealAction(attempts, MaxHealAttemptsBeforeEscalation) == HealDecision.EscalateToPolling)
+                if (ShouldEscalateToPolling(attempts, MaxHealAttemptsBeforeEscalation))
                 {
                     (toEscalate ??= []).Add(monitoredItem);
                 }
@@ -461,22 +455,9 @@ internal class SubscriptionManager : IAsyncDisposable
             {
                 _monitoredItems.TryRemove(monitoredItem.ClientHandle, out _);
                 _healAttempts.TryRemove(monitoredItem.ClientHandle, out _);
-                subscription.RemoveItem(monitoredItem);
             }
 
-            try
-            {
-                await subscription.ApplyChangesAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "ApplyChanges after escalating persistently-failed OPC UA monitored items to polling failed.");
-            }
-
-            foreach (var monitoredItem in toEscalate)
-            {
-                _pollingManager.AddItem(monitoredItem);
-            }
+            await RemoveAndFallBackToPollingAsync(subscription, toEscalate, toEscalate, cancellationToken).ConfigureAwait(false);
 
             _logger.LogWarning(
                 "Escalated {Count} persistently-failing monitored items to polling in subscription {SubscriptionId} after {Max} retries.",

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -28,6 +28,18 @@ internal enum FailedMonitoredItemDisposition
     Drop
 }
 
+/// <summary>
+/// What to do with a retryable monitored item that keeps failing to heal.
+/// </summary>
+internal enum HealDecision
+{
+    /// <summary>Still within the retry bound: let the health monitor keep retrying.</summary>
+    KeepRetrying,
+
+    /// <summary>Retry bound exceeded and polling available: move the item to the polling fallback.</summary>
+    EscalateToPolling
+}
+
 internal class SubscriptionManager : IAsyncDisposable
 {
     private static readonly ObjectPool<List<PropertyUpdate>> ChangesPool
@@ -42,6 +54,12 @@ internal class SubscriptionManager : IAsyncDisposable
 
     private readonly ConcurrentDictionary<uint, RegisteredSubjectProperty> _monitoredItems = new();
     private readonly ConcurrentDictionary<Subscription, byte> _subscriptions = new();
+    private readonly ConcurrentDictionary<uint, int> _healAttempts = new();
+
+    // Consecutive failed heal ticks a retryable item tolerates before it is escalated to polling
+    // instead of being retried forever. With polling disabled there is no escalation target, so the
+    // item keeps being retried and self-heals once the node recovers.
+    internal const int MaxHealAttemptsBeforeEscalation = 3;
 
     private volatile bool _shuttingDown; // Prevents new callbacks during cleanup
 
@@ -103,6 +121,7 @@ internal class SubscriptionManager : IAsyncDisposable
         }
         _subscriptions.Clear();
         _monitoredItems.Clear();
+        _healAttempts.Clear();
 
         // Reset shutdown flag AFTER clearing collections - prevents old callbacks from processing
         // during the window between flag reset and collection clearing (defense-in-depth).
@@ -376,6 +395,96 @@ internal class SubscriptionManager : IAsyncDisposable
     }
 
     /// <summary>
+    /// Decides what to do with a retryable item that keeps failing to heal, once polling fallback
+    /// is available: keep retrying within the bound, then escalate to polling. With polling disabled
+    /// the caller never escalates, so the health monitor keeps retrying and the item self-heals.
+    /// </summary>
+    internal static HealDecision DecideHealAction(int consecutiveFailures, int maxAttempts)
+    {
+        return consecutiveFailures < maxAttempts
+            ? HealDecision.KeepRetrying
+            : HealDecision.EscalateToPolling;
+    }
+
+    /// <summary>
+    /// Escalates retryable monitored items that keep failing after the health monitor has retried
+    /// them. An item that exceeds <see cref="MaxHealAttemptsBeforeEscalation"/> consecutive failed
+    /// heals falls back to polling instead of being retried forever. With polling disabled there is
+    /// no better target, so the item is never dropped: the health monitor keeps retrying and it
+    /// self-heals once the node recovers. Items that recover reset their attempt count, and reconnect
+    /// re-attempts a real subscription for every owned item, so escalation is not permanent.
+    /// </summary>
+    public async Task EscalatePersistentlyFailedItemsAsync(CancellationToken cancellationToken)
+    {
+        // Escalation only has a target when polling is available. With polling disabled there is
+        // nothing better than letting the health monitor keep retrying, which self-heals once the
+        // node recovers, so a retryable item is never dropped.
+        if (!_configuration.EnablePollingFallback || _pollingManager is null)
+        {
+            return;
+        }
+
+        foreach (var subscription in _subscriptions.Keys)
+        {
+            List<MonitoredItem>? toEscalate = null;
+
+            foreach (var monitoredItem in subscription.MonitoredItems)
+            {
+                if (!SubscriptionHealthMonitor.IsUnhealthy(monitoredItem))
+                {
+                    if (!_healAttempts.IsEmpty)
+                    {
+                        _healAttempts.TryRemove(monitoredItem.ClientHandle, out _); // recovered: reset
+                    }
+                    continue;
+                }
+
+                if (!SubscriptionHealthMonitor.IsRetryable(monitoredItem))
+                {
+                    continue; // permanent errors are handled at creation time
+                }
+
+                var attempts = _healAttempts.AddOrUpdate(monitoredItem.ClientHandle, 1, static (_, current) => current + 1);
+
+                if (DecideHealAction(attempts, MaxHealAttemptsBeforeEscalation) == HealDecision.EscalateToPolling)
+                {
+                    (toEscalate ??= []).Add(monitoredItem);
+                }
+            }
+
+            if (toEscalate is not { Count: > 0 })
+            {
+                continue;
+            }
+
+            foreach (var monitoredItem in toEscalate)
+            {
+                _monitoredItems.TryRemove(monitoredItem.ClientHandle, out _);
+                _healAttempts.TryRemove(monitoredItem.ClientHandle, out _);
+                subscription.RemoveItem(monitoredItem);
+            }
+
+            try
+            {
+                await subscription.ApplyChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ApplyChanges after escalating persistently-failed OPC UA monitored items to polling failed.");
+            }
+
+            foreach (var monitoredItem in toEscalate)
+            {
+                _pollingManager.AddItem(monitoredItem);
+            }
+
+            _logger.LogWarning(
+                "Escalated {Count} persistently-failing monitored items to polling in subscription {SubscriptionId} after {Max} retries.",
+                toEscalate.Count, subscription.Id, MaxHealAttemptsBeforeEscalation);
+        }
+    }
+
+    /// <summary>
     /// Removes monitored items for a detached subject. Idempotent.
     /// Note: OPC UA subscription items remain on server until session ends.
     /// This just cleans up local tracking to avoid memory leaks.
@@ -387,6 +496,7 @@ internal class SubscriptionManager : IAsyncDisposable
             if (kvp.Value.Reference.Subject == subject)
             {
                 _monitoredItems.TryRemove(kvp.Key, out _);
+                _healAttempts.TryRemove(kvp.Key, out _);
             }
         }
     }

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -110,6 +110,9 @@ internal class SubscriptionManager : IAsyncDisposable
         _subscriptions.Clear();
         _monitoredItems.Clear();
         _healAttempts.Clear();
+        // On reconnect, re-attempt every owned property as a real subscription; failed nodes are
+        // re-added to polling. Prevents double delivery of an escalated item that later recovers.
+        _pollingManager?.Clear();
 
         // Reset shutdown flag AFTER clearing collections - prevents old callbacks from processing
         // during the window between flag reset and collection clearing (defense-in-depth).
@@ -289,8 +292,8 @@ internal class SubscriptionManager : IAsyncDisposable
             switch (ClassifyFailedItem(statusCode, pollingEnabled))
             {
                 case FailedMonitoredItemDisposition.KeepForRetry:
-                    // Leave it in the subscription and in _monitoredItems so the health monitor
-                    // heals it. Removing it here silently orphaned transiently-failed items.
+                    // Keep it in the subscription so the health monitor heals it; removing it here
+                    // silently orphaned transiently-failed items.
                     keptForRetry++;
                     _logger.LogWarning("OPC UA monitored item {DisplayName} failed transiently ({Status}); keeping it for the health monitor to retry.",
                         monitoredItem.DisplayName, statusCode);
@@ -405,11 +408,9 @@ internal class SubscriptionManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Escalates retryable monitored items that keep failing after the health monitor has retried
-    /// them: once an item exceeds <see cref="MaxHealAttemptsBeforeEscalation"/> it falls back to
-    /// polling. Items that recover reset their attempt count, and reconnect re-attempts a real
-    /// subscription for every owned item, so escalation is not permanent. Only runs when polling is
-    /// enabled; see <see cref="MaxHealAttemptsBeforeEscalation"/> for the polling-disabled case.
+    /// Escalates a retryable item that keeps failing past <see cref="MaxHealAttemptsBeforeEscalation"/>
+    /// to polling instead of retrying forever. Runs only when polling is enabled; reconnect clears the
+    /// polling set and re-attempts every item, so escalation is not permanent.
     /// </summary>
     public async Task EscalatePersistentlyFailedItemsAsync(CancellationToken cancellationToken)
     {
@@ -435,7 +436,7 @@ internal class SubscriptionManager : IAsyncDisposable
 
                 if (!SubscriptionHealthMonitor.IsRetryable(monitoredItem))
                 {
-                    continue; // permanent errors are handled at creation time
+                    continue; // permanent errors are dropped at creation; a runtime transition to permanent-bad is left in place until reconnect
                 }
 
                 var attempts = _healAttempts.AddOrUpdate(monitoredItem.ClientHandle, 1, static (_, current) => current + 1);

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
@@ -369,6 +369,9 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
             sessionManager.Subscriptions,
             cancellationToken).ConfigureAwait(false);
 
+        await sessionManager.SubscriptionManager
+            .EscalatePersistentlyFailedItemsAsync(cancellationToken).ConfigureAwait(false);
+
         return false;
     }
 

--- a/src/Namotion.Interceptor.OpcUa/Client/Polling/PollingManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Polling/PollingManager.cs
@@ -175,6 +175,15 @@ internal sealed class PollingManager : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Removes all polled items so a subscription (re)creation re-attempts every owned property;
+    /// nodes that fail again are re-added. Prevents double delivery of a recovered escalated item.
+    /// </summary>
+    public void Clear()
+    {
+        _pollingItems.Clear();
+    }
+
     private async Task PollLoopAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)

--- a/src/Namotion.Interceptor.OpcUa/Client/Resilience/SubscriptionHealthMonitor.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Resilience/SubscriptionHealthMonitor.cs
@@ -93,7 +93,11 @@ internal sealed class SubscriptionHealthMonitor
     internal static bool IsRetryable(MonitoredItem item)
     {
         var statusCode = item.Status?.Error?.StatusCode ?? StatusCodes.Good;
+        return IsRetryable(statusCode);
+    }
 
+    internal static bool IsRetryable(StatusCode statusCode)
+    {
         // Design-time errors - don't retry (permanent errors)
         if (statusCode == StatusCodes.BadNodeIdUnknown ||
             statusCode == StatusCodes.BadAttributeIdInvalid ||


### PR DESCRIPTION
## What

Reconnect and subscription-recovery correctness fixes in the OPC UA client, surfaced while formalizing the client's invariants.

### 1. Transiently-failed monitored items: healed, bounded, then escalated (never orphaned, never looped forever)

`FilterOutFailedMonitoredItemsAsync` removed every failed item from its subscription, including transient failures (`BadOutOfService`, `BadTooManyMonitoredItems`, ...) that `SubscriptionHealthMonitor.IsRetryable` is meant to retry. Because the health monitor only heals items still present in a subscription, a removed item was never retried and stayed dark until some unrelated full reconnect.

Now failures are classified (`ClassifyFailedItem`): transient failures stay in the subscription for the health monitor to heal, subscription-unsupported nodes fall back to polling, and permanent design-time errors are dropped. A retryable item that keeps failing past a bound (`MaxHealAttemptsBeforeEscalation`, three consecutive health checks, roughly 15 seconds) then escalates instead of retrying the subscription forever:

- with `EnablePollingFallback` on (the default), it moves to polling;
- with polling off, there is no better target, so the health monitor keeps retrying and it self-heals once the node returns.

A retryable item is never dropped, and reconnect re-attempts a real subscription for every owned item, so escalation to polling is not permanent.

### 2. No stale notifications applied during session abandon

`AbandonCurrentSession` nulled the session without buffering and without detaching the old subscription's callback, so a late notification arriving before the next reconnect tick was applied directly to the model. It now buffers from abandon until the reconnect reloads and replays state.

## Tests

- `FailedMonitoredItemDispositionTests` covers the failure classification and the bounded-retry-then-escalate decision.
- Full OPC UA suite green: 272 tests (unit plus integration, including the reconnection, stall, and transfer paths that exercise the abandon window).

## Note

The abandon-buffering fix is a safe, idempotent change but lacks a dedicated regression test; reproducing the exact abandon-to-reconnect race deterministically needs reconnect fault-injection infrastructure, so it is covered here by the existing reconnection integration tests as a no-regression guard.
