### PR TITLE
Move project instructions to AGENTS.md

### DIFF
--- a/.claude/agents/performance-optimizer.md
+++ b/.claude/agents/performance-optimizer.md
@@ -63,7 +63,7 @@ This codebase prioritizes allocation reduction over micro-CPU optimization. In r
 - Do NOT commit. Do NOT push branches. Do NOT switch branches. The caller handles git plumbing.
 - Do NOT open PRs. Do NOT create issues or comments.
 - Do NOT run benchmarks. The orchestrator runs `pwsh scripts/benchmark.ps1` after you return; agents have been observed hanging or being sandbox-blocked on the benchmark step.
-- Do NOT touch CLAUDE.md, README.md, or design docs. The caller owns docs.
+- Do NOT touch AGENTS.md, CLAUDE.md, README.md, or design docs. The caller owns docs.
 - Do NOT use `git add` or `git commit`. Leave changes in the working tree.
 - Stay within the Namotion.Interceptor repository. Do not work in HomeBlaze.
 - Output in commit messages and report text: no em dashes, no AI attribution, no "Generated with..." footer.

--- a/.claude/commands/improve-performance.md
+++ b/.claude/commands/improve-performance.md
@@ -25,7 +25,7 @@ Ask the user one question at a time:
 3. **Benchmark mapping.** Read the benchmark project sources. For each candidate, propose a BenchmarkDotNet filter pattern. Show the table with a `Coverage` column. For candidates with no clear coverage, ask per candidate: (a) write a new benchmark on the parent branch, (b) skip the candidate, (c) run with the closest existing filter and accept noisy results.
 4. **Run config.** `LaunchCount` (default 3) and `Short` toggle (default off).
 
-Test verification is fixed: every candidate runs `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"` (matches the project default in `CLAUDE.md`). Results are recorded only in the local design doc on the parent branch, not posted to any GitHub issue.
+Test verification is fixed: every candidate runs `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"` (matches the project default in `AGENTS.md`). Results are recorded only in the local design doc on the parent branch, not posted to any GitHub issue.
 
 Then print a final plan summary (parent branch name, list of candidates with branch names, benchmark filter, doc path) and ask one explicit `proceed?` confirmation. Warn that the working directory will be owned by the skill for ~30-90 min.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Codex, GitHub Copilot) when working with code in this repository.
+
+## Overview
+
+Namotion.Interceptor is a .NET library for creating trackable object models through automatic property interception using C# 13 partial properties and source generation. It enables property change tracking, derived property updates, and object graph management with zero runtime reflection.
+
+## Priorities
+
+When tradeoffs conflict, prefer in this order:
+
+1. **Correctness** — documented semantics, thread-safety (no data races, no torn reads/writes), quiescent consistency (state agrees once writes settle), existing invariants hold.
+2. **Performance** — minimize allocations and CPU time. Both matter; when they trade, allocations usually win (GC pressure compounds across the host).
+3. **Code style / idiom** — non-idiomatic API is fine when 1 or 2 demand it (e.g., `ImmutableArray<T>` in public API instead of `IEnumerable<T>`).
+
+## Development Commands
+
+### Build and Test
+- `dotnet build src/Namotion.Interceptor.slnx` - Build entire solution
+- `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"` - Run unit tests (default)
+- `dotnet test src/Namotion.Interceptor.slnx` - Run all tests including integration
+- `dotnet pack src/Namotion.Interceptor.slnx` - Create NuGet packages
+
+Only run integration tests when changing connector implementations (OPC UA, MQTT, WebSocket, etc.) or HomeBlaze UI — run those targeted per project, e.g.:
+- `dotnet test src/Namotion.Interceptor.OpcUa.Tests`
+- `dotnet test src/HomeBlaze/HomeBlaze.E2E.Tests`
+
+### Running Samples
+- `dotnet run --project src/Namotion.Interceptor.SampleConsole` - Run console sample
+- `dotnet run --project src/Extensions/Namotion.Interceptor.SampleBlazor` - Run Blazor sample
+
+### Performance Testing
+- `dotnet run --project src/Namotion.Interceptor.Benchmarks -c Release` - Run performance benchmarks
+
+## Architecture
+
+### Core Components
+- **Core Library**: `Namotion.Interceptor` - Base interfaces and execution engine (.NET Standard 2.0)
+- **Source Generator**: `Namotion.Interceptor.Generator` - Compile-time code generation for `[InterceptorSubject]` classes
+- **Extension Libraries**: Tracking, Registry, Validation, Hosting, Sources, Dynamic (.NET 9.0)
+
+### Key Design Patterns
+- **Chain of Responsibility**: `IReadInterceptor`/`IWriteInterceptor` middleware chain
+- **Service Container**: `IInterceptorSubjectContext` for dependency injection and coordination
+- **Source Generation**: Zero runtime reflection through compile-time code generation
+- **Observable Streams**: System.Reactive integration for change notifications
+
+### Project Structure
+```
+src/
+├── Namotion.Interceptor/           # Core library with base interfaces
+├── Namotion.Interceptor.Generator/ # Source generator for [InterceptorSubject]
+├── Namotion.Interceptor.{Feature}/ # Extension libraries (Tracking, Registry, etc.)
+├── Extensions/                     # Integration packages (AspNetCore, Blazor, etc.)
+├── Samples/                        # Example applications
+└── Tests/                          # Unit test projects
+docs/                               # Feature and connector documentation
+├── design/                         # Internal design documents
+```
+
+## Language Requirements
+
+This codebase requires **C# 13 preview features** for partial properties. The `[InterceptorSubject]` attribute triggers source generation that creates interception logic at compile-time.
+
+### Basic Usage Pattern
+```csharp
+[InterceptorSubject]
+public partial class Person
+{
+    public partial string FirstName { get; set; }
+
+    [Derived]
+    public string FullName => $"{FirstName} {LastName}";
+}
+
+var context = InterceptorSubjectContext
+    .Create()
+    .WithFullPropertyTracking();
+
+var person = new Person(context);
+```
+
+## Configuration Extensions
+
+The library uses a fluent configuration API:
+- `WithFullPropertyTracking()` - Enable complete change detection
+- `WithRegistry()` - Enable object graph navigation
+- `WithDataAnnotationValidation()` - Enable automatic validation
+- `WithLifecycle()` - Enable attach/detach callbacks
+
+## Build Configuration
+
+- **Global Settings**: `Directory.Build.props` with nullable enabled, warnings as errors
+- **Target Frameworks**: .NET Standard 2.0 (core), .NET 9.0 (extensions)
+- **Package Version**: 0.0.2 (early development)
+- **CI/CD**: GitHub Actions with xUnit testing, coverage reporting, and NuGet publishing
+
+## Key Dependencies
+
+- Microsoft.CodeAnalysis.CSharp 4.14.0 (source generator)
+- System.Reactive 6.0.1 (change tracking observables)
+- Microsoft.Extensions.DependencyInjection.Abstractions (hosting)
+- OPCFoundation.NetStandard.Opc.Ua.* 1.5.376.244 (industrial integration)
+
+## Industrial Integration Focus
+
+The library has specialized support for:
+- **OPC UA**: Industrial automation protocol integration
+- **MQTT**: IoT messaging patterns
+- **ASP.NET Core**: Web API exposure
+- **GraphQL**: Real-time subscription support
+- **Blazor**: UI data binding components
+
+## Performance Considerations
+
+- All interception logic generated at compile-time (no runtime reflection)
+- Dedicated benchmarking with BenchmarkDotNet
+- Recent performance optimizations focused on allocation reduction
+- Observable streams for efficient change propagation
+
+## Coding Style
+
+- **Avoid abbreviations** in variable and parameter names unless the name is very long. Use descriptive names (e.g., `attribute` not `attr`).
+- **No em dashes** in docs, READMEs, or PR descriptions. Restructure into plain sentences instead.
+
+## Git Rules
+
+- Never include AI attribution in commit messages, PR descriptions, or GitHub comments. This covers agent names ("Claude", "Codex", "Copilot"), `Co-Authored-By` trailers, and "Generated with" footers.
+
+## Test Conventions
+
+- **Naming**: `When<Condition>_Then<ExpectedBehavior>` (e.g., `WhenDepthIsZero_ThenReturnsNoChildren`)
+- **Structure**: Explicit `// Arrange`, `// Act`, `// Assert` comments separating each phase (use `// Act & Assert` for exception tests)
+- **No hardcoded waits**: Use `AsyncTestHelpers.WaitUntilAsync(() => condition)` or event-based synchronization (`ManualResetEventSlim`, `CountdownEvent`) instead of `Task.Delay`/`Thread.Sleep`. Hardcoded delays are either too long (slow CI) or too short (flaky CI).
+
+## Public API Tracking
+
+The public API for some libraries is snapshot-tested via `PublicApiGenerator` + `Verify`. Each one's test project has a `VerifyChecksTests.PublicApi` test that compares the generated API against a checked-in `VerifyChecksTests.PublicApi.verified.txt`. When the API changes intentionally, accept the new snapshot by replacing `.verified.txt` with the test's `.received.txt` output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,139 +1,19 @@
-# CLAUDE.md
+<!--
+Canonical project instructions live in AGENTS.md so that Claude Code, Codex and
+GitHub Copilot all read the same content.
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+  Codex   reads AGENTS.md directly. It does NOT read CLAUDE.md.
+  Copilot reads AGENTS.md directly (nearest file in the tree wins).
+  Claude Code reads CLAUDE.md only, so it imports AGENTS.md below.
+  See https://code.claude.com/docs/en/memory (AGENTS.md section).
 
-## Overview
+Keep AGENTS.md fully self-contained: Codex does not support Claude's import
+syntax, so anything pulled in by reference would be invisible to it.
 
-Namotion.Interceptor is a .NET library for creating trackable object models through automatic property interception using C# 13 partial properties and source generation. It enables property change tracking, derived property updates, and object graph management with zero runtime reflection.
+Put shared rules in AGENTS.md. Put Claude-Code-only rules under the import below.
 
-## Priorities
+This comment block is stripped before the file enters Claude's context, so it
+costs no tokens.
+-->
 
-When tradeoffs conflict, prefer in this order:
-
-1. **Correctness** — documented semantics, thread-safety (no data races, no torn reads/writes), quiescent consistency (state agrees once writes settle), existing invariants hold.
-2. **Performance** — minimize allocations and CPU time. Both matter; when they trade, allocations usually win (GC pressure compounds across the host).
-3. **Code style / idiom** — non-idiomatic API is fine when 1 or 2 demand it (e.g., `ImmutableArray<T>` in public API instead of `IEnumerable<T>`).
-
-## Development Commands
-
-### Build and Test
-- `dotnet build src/Namotion.Interceptor.slnx` - Build entire solution
-- `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"` - Run unit tests (default)
-- `dotnet test src/Namotion.Interceptor.slnx` - Run all tests including integration
-- `dotnet pack src/Namotion.Interceptor.slnx` - Create NuGet packages
-
-Only run integration tests when changing connector implementations (OPC UA, MQTT, WebSocket, etc.) or HomeBlaze UI — run those targeted per project, e.g.:
-- `dotnet test src/Namotion.Interceptor.OpcUa.Tests`
-- `dotnet test src/HomeBlaze/HomeBlaze.E2E.Tests`
-
-### Running Samples
-- `dotnet run --project src/Namotion.Interceptor.SampleConsole` - Run console sample
-- `dotnet run --project src/Extensions/Namotion.Interceptor.SampleBlazor` - Run Blazor sample
-
-### Performance Testing
-- `dotnet run --project src/Namotion.Interceptor.Benchmarks -c Release` - Run performance benchmarks
-
-## Architecture
-
-### Core Components
-- **Core Library**: `Namotion.Interceptor` - Base interfaces and execution engine (.NET Standard 2.0)
-- **Source Generator**: `Namotion.Interceptor.Generator` - Compile-time code generation for `[InterceptorSubject]` classes
-- **Extension Libraries**: Tracking, Registry, Validation, Hosting, Sources, Dynamic (.NET 9.0)
-
-### Key Design Patterns
-- **Chain of Responsibility**: `IReadInterceptor`/`IWriteInterceptor` middleware chain
-- **Service Container**: `IInterceptorSubjectContext` for dependency injection and coordination
-- **Source Generation**: Zero runtime reflection through compile-time code generation
-- **Observable Streams**: System.Reactive integration for change notifications
-
-### Project Structure
-```
-src/
-├── Namotion.Interceptor/           # Core library with base interfaces
-├── Namotion.Interceptor.Generator/ # Source generator for [InterceptorSubject]
-├── Namotion.Interceptor.{Feature}/ # Extension libraries (Tracking, Registry, etc.)
-├── Extensions/                     # Integration packages (AspNetCore, Blazor, etc.)
-├── Samples/                        # Example applications
-└── Tests/                          # Unit test projects
-docs/                               # Feature and connector documentation
-├── design/                         # Internal design documents
-```
-
-## Language Requirements
-
-This codebase requires **C# 13 preview features** for partial properties. The `[InterceptorSubject]` attribute triggers source generation that creates interception logic at compile-time.
-
-### Basic Usage Pattern
-```csharp
-[InterceptorSubject]
-public partial class Person
-{
-    public partial string FirstName { get; set; }
-
-    [Derived]
-    public string FullName => $"{FirstName} {LastName}";
-}
-
-var context = InterceptorSubjectContext
-    .Create()
-    .WithFullPropertyTracking();
-
-var person = new Person(context);
-```
-
-## Configuration Extensions
-
-The library uses a fluent configuration API:
-- `WithFullPropertyTracking()` - Enable complete change detection
-- `WithRegistry()` - Enable object graph navigation
-- `WithDataAnnotationValidation()` - Enable automatic validation
-- `WithLifecycle()` - Enable attach/detach callbacks
-
-## Build Configuration
-
-- **Global Settings**: `Directory.Build.props` with nullable enabled, warnings as errors
-- **Target Frameworks**: .NET Standard 2.0 (core), .NET 9.0 (extensions)
-- **Package Version**: 0.0.2 (early development)
-- **CI/CD**: GitHub Actions with xUnit testing, coverage reporting, and NuGet publishing
-
-## Key Dependencies
-
-- Microsoft.CodeAnalysis.CSharp 4.14.0 (source generator)
-- System.Reactive 6.0.1 (change tracking observables)
-- Microsoft.Extensions.DependencyInjection.Abstractions (hosting)
-- OPCFoundation.NetStandard.Opc.Ua.* 1.5.376.244 (industrial integration)
-
-## Industrial Integration Focus
-
-The library has specialized support for:
-- **OPC UA**: Industrial automation protocol integration
-- **MQTT**: IoT messaging patterns
-- **ASP.NET Core**: Web API exposure
-- **GraphQL**: Real-time subscription support
-- **Blazor**: UI data binding components
-
-## Performance Considerations
-
-- All interception logic generated at compile-time (no runtime reflection)
-- Dedicated benchmarking with BenchmarkDotNet
-- Recent performance optimizations focused on allocation reduction
-- Observable streams for efficient change propagation
-
-## Coding Style
-
-- **Avoid abbreviations** in variable and parameter names unless the name is very long. Use descriptive names (e.g., `attribute` not `attr`).
-- **No em dashes** in docs, READMEs, or PR descriptions. Restructure into plain sentences instead.
-
-## Git Rules
-
-- Never include "Claude", "Co-Authored-By", or AI attribution in commit messages, PR descriptions, or GitHub comments.
-
-## Test Conventions
-
-- **Naming**: `When<Condition>_Then<ExpectedBehavior>` (e.g., `WhenDepthIsZero_ThenReturnsNoChildren`)
-- **Structure**: Explicit `// Arrange`, `// Act`, `// Assert` comments separating each phase (use `// Act & Assert` for exception tests)
-- **No hardcoded waits**: Use `AsyncTestHelpers.WaitUntilAsync(() => condition)` or event-based synchronization (`ManualResetEventSlim`, `CountdownEvent`) instead of `Task.Delay`/`Thread.Sleep`. Hardcoded delays are either too long (slow CI) or too short (flaky CI).
-
-## Public API Tracking
-
-The public API for some libraries is snapshot-tested via `PublicApiGenerator` + `Verify`. Each one's test project has a `VerifyChecksTests.PublicApi` test that compares the generated API against a checked-in `VerifyChecksTests.PublicApi.verified.txt`. When the API changes intentionally, accept the new snapshot by replacing `.verified.txt` with the test's `.received.txt` output.
+@AGENTS.md

--- a/src/Namotion.Interceptor.slnx
+++ b/src/Namotion.Interceptor.slnx
@@ -11,6 +11,7 @@
     <File Path="../.gitignore" />
     <File Path="../features.png" />
     <File Path="../README.md" />
+    <File Path="../AGENTS.md" />
     <File Path="../CLAUDE.md" />
     <File Path="Directory.Build.props" />
   </Folder>


### PR DESCRIPTION
## What

Makes `AGENTS.md` the canonical project instruction file. `CLAUDE.md` is reduced to a single `@AGENTS.md` import plus an explanatory comment.

## Why

Claude Code, Codex and GitHub Copilot each look for a different file. Keeping the rules in one place avoids the three copies drifting apart.

| Agent | Reads |
| --- | --- |
| Codex | `AGENTS.md` directly, never `CLAUDE.md` |
| GitHub Copilot | `AGENTS.md` directly, nearest file in the tree wins |
| Claude Code | `CLAUDE.md`, which imports `AGENTS.md` |

`AGENTS.md` has to stay self-contained: Codex does not support Claude's `@` import syntax, so anything pulled in by reference would be invisible to it. Claude-Code-only rules can be placed under the import in `CLAUDE.md`.

The comment block in `CLAUDE.md` is an HTML comment and is stripped before the file enters the model context, so it costs no tokens. Verified against a live session.

## Also in this change

- `AGENTS.md` added to the solution folder in `Namotion.Interceptor.slnx`, next to `CLAUDE.md`.
- `.claude/agents/performance-optimizer.md` and `.claude/commands/improve-performance.md` updated where they referenced `CLAUDE.md` as the source of project rules.
- The git attribution rule is stated more explicitly: it now names agent names, `Co-Authored-By` trailers and "Generated with" footers rather than listing a couple of examples.

No source or test changes.