### PR TITLE
Harden FromSource origin survival and skip Local-replay origin arming

### DIFF
--- a/src/Namotion.Interceptor.Tests/OriginWriteContextTests.cs
+++ b/src/Namotion.Interceptor.Tests/OriginWriteContextTests.cs
@@ -1,6 +1,23 @@
+using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Interceptors;
 
 namespace Namotion.Interceptor.Tests;
+
+public enum ProbeMode
+{
+    Idle = 0,
+    Running = 1,
+    Fault = 2
+}
+
+/// <summary>Dedicated model with a reference-typed and a nullable-enum property for the survival tests.</summary>
+[InterceptorSubject]
+public partial class OriginProbeSubject
+{
+    public partial string? Name { get; set; }
+
+    public partial ProbeMode? Mode { get; set; }
+}
 
 public class OriginWriteContextTests
 {
@@ -59,6 +76,100 @@ public class OriginWriteContextTests
         // Assert: attempted origin visible mid-chain, Local after finalization.
         Assert.Equal(ChangeOriginKind.FromSource, probe.KindBeforeWrite);
         Assert.Equal(ChangeOriginKind.Local, probe.KindAfterWrite);
+    }
+
+    [Fact]
+    public void WhenSentValueIsNullForValueTypeProperty_ThenOriginIsFinalizedToLocalWithoutThrowing()
+    {
+        // Arrange: a stamped write on a value-type property whose sent value is null (a malformed
+        // inbound value). The survival check must demote to Local via the typed-pattern unbox instead
+        // of throwing when it casts null down to the value type.
+        var probe = new OriginProbe();
+        var context = InterceptorSubjectContext.Create();
+        context.AddService(probe);
+        var car = new Car(context);
+        var property = new PropertyReference(car, "Speed");
+
+        // Act
+        using (PendingOrigin.Set(property, ChangeOrigin.FromSource(new object()), sentValue: null))
+        {
+            car.Speed = 55;
+        }
+
+        // Assert: no throw; attempted origin visible mid-chain, demoted to Local after finalization.
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindBeforeWrite);
+        Assert.Equal(ChangeOriginKind.Local, probe.KindAfterWrite);
+    }
+
+    [Fact]
+    public void WhenSentValueTypeMismatchesValueTypeProperty_ThenOriginIsFinalizedToLocalWithoutThrowing()
+    {
+        // Arrange: the sent value is a boxed string but the property is an int, so the typed-pattern
+        // unbox fails and the origin demotes to Local rather than throwing an InvalidCastException.
+        var probe = new OriginProbe();
+        var context = InterceptorSubjectContext.Create();
+        context.AddService(probe);
+        var car = new Car(context);
+        var property = new PropertyReference(car, "Speed");
+
+        // Act
+        using (PendingOrigin.Set(property, ChangeOrigin.FromSource(new object()), sentValue: "55"))
+        {
+            car.Speed = 55;
+        }
+
+        // Assert
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindBeforeWrite);
+        Assert.Equal(ChangeOriginKind.Local, probe.KindAfterWrite);
+    }
+
+    [Fact]
+    public void WhenSentValueIsNullForReferenceTypeProperty_ThenOriginSurvivesAsFromSource()
+    {
+        // Arrange: a source clears a reference-typed property to null (old value non-null, so the write
+        // proceeds and stores null faithfully). `null is TProperty` is always false in C#, so the
+        // survival check must special-case null-matches-null to keep the origin FromSource; otherwise
+        // the null would wrongly demote to Local and be echoed back to the source.
+        var probe = new OriginProbe();
+        var context = InterceptorSubjectContext.Create();
+        context.AddService(probe);
+        var subject = new OriginProbeSubject(context) { Name = "initial" };
+        var property = new PropertyReference(subject, "Name");
+
+        // Act
+        using (PendingOrigin.Set(property, ChangeOrigin.FromSource(new object()), sentValue: null))
+        {
+            subject.Name = null;
+        }
+
+        // Assert: null was faithfully stored, so the origin survives as FromSource (not demoted).
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindBeforeWrite);
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindAfterWrite);
+    }
+
+    [Fact]
+    public void WhenSentValueIsNullableEnumUnderlyingInteger_ThenOriginSurvivesAsFromSource()
+    {
+        // Arrange: a source delivers a nullable enum as its boxed underlying integer (the OPC UA wire
+        // shape). The write stores the enum faithfully, so the origin must survive as FromSource. Casting
+        // the boxed integer to the nullable enum throws, so the survival check must unwrap Nullable<T> and
+        // coerce the underlying integer to the enum before comparing; otherwise the value demotes to Local
+        // and is echoed straight back to the source.
+        var probe = new OriginProbe();
+        var context = InterceptorSubjectContext.Create();
+        context.AddService(probe);
+        var subject = new OriginProbeSubject(context);
+        var property = new PropertyReference(subject, "Mode");
+
+        // Act: sentValue is the boxed underlying integer while the stored value is the enum.
+        using (PendingOrigin.Set(property, ChangeOrigin.FromSource(new object()), sentValue: (int)ProbeMode.Fault))
+        {
+            subject.Mode = ProbeMode.Fault;
+        }
+
+        // Assert
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindBeforeWrite);
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindAfterWrite);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeOperations.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeOperations.cs
@@ -119,12 +119,23 @@ internal static class SubjectPropertyChangeOperations
         {
             var metadata = change.Property.Metadata;
             var newValue = change.GetNewValue<object?>();
-            // Setting a Local origin is a no-op stamp (consume yields Local), so revert paths
-            // re-apply each change with its original provenance without branching.
+            // Local origins arm no stamp: an absent stamp and a Local stamp both finalize to Local
+            // (FinalizeOrigin short-circuits on Local before reading the sent value), so skip
+            // PendingOrigin.Set on the Local replay/revert hot path. Non-Local origins (FromSource,
+            // Confirmed) still arm so echo suppression sees the source.
             using (SubjectChangeContext.WithTimestamps(change.ChangedTimestamp, change.ReceivedTimestamp))
-            using (PendingOrigin.Set(change.Property, change.Origin, newValue))
             {
-                metadata.SetValue?.Invoke(change.Property.Subject, newValue);
+                if (change.Origin.Kind == ChangeOriginKind.Local)
+                {
+                    metadata.SetValue?.Invoke(change.Property.Subject, newValue);
+                }
+                else
+                {
+                    using (PendingOrigin.Set(change.Property, change.Origin, newValue))
+                    {
+                        metadata.SetValue?.Invoke(change.Property.Subject, newValue);
+                    }
+                }
             }
             error = null;
             return true;

--- a/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
@@ -200,13 +200,8 @@ public struct PropertyWriteContext<TProperty>
 
     /// <summary>
     /// Finalizes <see cref="Origin"/> at the terminal write (right after <see cref="IsWritten"/>
-    /// becomes true). A stamped origin survives only when the stored value is exactly the value
-    /// the source sent; otherwise the value was computed locally and the origin becomes Local.
-    ///
-    /// A derived property's stored value is recomputed by its getter (published via
-    /// <see cref="GetFinalValue"/>), never literally the value the source sent, so a stamped origin
-    /// never survives a derived write. It is demoted unconditionally without invoking the getter,
-    /// because the getter must not run here (this executes under the subject's SyncRoot).
+    /// becomes true). A stamped origin survives only when the stored value is exactly the value the
+    /// source sent; otherwise the value was computed locally and the origin becomes Local.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void FinalizeOrigin()
@@ -216,14 +211,61 @@ public struct PropertyWriteContext<TProperty>
             return;
         }
 
-        // Typed comparison in the generic frame: NewValue is never boxed. SentValue arrives already
-        // boxed from the inbound apply; cast it down to TProperty for EqualityComparer.Default. On the
-        // non-generic path (TProperty == object) both operands are already boxed objects. Derived
-        // properties short-circuit the comparison (and its cast): they always demote.
-        if (Property.Metadata.IsDerived ||
-            !EqualityComparer<TProperty>.Default.Equals((TProperty)_attempted.SentValue!, NewValue))
+        // A derived property's stored value is recomputed by its getter, never literally the sent value,
+        // so a stamped origin never survives. Demoted without invoking the getter, which must not run
+        // here (this executes under the subject's SyncRoot).
+        if (Property.Metadata.IsDerived)
         {
             _attempted = default;
+            return;
+        }
+
+        // Survive only when the sent value was faithfully stored. The 'is TProperty' pattern unboxes
+        // SentValue for the exact type against the unboxed NewValue. A null sent value must be handled
+        // explicitly ('null is TProperty' is always false), else a legitimately stored null would demote
+        // to Local and defeat echo suppression. A box the pattern rejects falls back to the setter's own
+        // unbox (see SentValueEqualsAfterUnbox); a box the setter would reject demotes.
+        var survives = _attempted.SentValue is TProperty typedSentValue
+            ? EqualityComparer<TProperty>.Default.Equals(typedSentValue, NewValue)
+            : _attempted.SentValue is null
+                ? NewValue is null
+                : SentValueEqualsAfterUnbox(_attempted.SentValue, NewValue);
+
+        if (!survives)
+        {
+            _attempted = default;
+        }
+    }
+
+    /// <summary>
+    /// Fallback comparison mirroring the setter's own unbox: the is-pattern is type-strict, but the CLR
+    /// unboxes an enum and its underlying integral type interchangeably, like the generated setter's cast
+    /// (OPC UA delivers enums as boxed integers, so such a write stores faithfully and must keep its
+    /// origin). A boxed underlying integer is first coerced to the enum so a nullable enum survives too:
+    /// (DeviceMode)boxedInt unboxes leniently but (DeviceMode?)boxedInt throws, so without the coercion a
+    /// faithfully-stored nullable enum would demote to Local and defeat echo suppression. On a genuinely
+    /// incompatible box the cast throws and this method catches it, demoting to Local (safe for survival:
+    /// a value the setter could not have produced does not deserve to keep the source's origin). The catch
+    /// arm is unreachable for chain writes (a box the setter would reject never produced a successful
+    /// write) and only guards hand-constructed sent values. Kept out of the inlined finalize path: an
+    /// exception handler would make FinalizeOrigin uninlinable for every write.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool SentValueEqualsAfterUnbox(object sentValue, TProperty newValue)
+    {
+        var targetType = Nullable.GetUnderlyingType(typeof(TProperty)) ?? typeof(TProperty);
+        if (targetType.IsEnum && sentValue.GetType() == Enum.GetUnderlyingType(targetType))
+        {
+            sentValue = Enum.ToObject(targetType, sentValue);
+        }
+
+        try
+        {
+            return EqualityComparer<TProperty>.Default.Equals((TProperty)sentValue, newValue);
+        }
+        catch (InvalidCastException)
+        {
+            return false;
         }
     }
 }


### PR DESCRIPTION
Two small, independent changes to the core write path, extracted from #372 (corrections) so they can be reviewed and merged on their own. #372 rebases on top once this lands.

## Origin survival hardening (fix)

`FinalizeOrigin` decided whether a stamped `FromSource` origin survives by casting the boxed sent value straight down to the property type. That raw cast:

- throws for a null sent value on a value-type property,
- throws for a nullable enum delivered as its boxed underlying integer (the OPC UA wire shape),
- and wrongly demotes a faithfully stored value when the sent value is a type-mismatched box.

A demoted origin defeats echo suppression: the stored value is written straight back to the source. The replacement uses a null-safe `is`-pattern plus a `NoInlining` fallback that mirrors the generated setter's own unbox. A boxed underlying integer is coerced to the enum (unwrapping `Nullable<T>` first, so nullable enums survive too), and a genuinely incompatible box is caught and demoted rather than thrown. A stored value keeps its source origin exactly when the setter could have produced it, and a stored null is no longer echoed back.

`OriginWriteContextTests` pins survival across the null, reference-null, type-mismatch, and nullable-enum-underlying cases.

## Skip Local-replay origin arming (perf)

A Local-origin change finalizes to Local whether or not a pending stamp is armed (`FinalizeOrigin` short-circuits on Local before reading the sent value), so arming `PendingOrigin` for it is pure overhead on the transaction commit-replay and revert hot path. Local writes now call the setter directly; non-Local origins (FromSource, Confirmed) still arm so echo suppression sees the source.

Recovers most of the Local-commit cost (`SubjectTransactionBenchmark` Local from +8.6% to +1.6% vs master), allocation-neutral.

## Tests

Full unit suite (`Category != Integration`) passes. No public API change.
