### PR TITLE
fix: resolve cross-type and value-typed property expressions in TryGetRegisteredProperty

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -32,6 +32,18 @@ foreach (var prop in registeredTire.Properties)
 }
 ```
 
+You can also resolve a specific registered property from a strongly-typed expression, including nested paths across subjects:
+
+```csharp
+// Direct property
+var pressure = tire.TryGetRegisteredProperty(t => t.Pressure);
+
+// Nested path, including collection or dictionary segments
+var frontPressure = car.TryGetRegisteredProperty(c => c.Tires[0].Pressure);
+```
+
+The expression is resolved through the registry and is null-safe: if any subject along the path is null or not tracked by the registry, the method returns `null` instead of throwing.
+
 ## Enumerate property attributes
 
 The registry makes it easy to find metadata associated with properties:

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -36,13 +36,13 @@ You can also resolve a specific registered property from a strongly-typed expres
 
 ```csharp
 // Direct property
-var pressure = tire.TryGetRegisteredProperty(t => t.Pressure);
+var pressureProperty = tire.TryGetRegisteredProperty(t => t.Pressure);
 
 // Nested path, including collection or dictionary segments
-var frontPressure = car.TryGetRegisteredProperty(c => c.Tires[0].Pressure);
+var frontPressureProperty = car.TryGetRegisteredProperty(c => c.Tires[0].Pressure);
 ```
 
-The expression is resolved through the registry and is null-safe: if any subject along the path is null or not tracked by the registry, the method returns `null` instead of throwing.
+Member-access hops resolve through the registry; index and dictionary segments evaluate against the object graph. The lookup is null-safe either way: if a subject along the path is null or not tracked by the registry, the method returns `null` instead of throwing.
 
 ## Enumerate property attributes
 

--- a/src/Namotion.Interceptor.Registry.Tests/Models/LightGroup.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/Models/LightGroup.cs
@@ -1,0 +1,14 @@
+namespace Namotion.Interceptor.Registry.Tests.Models;
+
+[MyInterceptorSubject]
+public partial class LightGroup
+{
+    public LightGroup()
+    {
+        Lights = [];
+    }
+
+    public partial List<Light> Lights { get; set; }
+
+    public partial Dictionary<string, Light>? LightsByName { get; set; }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/Models/Room.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/Models/Room.cs
@@ -1,0 +1,9 @@
+namespace Namotion.Interceptor.Registry.Tests.Models;
+
+[MyInterceptorSubject]
+public partial class Room
+{
+    public partial Light? Light { get; set; }
+
+    public partial Zone? Zone { get; set; }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/Models/Zone.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/Models/Zone.cs
@@ -1,0 +1,7 @@
+namespace Namotion.Interceptor.Registry.Tests.Models;
+
+[MyInterceptorSubject]
+public partial class Zone
+{
+    public partial Light? Light { get; set; }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryExtensionsTests.cs
@@ -159,7 +159,7 @@ public class SubjectRegistryExtensionsTests
             .WithRegistry();
 
         // Room is attached, but Room.Zone (the first hop of the depth-3 chain) is never
-        // set, so Zone.Light.On can never be reached — the resolver must not dereference
+        // set, so Zone.Light.On can never be reached. The resolver must not dereference
         // through the null Zone to get there.
         var room = new Room(context);
 
@@ -250,5 +250,100 @@ public class SubjectRegistryExtensionsTests
         // Assert
         Assert.NotNull(registeredSubjectProperty);
         Assert.Equal("FirstName_MaxLength", registeredSubjectProperty.Name);
+    }
+
+    [Fact]
+    public void WhenSubjectBeforeCollectionIndexIsNull_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        // Mother is null, so evaluating Mother.Children[0] throws a NullReferenceException;
+        // the resolver must treat that navigation miss as null.
+        var person = new Person(context)
+        {
+            FirstName = "Root"
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p.Mother!.Children[0].FirstName);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
+    }
+
+    [Fact]
+    public void WhenArrayIndexIsOutOfRange_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        // Children has a single element, so index 5 throws IndexOutOfRangeException.
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children =
+            [
+                new Person { FirstName = "A" }
+            ]
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p.Children[5].FirstName);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
+    }
+
+    [Fact]
+    public void WhenListIndexIsOutOfRange_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        // Lights has a single element, so the List indexer throws ArgumentOutOfRangeException.
+        var group = new LightGroup(context)
+        {
+            Lights =
+            [
+                new Light { Name = "A", On = true }
+            ]
+        };
+
+        // Act
+        var registeredSubjectProperty = group.TryGetRegisteredProperty(g => g.Lights[5].Name);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
+    }
+
+    [Fact]
+    public void WhenDictionaryKeyIsMissing_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        // "missing" is absent, so the dictionary indexer throws KeyNotFoundException.
+        var group = new LightGroup(context)
+        {
+            LightsByName = new Dictionary<string, Light>
+            {
+                ["known"] = new Light { Name = "A", On = true }
+            }
+        };
+
+        // Act
+        var registeredSubjectProperty = group.TryGetRegisteredProperty(g => g.LightsByName!["missing"].Name);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
     }
 }

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryExtensionsTests.cs
@@ -36,4 +36,219 @@ public class SubjectRegistryExtensionsTests
 
         Assert.Equal("Mother", registeredSubjectProperty.GetValue());
     }
+
+    [Fact]
+    public void WhenExpressionSelectsValueTypedLeafAtRoot_ThenPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var person = new Person(context)
+        {
+            FirstName = "Child"
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p.FirstName_MaxLength);
+
+        // Assert
+        Assert.NotNull(registeredSubjectProperty);
+        Assert.Equal("FirstName_MaxLength", registeredSubjectProperty.Name);
+    }
+
+    [Fact]
+    public void WhenExpressionSelectsSameTypeNestedValueTypedLeaf_ThenPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var person = new Person(context)
+        {
+            FirstName = "Child",
+            Mother = new Person
+            {
+                FirstName = "Mother"
+            }
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p.Mother!.FirstName_MaxLength);
+
+        // Assert
+        Assert.NotNull(registeredSubjectProperty);
+        Assert.Equal("FirstName_MaxLength", registeredSubjectProperty.Name);
+        Assert.Equal(person.Mother, registeredSubjectProperty.Subject);
+    }
+
+    [Fact]
+    public void WhenExpressionSelectsCrossTypeNestedValueTypedLeaf_ThenPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var room = new Room(context)
+        {
+            Light = new Light
+            {
+                Name = "Ceiling",
+                On = true
+            }
+        };
+
+        // Act
+        var registeredSubjectProperty = room.TryGetRegisteredProperty(r => r.Light!.On);
+
+        // Assert
+        Assert.NotNull(registeredSubjectProperty);
+        Assert.Equal("On", registeredSubjectProperty.Name);
+        Assert.Equal(room.Light, registeredSubjectProperty.Subject);
+    }
+
+    [Fact]
+    public void WhenIntermediateSubjectIsNull_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var person = new Person(context)
+        {
+            FirstName = "Child"
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p.Mother!.FirstName);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
+    }
+
+    [Fact]
+    public void WhenExpressionIsNotMemberAccess_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var person = new Person(context)
+        {
+            FirstName = "Child"
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
+    }
+
+    [Fact]
+    public void WhenNonAdjacentIntermediateAtDepthThreeIsNull_ThenPropertyIsNull()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        // Room is attached, but Room.Zone (the first hop of the depth-3 chain) is never
+        // set, so Zone.Light.On can never be reached — the resolver must not dereference
+        // through the null Zone to get there.
+        var room = new Room(context);
+
+        // Act
+        var registeredSubjectProperty = room.TryGetRegisteredProperty(r => r.Zone!.Light!.On);
+
+        // Assert
+        Assert.Null(registeredSubjectProperty);
+    }
+
+    [Fact]
+    public void WhenDepthThreeChainIsFullyAttached_ThenDeepestPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var room = new Room(context)
+        {
+            Zone = new Zone
+            {
+                Light = new Light
+                {
+                    Name = "Ceiling",
+                    On = true
+                }
+            }
+        };
+
+        // Act
+        var registeredSubjectProperty = room.TryGetRegisteredProperty(r => r.Zone!.Light!.On);
+
+        // Assert
+        Assert.NotNull(registeredSubjectProperty);
+        Assert.Equal("On", registeredSubjectProperty.Name);
+        Assert.Equal(room.Zone.Light, registeredSubjectProperty.Subject);
+    }
+
+    [Fact]
+    public void WhenExpressionSelectsLeafThroughCollectionIndex_ThenPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        // Children[1] is an indexer (not a member access), so the resolver must evaluate
+        // the segment against the actual graph rather than walking it through the registry.
+        var person = new Person(context)
+        {
+            FirstName = "Root",
+            Children =
+            [
+                new Person { FirstName = "A" },
+                new Person { FirstName = "B" }
+            ]
+        };
+
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty(p => p.Children[1].FirstName);
+
+        // Assert
+        Assert.NotNull(registeredSubjectProperty);
+        Assert.Equal("FirstName", registeredSubjectProperty.Name);
+        Assert.Equal(person.Children[1], registeredSubjectProperty.Subject);
+    }
+
+    [Fact]
+    public void WhenValueTypedLeafIsBoxedByObjectTypedExpression_ThenPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var person = new Person(context)
+        {
+            FirstName = "Child"
+        };
+
+        // Explicit object? value type forces the int leaf into a boxing Convert node,
+        // exercising the conversion-unwrap loop that keeps Expression<Func<T, object?>>
+        // selectors working.
+        // Act
+        var registeredSubjectProperty = person.TryGetRegisteredProperty<Person, object?>(p => p.FirstName_MaxLength);
+
+        // Assert
+        Assert.NotNull(registeredSubjectProperty);
+        Assert.Equal("FirstName_MaxLength", registeredSubjectProperty.Name);
+    }
 }

--- a/src/Namotion.Interceptor.Registry.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Registry.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -119,7 +119,7 @@ namespace Namotion.Interceptor.Registry
         public static void SetSubjectId(this Namotion.Interceptor.IInterceptorSubject subject, string id) { }
         public static Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty? TryGetRegisteredProperty(this Namotion.Interceptor.PropertyReference propertyReference) { }
         public static Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty? TryGetRegisteredProperty(this Namotion.Interceptor.IInterceptorSubject subject, string propertyName, Namotion.Interceptor.Registry.Abstractions.ISubjectRegistry? registry = null) { }
-        public static Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty? TryGetRegisteredProperty<T>(this T subject, System.Linq.Expressions.Expression<System.Func<T, object?>> propertyExpression)
+        public static Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty? TryGetRegisteredProperty<T, TValue>(this T subject, System.Linq.Expressions.Expression<System.Func<T, TValue>> propertyExpression)
             where T : Namotion.Interceptor.IInterceptorSubject { }
         public static Namotion.Interceptor.Registry.Abstractions.RegisteredSubject? TryGetRegisteredSubject(this Namotion.Interceptor.IInterceptorSubject subject) { }
         public static string? TryGetSubjectId(this Namotion.Interceptor.IInterceptorSubject subject) { }

--- a/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
@@ -186,11 +186,31 @@ public static class SubjectRegistryExtensions
                 MemberExpression member => ResolveSubject(member.Expression, root, rootParameter)?
                     .TryGetRegisteredProperty(member.Member.Name)?
                     .GetValue() as IInterceptorSubject,
-                _ => Expression
+                _ => TryEvaluate(expression, root, rootParameter),
+            };
+
+        // Compiles and invokes a non-member segment (index, dictionary key or method call) against the real
+        // object graph. Navigation misses - a null subject before the index, an out-of-range index or a
+        // missing dictionary key - return null to match the null-safe member-access path; any other exception
+        // (for example a throwing property getter) is left to propagate.
+        static IInterceptorSubject? TryEvaluate(Expression expression, T root, ParameterExpression rootParameter)
+        {
+            try
+            {
+                return Expression
                     .Lambda<Func<T, object?>>(Expression.Convert(expression, typeof(object)), rootParameter)
                     .Compile()
-                    .Invoke(root) as IInterceptorSubject,
-            };
+                    .Invoke(root) as IInterceptorSubject;
+            }
+            catch (Exception exception) when (exception
+                is NullReferenceException
+                or IndexOutOfRangeException
+                or ArgumentOutOfRangeException
+                or KeyNotFoundException)
+            {
+                return null;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
@@ -141,40 +141,56 @@ public static class SubjectRegistryExtensions
     }
     
     /// <summary>
-    /// Gets a registered property from an expression.
+    /// Gets the registered property selected by a member-access expression (e.g. <c>x =&gt; x.Child.Value</c>).
+    /// Unwraps boxing conversions (so value-typed members work) and resolves intermediate subjects of any
+    /// type via <see cref="IInterceptorSubject"/>. Pure member-access hops are resolved through the registry
+    /// (null-safe, no compilation); segments that contain an index, dictionary key or method call are compiled
+    /// and evaluated against the actual object graph. Returns <see langword="null"/> when the expression is not
+    /// a member-access chain, a member hop is <see langword="null"/> at any depth, or the property is not
+    /// registered.
     /// </summary>
     /// <param name="subject">The subject with the property.</param>
     /// <param name="propertyExpression">The property expression to find.</param>
     /// <typeparam name="T">The subject type to allow properly typed expression.</typeparam>
-    /// <returns>The registered property.</returns>
-    public static RegisteredSubjectProperty? TryGetRegisteredProperty<T>(this T subject, Expression<Func<T, object?>> propertyExpression)
+    /// <typeparam name="TValue">The selected property value type.</typeparam>
+    /// <returns>The registered property, or <see langword="null"/>.</returns>
+    public static RegisteredSubjectProperty? TryGetRegisteredProperty<T, TValue>(
+        this T subject, Expression<Func<T, TValue>> propertyExpression)
         where T : IInterceptorSubject
     {
-        var actualSubject = subject;
+        var parameter = propertyExpression.Parameters[0];
+        var body = propertyExpression.Body;
 
-        var bodyMemberExpression = propertyExpression.Body as MemberExpression;
-        var parentExpression = bodyMemberExpression?.Expression;
-        if (parentExpression is not null)
+        // Unwrap boxing conversions (e.g. Expression<Func<T, object?>> over a value-typed member).
+        while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
         {
-            // Extract the parameter from the original lambda expression
-            var originalParameter = propertyExpression.Parameters[0];
-
-            // Create a new lambda using the same parameter
-            var compiledParent = Expression
-                .Lambda<Func<T, object?>>(parentExpression, originalParameter)
-                .Compile()
-                .Invoke(subject);
-            
-            actualSubject = (T?)compiledParent;
+            body = unary.Operand;
         }
 
-        if (actualSubject is not null)
+        if (body is not MemberExpression memberExpression)
         {
-            var propertyName = bodyMemberExpression?.Member.Name;
-            return propertyName is not null ? actualSubject.TryGetRegisteredProperty(propertyName) : null;
+            return null;
         }
 
-        return null;
+        var parentSubject = ResolveSubject(memberExpression.Expression, subject, parameter);
+        return parentSubject?.TryGetRegisteredProperty(memberExpression.Member.Name);
+
+        // Resolves the subject an intermediate expression evaluates to. Member-access hops are walked
+        // through the registry (null-safe, no compilation). Any other node - array/list index, dictionary
+        // key or method call - is compiled and invoked once against the root to read the actual graph value.
+        static IInterceptorSubject? ResolveSubject(Expression? expression, T root, ParameterExpression rootParameter)
+            => expression switch
+            {
+                null => null,
+                ParameterExpression => root,
+                MemberExpression member => ResolveSubject(member.Expression, root, rootParameter)?
+                    .TryGetRegisteredProperty(member.Member.Name)?
+                    .GetValue() as IInterceptorSubject,
+                _ => Expression
+                    .Lambda<Func<T, object?>>(Expression.Convert(expression, typeof(object)), rootParameter)
+                    .Compile()
+                    .Invoke(root) as IInterceptorSubject,
+            };
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
@@ -191,8 +191,8 @@ public static class SubjectRegistryExtensions
 
         // Compiles and invokes a non-member segment (index, dictionary key or method call) against the real
         // object graph. Navigation misses - a null subject before the index, an out-of-range index or a
-        // missing dictionary key - return null to match the null-safe member-access path; any other exception
-        // (for example a throwing property getter) is left to propagate.
+        // missing dictionary key - return null to match the null-safe member-access path. Other exception
+        // types propagate unchanged.
         static IInterceptorSubject? TryEvaluate(Expression expression, T root, ParameterExpression rootParameter)
         {
             try


### PR DESCRIPTION
## Summary

Reworks the expression-based `TryGetRegisteredProperty` so it resolves property selectors the previous implementation could not, while keeping everything the old code already supported and making the `Try` contract uniform (resolves, or returns `null`, and never throws for a navigation miss).

The old resolver compiled the parent expression and cast the result to the root type `T`, so:

- Cross-type nesting threw `InvalidCastException` (e.g. `room => room.Light.On`, where the parent is a `Light`, not a `Room`).
- Value-typed leaves were not handled (the boxing `Convert` node broke the member-access cast, silently returning `null`).

## What changed

- Pure member-access hops resolve through the registry, null-safe at any depth, with no compilation.
- Boxing conversions are unwrapped, so value-typed leaves (e.g. `p => p.FirstName_MaxLength`) resolve correctly.
- Segments that contain an index, dictionary key or method call (`Children[2]`, `Relationships["boss"]`) are compiled and evaluated against the actual object graph, preserving the existing collection and dictionary support.
- Navigation misses on those compiled segments (a null subject before the index, an out-of-range index, or a missing dictionary key) return `null` instead of throwing, matching the null-safe member-access path. Any other exception type (for example a throwing property getter) still propagates.
- The two expression overloads are consolidated into a single generic `TryGetRegisteredProperty<T, TValue>`. The previous object-typed overload is removed.

## Contract and compatibility notes

- Uniform `Try` semantics: the method resolves the property or returns `null`; a path that cannot be navigated in the current graph state (null subject, out-of-range index, missing key) returns `null` rather than throwing.
- Member-access hops resolve strictly through the registry, so each intermediate subject (including the root the call is made on) must be registered. The old code walked live property getters and only required the leaf's immediate parent to be registered. No existing test depends on the old behavior, and in a normally attached graph every reachable subject is registered.
- Removing the `<T>` overload is source compatible for all inferred call sites in the repository (the full solution builds with no changes elsewhere); only an explicit single type argument (`<T>`) would need updating.

## Testing

- `dotnet build src/Namotion.Interceptor.slnx`: 0 warnings, 0 errors (warnings as errors)
- `Namotion.Interceptor.Registry.Tests`: 141 passed
- `Namotion.Interceptor.Connectors.Tests`: 449 passed
- New tests cover cross-type nesting, same-type nesting, value-typed leaves, boxed value selectors, depth-three chains, null intermediates, collection index resolution, and the four navigation-miss cases (null subject before an index, array and list index out of range, missing dictionary key).

## Docs

`docs/registry.md` now documents the expression-based lookup, including nested and collection or dictionary segments and the null-safe behavior.