### PR TITLE
fix: TryGetRegisteredProperty returns null when the registry is absent instead of throwing

### DIFF
--- a/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryExtensionsTests.cs
@@ -346,4 +346,22 @@ public class SubjectRegistryExtensionsTests
         // Assert
         Assert.Null(registeredSubjectProperty);
     }
+
+    [Fact]
+    public void WhenContextHasNoRegistry_ThenTryGetRegisteredPropertyReturnsNull()
+    {
+        // Arrange
+        var person = new Person(InterceptorSubjectContext.Create())
+        {
+            FirstName = "Child"
+        };
+
+        // Act
+        var byName = person.TryGetRegisteredProperty(nameof(Person.FirstName));
+        var byExpression = person.TryGetRegisteredProperty(p => p.FirstName);
+
+        // Assert
+        Assert.Null(byName);
+        Assert.Null(byExpression);
+    }
 }

--- a/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistryExtensions.cs
@@ -90,12 +90,12 @@ public static class SubjectRegistryExtensions
     /// <param name="subject">The subject with the property.</param>
     /// <param name="propertyName">The property name to find.</param>
     /// <param name="registry">The optional registry, otherwise the registry is resolved dynamically.</param>
-    /// <returns>The registered property.</returns>
+    /// <returns>The registered property, or <see langword="null"/> when the context has no registry or the property is not registered.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static RegisteredSubjectProperty? TryGetRegisteredProperty(this IInterceptorSubject subject, string propertyName, ISubjectRegistry? registry = null)
     {
-        registry ??= subject.Context.GetService<ISubjectRegistry>();
-        return registry
+        registry ??= subject.Context.TryGetService<ISubjectRegistry>();
+        return registry?
             .TryGetRegisteredSubject(subject)?
             .TryGetProperty(propertyName);
     }


### PR DESCRIPTION
## Problem

`TryGetRegisteredProperty(this IInterceptorSubject, string, ISubjectRegistry?)` resolved the registry with the throwing `GetService<ISubjectRegistry>()`:

```csharp
registry ??= subject.Context.GetService<ISubjectRegistry>(); // throws if absent
```

So a `Try*` method threw `InvalidOperationException: Service type 'ISubjectRegistry' not found.` whenever the subject's context had no registry. This is inconsistent with the sibling `Try*` overloads, which are null-safe:

- `TryGetRegisteredSubject(this IInterceptorSubject)` uses `TryGetService<ISubjectRegistry>()`
- `TryGetRegisteredProperty(this PropertyReference)` resolves via that null-safe path

## Where it bites

A freshly constructed subject's context has no registry until it is attached into a registered graph and the parent context is wired in. Property changes are delivered asynchronously (`ObserveOn(Scheduler.Default)`), so a subscriber that resolves a just-assigned child subject's property can run during that attach window and hit the throw. It is transient (the value is never lost, and resolving after the attach completes succeeds), but a `Try*` method should not throw on it.

## Fix

Resolve the registry with `TryGetService` and return `null` when it is absent, matching the other `Try*` overloads:

```csharp
registry ??= subject.Context.TryGetService<ISubjectRegistry>();
return registry?
    .TryGetRegisteredSubject(subject)?
    .TryGetProperty(propertyName);
```

The expression overload `TryGetRegisteredProperty<T, TValue>(Expression<...>)` delegates to this method for each hop, so it becomes null-safe too.

The public API surface is unchanged (same signature). Added a test covering both the string and expression overloads on a registry-less context; all 142 registry tests pass.