### PR TITLE
Bind service ordering edges to all instances of a referenced type (#380)

### DIFF
--- a/docs/interceptor.md
+++ b/docs/interceptor.md
@@ -98,6 +98,8 @@ public class LateHandler : IWriteInterceptor { }
 
 - Services are partitioned into three groups: `[RunsFirst]` → Middle → `[RunsLast]`
 - Within each group, `[RunsBefore]` and `[RunsAfter]` define the topological order
+- A reference to a type with multiple registered instances binds against every instance, for example when a context aggregates fallback contexts that each register the same service type
+- Instances of the same type keep their registration order relative to each other
 - Without ordering attributes, registration order is preserved
 - Missing dependency types are silently ignored (supports optional dependencies)
 - Circular dependencies throw `InvalidOperationException`

--- a/src/Namotion.Interceptor.Tests/InterceptorSubjectContextTests.cs
+++ b/src/Namotion.Interceptor.Tests/InterceptorSubjectContextTests.cs
@@ -1,3 +1,5 @@
+using Namotion.Interceptor.Attributes;
+
 namespace Namotion.Interceptor.Tests;
 
 public class InterceptorSubjectContextTests
@@ -55,4 +57,42 @@ public class InterceptorSubjectContextTests
         Assert.Equal(2, context1.GetServices<int>().Count());
         Assert.Equal(3, context2.GetServices<int>().Count());
     }
+
+    [Fact]
+    public void WhenFallbackContextsRegisterSameServiceType_ThenOrderingAttributeBindsAgainstAllInstances()
+    {
+        // Arrange: the duplicate in the first fallback enumerates before the constrainer
+        // in the second, so last-index binding leaves it unordered (issue #380); relies on
+        // fallback enumeration following HashSet insertion order (true in practice, not contractual)
+        var parent = new InterceptorSubjectContext();
+        var fallback1 = new InterceptorSubjectContext();
+        var fallback2 = new InterceptorSubjectContext();
+
+        var duplicate0 = new DuplicateOrderedService();
+        var constrainer = new ConstrainerOrderedService();
+        var duplicate1 = new DuplicateOrderedService();
+
+        fallback1.AddService(duplicate0);
+        fallback2.AddService(constrainer);
+        fallback2.AddService(duplicate1);
+
+        parent.AddFallbackContext(fallback1);
+        parent.AddFallbackContext(fallback2);
+
+        // Act
+        var services = parent.GetServices<IOrderedTestService>();
+
+        // Assert: the constrainer precedes both duplicate instances
+        Assert.Equal(3, services.Length);
+        Assert.Same(constrainer, services[0]);
+        Assert.Same(duplicate0, services[1]);
+        Assert.Same(duplicate1, services[2]);
+    }
+
+    private interface IOrderedTestService { }
+
+    private class DuplicateOrderedService : IOrderedTestService { }
+
+    [RunsBefore(typeof(DuplicateOrderedService))]
+    private class ConstrainerOrderedService : IOrderedTestService { }
 }

--- a/src/Namotion.Interceptor.Tests/Ordering/ServiceOrderResolverTests.cs
+++ b/src/Namotion.Interceptor.Tests/Ordering/ServiceOrderResolverTests.cs
@@ -398,6 +398,142 @@ public class ServiceOrderResolverTests
 
     #endregion
 
+    #region Multi-instance (duplicated types)
+
+    [Fact]
+    public void RunsBefore_WithDuplicatedTarget_OrdersBeforeAllInstances()
+    {
+        // Arrange: [D0, C, D1] where C runs before D; last-index binding leaves D0 before C
+        var duplicated0 = new DuplicatedService();
+        var constrainer = new ServiceBeforeDuplicated();
+        var duplicated1 = new DuplicatedService();
+        var services = new object[] { duplicated0, constrainer, duplicated1 };
+
+        // Act
+        var result = ServiceOrderResolver.OrderByDependencies(services);
+
+        // Assert: constrainer first, duplicates keep registration order
+        Assert.Equal(3, result.Length);
+        Assert.Same(constrainer, result[0]);
+        Assert.Same(duplicated0, result[1]);
+        Assert.Same(duplicated1, result[2]);
+    }
+
+    [Fact]
+    public void DuplicatedType_WithinRunsFirstGroup_OrdersAgainstAllInstances()
+    {
+        // Arrange: two RunsFirst duplicates around a RunsFirst constrainer, plus a middle service
+        var duplicatedFirst0 = new DuplicatedFirstService();
+        var middle = new ServiceA();
+        var constrainer = new FirstServiceBeforeDuplicatedFirst();
+        var duplicatedFirst1 = new DuplicatedFirstService();
+        var services = new object[] { duplicatedFirst0, middle, constrainer, duplicatedFirst1 };
+
+        // Act
+        var result = ServiceOrderResolver.OrderByDependencies(services);
+
+        // Assert: within the first group the constrainer precedes both duplicates; middle service last
+        Assert.Equal(4, result.Length);
+        Assert.Same(constrainer, result[0]);
+        Assert.Same(duplicatedFirst0, result[1]);
+        Assert.Same(duplicatedFirst1, result[2]);
+        Assert.Same(middle, result[3]);
+    }
+
+    [Fact]
+    public void RunsAfter_WithDuplicatedTarget_OrdersAfterAllInstances()
+    {
+        // Arrange: constrained service registered first, two duplicates after it
+        var constrained = new ServiceAfterDuplicated();
+        var duplicated0 = new DuplicatedService();
+        var duplicated1 = new DuplicatedService();
+        var services = new object[] { constrained, duplicated0, duplicated1 };
+
+        // Act
+        var result = ServiceOrderResolver.OrderByDependencies(services);
+
+        // Assert: both duplicates precede the constrained service
+        Assert.Equal(3, result.Length);
+        Assert.Same(duplicated0, result[0]);
+        Assert.Same(duplicated1, result[1]);
+        Assert.Same(constrained, result[2]);
+    }
+
+    [Fact]
+    public void DuplicatedType_WithoutConstraints_PreservesRegistrationOrder()
+    {
+        // Arrange: duplicates that no constraint references
+        var duplicated0 = new DuplicatedService();
+        var serviceB = new ServiceB();
+        var duplicated1 = new DuplicatedService();
+        var services = new object[] { duplicated0, serviceB, duplicated1 };
+
+        // Act
+        var result = ServiceOrderResolver.OrderByDependencies(services);
+
+        // Assert
+        Assert.Equal(3, result.Length);
+        Assert.Same(duplicated0, result[0]);
+        Assert.Same(serviceB, result[1]);
+        Assert.Same(duplicated1, result[2]);
+    }
+
+    [Fact]
+    public void DuplicatedType_InTypeLevelCycle_ThrowsCircularDependency()
+    {
+        // Arrange: mutual RunsBefore between two types, one of them duplicated
+        var services = new object[] { new Circular1(), new Circular2(), new Circular1() };
+
+        // Act & Assert: throw outcome is invariant under the fix; only the set of
+        // listed type names may differ, so assert the prefix, never the exact message
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ServiceOrderResolver.OrderByDependencies(services));
+        Assert.Contains("Circular dependency detected", ex.Message);
+    }
+
+    [Fact]
+    public void DuplicatedInstances_OfConstrainedType_PreserveRegistrationOrder()
+    {
+        // Arrange: three duplicates, all constrained by the same RunsAfter service
+        var duplicated0 = new DuplicatedService();
+        var constrained = new ServiceAfterDuplicated();
+        var duplicated1 = new DuplicatedService();
+        var duplicated2 = new DuplicatedService();
+        var services = new object[] { duplicated0, constrained, duplicated1, duplicated2 };
+
+        // Act
+        var result = ServiceOrderResolver.OrderByDependencies(services);
+
+        // Assert: duplicates emit in registration order relative to each other
+        Assert.Equal(4, result.Length);
+        Assert.Same(duplicated0, result[0]);
+        Assert.Same(duplicated1, result[1]);
+        Assert.Same(duplicated2, result[2]);
+        Assert.Same(constrained, result[3]);
+    }
+
+    [Fact]
+    public void ParallelEdges_WithDuplicatedTarget_SortCleanly()
+    {
+        // Arrange: U declares RunsBefore(T) and T declares RunsAfter(U), so every
+        // instance pair gets the same edge twice; in-degree accounting must stay symmetric
+        var target0 = new DuplicatedTargetService();
+        var source = new ParallelEdgeSource();
+        var target1 = new DuplicatedTargetService();
+        var services = new object[] { target0, source, target1 };
+
+        // Act
+        var result = ServiceOrderResolver.OrderByDependencies(services);
+
+        // Assert
+        Assert.Equal(3, result.Length);
+        Assert.Same(source, result[0]);
+        Assert.Same(target0, result[1]);
+        Assert.Same(target1, result[2]);
+    }
+
+    #endregion
+
     #region Test services
 
     // Basic services without attributes
@@ -468,6 +604,29 @@ public class ServiceOrderResolverTests
     [RunsLast]
     [RunsBefore(typeof(ServiceA))]
     private class LastServiceWithRunsBeforeMiddle { }
+
+    // Multi-instance services (duplicate-type aggregation, issue #380)
+    private class DuplicatedService { }
+
+    [RunsBefore(typeof(DuplicatedService))]
+    private class ServiceBeforeDuplicated { }
+
+    [RunsFirst]
+    private class DuplicatedFirstService { }
+
+    [RunsFirst]
+    [RunsBefore(typeof(DuplicatedFirstService))]
+    private class FirstServiceBeforeDuplicatedFirst { }
+
+    [RunsAfter(typeof(DuplicatedService))]
+    private class ServiceAfterDuplicated { }
+
+    // Parallel-edge pair: both sides declare the same relationship
+    [RunsBefore(typeof(DuplicatedTargetService))]
+    private class ParallelEdgeSource { }
+
+    [RunsAfter(typeof(ParallelEdgeSource))]
+    private class DuplicatedTargetService { }
 
     #endregion
 }

--- a/src/Namotion.Interceptor/Attributes/RunsAfterAttribute.cs
+++ b/src/Namotion.Interceptor/Attributes/RunsAfterAttribute.cs
@@ -2,6 +2,7 @@ namespace Namotion.Interceptor.Attributes;
 
 /// <summary>
 /// Specifies that this service runs AFTER the specified types.
+/// When a referenced type has multiple registered instances, the service runs after every instance.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public sealed class RunsAfterAttribute : Attribute

--- a/src/Namotion.Interceptor/Attributes/RunsBeforeAttribute.cs
+++ b/src/Namotion.Interceptor/Attributes/RunsBeforeAttribute.cs
@@ -2,6 +2,7 @@ namespace Namotion.Interceptor.Attributes;
 
 /// <summary>
 /// Specifies that this service runs BEFORE the specified types.
+/// When a referenced type has multiple registered instances, the service runs before every instance.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public sealed class RunsBeforeAttribute : Attribute

--- a/src/Namotion.Interceptor/Ordering/ServiceOrderResolver.cs
+++ b/src/Namotion.Interceptor/Ordering/ServiceOrderResolver.cs
@@ -111,12 +111,18 @@ internal static class ServiceOrderResolver
             return;
         }
 
-        // Build type-to-index mapping
-        var typeToIndex = new Dictionary<Type, int>(count);
+        // Build type-to-indices mapping; a type can have multiple instances when a
+        // context aggregates fallback contexts that each register the same service type
+        var typeToIndices = new Dictionary<Type, List<int>>(count);
         for (var i = 0; i < count; i++)
-            typeToIndex[services[i]!.GetType()] = i;
+        {
+            var type = services[i]!.GetType();
+            if (!typeToIndices.TryGetValue(type, out var indices))
+                typeToIndices[type] = indices = [];
+            indices.Add(i);
+        }
 
-        // Build adjacency list and in-degree counts
+        // Build adjacency list and in-degree counts; edges bind to every instance of the referenced type
         var adjacency = new List<int>[count];
         var inDegree = new int[count];
 
@@ -126,19 +132,25 @@ internal static class ServiceOrderResolver
 
             foreach (var beforeType in info.RunsBefore)
             {
-                if (typeToIndex.TryGetValue(beforeType, out var target))
+                if (typeToIndices.TryGetValue(beforeType, out var targets))
                 {
-                    (adjacency[i] ??= []).Add(target);
-                    inDegree[target]++;
+                    foreach (var target in targets)
+                    {
+                        (adjacency[i] ??= []).Add(target);
+                        inDegree[target]++;
+                    }
                 }
             }
 
             foreach (var afterType in info.RunsAfter)
             {
-                if (typeToIndex.TryGetValue(afterType, out var source))
+                if (typeToIndices.TryGetValue(afterType, out var sources))
                 {
-                    (adjacency[source] ??= []).Add(i);
-                    inDegree[i]++;
+                    foreach (var source in sources)
+                    {
+                        (adjacency[source] ??= []).Add(i);
+                        inDegree[i]++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #380.

## Problem

`ServiceOrderResolver.TopologicalSortInto` built a `Dictionary<Type, int>` mapping each service type to a single index, the last-registered instance:

```csharp
var typeToIndex = new Dictionary<Type, int>(count);
for (var i = 0; i < count; i++)
    typeToIndex[services[i].GetType()] = i;   // overwrites, keeps only the last index per type
```

Both edge loops resolved a referenced type to that single index, so when a type had multiple aggregated instances (a context aggregating fallback contexts that each register the same interceptor type), a `[RunsBefore]` or `[RunsAfter]` edge bound to only the last instance. The others were left unordered relative to that edge, silently violating the constraint.

Duplicates are reachable in practice: the call site deduplicates with `.Distinct()`, which is by reference, so two instances of the same type survive into the sort.

## Only the RunsBefore direction was observably broken

Worth recording, because it explains why this survived on master and which case is the real regression test.

`RunsAfter(T)` resolved `T` to the last instance, which has the highest index among `T` instances. The unlinked instances all have lower indices, and Kahn's algorithm drains a `SortedSet` by minimum index, so those instances emitted before the constrained service anyway. The constraint was satisfied by accident.

`RunsBefore(T)` is different: the unlinked earlier instances were free to emit before the constrainer. Services registered as `[D0, C, D1]` where `C` is `[RunsBefore(D)]` yielded `D0, C, D1`, with `D0` running before `C`. After the fix they yield `C, D0, D1`.

## Fix

Replace the single-index map with a multi-index map and add an edge per instance in both loops. Nothing else in the resolver changes: partitioning, `ValidateCrossGroupDependencies`, the Kahn drain, and the cycle report are untouched.

Duplicate edges need no dedup, since `inDegree` increments and drain-loop decrements stay symmetric.

## Why this is safe

Adding edges can only create cycles, never remove them, so the natural worry is that a configuration sorting cleanly today starts throwing. It cannot, for a structural reason:

Attributes live on types, so every instance edge projects onto a type-level edge. Any cycle in the new instance graph projects to a closed walk in the type graph, which must contain a type-level cycle. The old code already materialized every type-level edge `U -> T` as `u_last -> t_last`, so any type-level cycle already formed an instance cycle among the last instances and already threw. Combined with the trivial converse (old edges are a subset of new edges), the set of throwing configurations is exactly unchanged.

Independent review brute-forced roughly 779,000 configurations replicating both algorithms and found zero throw-outcome divergences and zero `RunsAfter` violations under the old code against 9,002 `RunsBefore` violations, confirming both claims. A second reviewer reproduced this with an independent 200,000-configuration fuzz.

## Behavioral impact

- Configurations without duplicate types: identical output.
- Configurations with duplicates that no constraint references: identical output.
- Configurations with referenced duplicates: the only changed set. They go from silently violating constraints to satisfying them.
- Duplicate instances emit in registration order relative to each other, since they now carry identical edge sets.
- One consumer-visible side effect: an attribute-free service can flip relative to a referenced-duplicate instance, because that instance gained an incoming edge. That is the fix working as intended.

## Performance

`OrderByDependencies` runs at configuration time only: on service-cache misses and on `TryAddService`, never on property reads or writes. The method already allocates a dictionary, an adjacency array, an in-degree array, and a `SortedSet` per call, so one `List<int>` per distinct type is marginal. Lower-allocation schemes were considered and rejected as complexity without measurable return.

## Tests

8 new tests. The three regression tests were verified failing before the fix:

- `RunsBefore` with a duplicated target, registered `[D0, C, D1]` (primary regression test)
- The same misordering inside a `RunsFirst` group
- Context-level integration test building the aggregation scenario through the public API, with the arrangement that actually fails on master (the duplicate must enumerate before the constrainer, so it lives in an earlier fallback context)

Plus five behavior pins: `RunsAfter` multi-instance edge correctness, duplicates without constraints preserving registration order, registration-order stability among three duplicates, parallel-edge tolerance, and cycle fail-fast (asserting the message prefix only, since the fix can change which type names are listed).

Full solution unit suite passes. Public API is untouched, so no snapshot churn.

## Docs

`docs/interceptor.md` records the multi-instance binding rule, and the XML docs on both attributes state the contract: a reference to a type with multiple registered instances binds against every instance.
