### PR TITLE
Cleanup: tracking doc/benchmark polish and fail-closed secret/state conflict

### DIFF
--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Attributes/ConfigurationAttributeInitializerTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Attributes/ConfigurationAttributeInitializerTests.cs
@@ -2,6 +2,7 @@ using HomeBlaze.Abstractions;
 using HomeBlaze.Abstractions.Attributes;
 using HomeBlaze.Abstractions.Metadata;
 using HomeBlaze.Services.Lifecycle;
+using Microsoft.Extensions.Logging;
 using Namotion.Interceptor;
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Registry;
@@ -92,16 +93,57 @@ public class ConfigurationAttributeInitializerTests
     }
 
     [Fact]
-    public void WhenStateAndSecretConfiguration_ThenThrowsInvalidOperationException()
+    public void WhenStateAndSecretConfiguration_ThenFailsClosedWithoutExposingSecretAsState()
     {
         // Arrange
         var context = CreateContext();
 
-        // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(() => new InvalidSecretStateSubject(context));
-        Assert.Contains("LeakySecret", exception.Message);
-        Assert.Contains("[State]", exception.Message);
-        Assert.Contains("[Configuration(IsSecret = true)]", exception.Message);
+        // Act: attaching must not throw (a throw would abort attach and can stop the host).
+        var subject = new InvalidSecretStateSubject(context);
+
+        // Assert: the secret configuration is registered, but the property is NOT exposed as state.
+        var property = subject.TryGetRegisteredSubject()!
+            .TryGetProperty(nameof(InvalidSecretStateSubject.LeakySecret))!;
+        var configuration = property.TryGetAttribute(KnownAttributes.Configuration)?.GetValue() as ConfigurationMetadata;
+        Assert.NotNull(configuration);
+        Assert.True(configuration.IsSecret);
+        Assert.Null(property.TryGetAttribute(KnownAttributes.State));
+    }
+
+    [Fact]
+    public void WhenStateAndSecretConfigurationAndLoggingAvailable_ThenWarns()
+    {
+        // Arrange: register a capturing logger factory into the context, the way RootManager makes
+        // host logging available to the context at startup.
+        var context = CreateContext();
+        var loggerFactory = new CapturingLoggerFactory();
+        context.AddService<ILoggerFactory>(loggerFactory);
+
+        // Act
+        _ = new InvalidSecretStateSubject(context);
+
+        // Assert: the conflict is surfaced as a warning naming the offending property.
+        var warning = Assert.Single(loggerFactory.Entries, entry => entry.Level == LogLevel.Warning);
+        Assert.Contains("LeakySecret", warning.Message);
+        Assert.Contains("[State]", warning.Message);
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Entries);
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(List<(LogLevel Level, string Message)> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => entries.Add((logLevel, formatter(state, exception)));
+        }
     }
 }
 

--- a/src/HomeBlaze/HomeBlaze.Services/Lifecycle/PropertyAttributeInitializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/Lifecycle/PropertyAttributeInitializer.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using HomeBlaze.Abstractions;
 using HomeBlaze.Abstractions.Attributes;
 using HomeBlaze.Abstractions.Metadata;
+using Microsoft.Extensions.Logging;
 using Namotion.Interceptor;
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Registry.Abstractions;
@@ -82,6 +84,32 @@ public class PropertyAttributeInitializer : IPropertyLifecycleHandler
             }
         }
 
+        // Fail closed on the [State] + secret [Configuration] conflict: a secret must never be
+        // exposed as state, so skip the State registration and leave the property usable as secret
+        // configuration. This replaces a throw that aborted attach and, from the hosted root loader,
+        // could stop the whole host (see #384 for making lifecycle handler failures recoverable).
+        // The warning is best-effort (only if host logging was made available to the context, see
+        // RootManager) and wrapped, so a disposed or faulting logging provider cannot re-abort attach.
+        if (hasState && configurationAttribute is { IsSecret: true })
+        {
+            var subject = property.Parent.Subject;
+            try
+            {
+                subject.Context.GetServices<ILoggerFactory>().FirstOrDefault()?
+                    .CreateLogger(typeof(PropertyAttributeInitializer).FullName!)
+                    .LogWarning(
+                        "Property '{Property}' on '{Subject}' has both [State] and [Configuration(IsSecret = true)]; " +
+                        "the [State] attribute is ignored because secret configuration must not be exposed as state.",
+                        property.Name, subject.GetType().Name);
+            }
+            catch
+            {
+                // Logging is diagnostics only; never let it reintroduce the fatal attach failure.
+            }
+
+            return;
+        }
+
         if (hasState && property.TryGetAttribute(KnownAttributes.State) is null)
         {
             var stateMetadata = new StateMetadata
@@ -95,14 +123,6 @@ public class PropertyAttributeInitializer : IPropertyLifecycleHandler
             };
             property.AddAttribute(KnownAttributes.State, typeof(StateMetadata),
                 _ => stateMetadata, null);
-        }
-
-        if (hasState && configurationAttribute is { IsSecret: true })
-        {
-            throw new InvalidOperationException(
-                $"Property '{property.Name}' on '{property.Parent.Subject.GetType().Name}' " +
-                $"has both [State] and [Configuration(IsSecret = true)]. " +
-                $"Secret configuration properties must not be exposed as state.");
         }
     }
 }

--- a/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
@@ -34,7 +34,8 @@ public class RootManager : BackgroundService, IConfigurationWriter
         ConfigurableSubjectSerializer serializer,
         IInterceptorSubjectContext context,
         IConfiguration? configuration = null,
-        ILogger<RootManager>? logger = null)
+        ILogger<RootManager>? logger = null,
+        ILoggerFactory? loggerFactory = null)
     {
         _typeRegistry = typeRegistry;
         _serializer = serializer;
@@ -44,6 +45,15 @@ public class RootManager : BackgroundService, IConfigurationWriter
 
         // Register self with context for subjects to access
         context.AddService(this);
+
+        // Make host logging available to context services and lifecycle handlers, which are
+        // constructed by the context factory before any provider exists and so cannot inject it
+        // (for example PropertyAttributeInitializer warning on a [State]/secret conflict). Runs
+        // before the root graph is built in ExecuteAsync, so handlers see it during attach.
+        if (loggerFactory is not null)
+        {
+            context.AddService(loggerFactory);
+        }
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Namotion.Interceptor.Benchmark/PropertyChangeSubscriptionsBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/PropertyChangeSubscriptionsBenchmark.cs
@@ -43,14 +43,14 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteIdle))]
     public void SetupIdle()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
     }
 
     // queue-only active: a single pull-queue subscription with a background consumer draining it.
     [GlobalSetup(Target = nameof(WriteWithQueueConsumer))]
     public void SetupQueueOnly()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _queueSubscription = _context.CreatePropertyChangeQueueSubscription();
         StartQueueDrain(_queueSubscription);
     }
@@ -59,7 +59,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteWithObservableConsumer))]
     public void SetupObservableOnly()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _observableSubscription = _context
             .GetPropertyChangeObservable(ImmediateScheduler.Instance)
             .Subscribe(_ => { });
@@ -69,7 +69,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteWithQueueAndObservableConsumers))]
     public void SetupBoth()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _queueSubscription = _context.CreatePropertyChangeQueueSubscription();
         StartQueueDrain(_queueSubscription);
         _observableSubscription = _context
@@ -81,7 +81,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteWithListenerOnSameProperty))]
     public void SetupListenerOnWrittenProperty()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _perPropertySubscription = _car.SubscribeToProperty(x => x.Name, (in SubjectPropertyChange _) => { });
     }
 
@@ -90,7 +90,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteWithListenerOnOtherProperty))]
     public void SetupListenerElsewhere()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _perPropertySubscription = new PropertyReference(_car, nameof(Car.Name_MaxLength_Unit))
             .Subscribe((in SubjectPropertyChange _) => { });
     }
@@ -100,7 +100,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteAfterObservableFullyUnsubscribed))]
     public void SetupObservableThenUnsubscribed()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         var subscription = _context
             .GetPropertyChangeObservable(ImmediateScheduler.Instance)
             .Subscribe(_ => { });
@@ -112,7 +112,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteObservableOnlyBoxed))]
     public void SetupObservableOnlyBoxed()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _boxedValue = new[] { _car };
         _observableSubscription = _context
             .GetPropertyChangeObservable(ImmediateScheduler.Instance)
@@ -124,7 +124,7 @@ public class PropertyChangeSubscriptionsBenchmark
     [GlobalSetup(Target = nameof(WriteBothActiveBoxed))]
     public void SetupBothBoxed()
     {
-        _car = CreateCar();
+        _car = CreateCarInFreshContext();
         _boxedValue = new[] { _car };
         _queueSubscription = _context.CreatePropertyChangeQueueSubscription();
         StartQueueDrain(_queueSubscription);
@@ -199,7 +199,9 @@ public class PropertyChangeSubscriptionsBenchmark
         _queueSubscription?.Dispose();
     }
 
-    private Car CreateCar()
+    // Establishes a fresh _context as a side effect and returns a subject bound to it; the name
+    // signals that the field is (re)assigned, not just that a Car is constructed.
+    private Car CreateCarInFreshContext()
     {
         _context = InterceptorSubjectContext
             .Create()
@@ -217,6 +219,8 @@ public class PropertyChangeSubscriptionsBenchmark
         var cancellationToken = _drainCancellation.Token;
         _drainThread = new Thread(() =>
         {
+            // TryDequeue observes cancellation as its first action and returns false, so the loop
+            // exits on Cancel() even while producers keep feeding the queue.
             while (subscription.TryDequeue(out _, cancellationToken))
             {
             }

--- a/src/Namotion.Interceptor.Tracking/InterceptorSubjectContextExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/InterceptorSubjectContextExtensions.cs
@@ -100,6 +100,7 @@ public static class InterceptorSubjectContextExtensions
     /// the property after subscribing observes that earlier state. OldValue is the value the setter observed
     /// when it started, including when the subscription raced the write. For a scheduler-based observer,
     /// delivered means accepted by the channel, not that the callback has already run.
+    /// A dispatch already in flight may still invoke the observer after its subscription's Dispose returns.
     /// </summary>
     /// <param name="context">The context.</param>
     /// <param name="scheduler">The scheduler to run the callbacks on (defaults to Scheduler.Default).


### PR DESCRIPTION
Follow-ups from the review of #377. Two independent parts.

## Tracking polish (docs and benchmark only, no behavior change)

- `GetPropertyChangeObservable` now documents that an observer may be invoked after its subscription's `Dispose` returns, matching the wording already used for the per-property channel. Docs only; not part of the public API snapshot.
- Renamed the subscriptions benchmark's `CreateCar` helper to `CreateCarInFreshContext` so its name signals the `_context` field assignment it performs as a side effect. An earlier redundant drain-loop cancellation guard was dropped after review found `TryDequeue` already checks cancellation as its first action.

## HomeBlaze: fail closed on a `[State]` + secret `[Configuration]` conflict (behavioral fix)

`PropertyAttributeInitializer` threw `InvalidOperationException` during attach when a property carried both `[State]` and a secret `[Configuration(IsSecret = true)]`. Because lifecycle handlers run inside graph reconciliation with no surrounding try/catch, that exception propagated out of the property write, faulted the hosted `RootManager` (a `BackgroundService`), and, under .NET's default `BackgroundServiceExceptionBehavior.StopHost`, stopped the whole host. One misconfigured property could take down every other working subject.

The handler now fails closed instead:

- The conflict is checked before the State attribute is added, and on conflict the State registration is skipped. The secret is therefore never exposed as state (verified: this file is the only writer of the State registry attribute, and every state-reading consumer reads that attribute, not the reflection `[State]`). The property remains usable as secret configuration.
- A best-effort warning is logged so the misconfiguration is not silent. The warning fires only if host logging was made available to the context and is wrapped in a catch, so a disposed or faulting logging provider cannot re-abort attach and reintroduce the failure this change removes.
- `RootManager` registers the host `ILoggerFactory` into the subject context at startup (before the root graph is built), so handlers that are constructed by the context factory before any DI provider exists can still log.

`MethodPropertyInitializer` intentionally keeps throwing: its "subject not registered" case is an internal invariant, not a user-authorable misconfiguration.

See #384 for the general fix (making any lifecycle-handler exception recoverable rather than corrupting reconciliation state or killing the host); this change is the targeted, safe mitigation for the one user-facing throw.

## Testing

- `HomeBlaze.Services.Tests` green (220). The throw-asserting test was rewritten to assert the fail-closed outcome (secret configuration registered, no State attribute), and a new test registers a capturing logger factory and asserts the warning fires; it was mutation-checked (neutralizing the log makes it fail).
- Tracking and benchmark projects build clean.
