### PR TITLE
benchmarks: Make benchmark.ps1 use memoryRandomization by default

### DIFF
--- a/scripts/benchmark.ps1
+++ b/scripts/benchmark.ps1
@@ -9,6 +9,7 @@
 #   pwsh scripts/benchmark.ps1 -Short               # Quick benchmark (fewer iterations)
 #   pwsh scripts/benchmark.ps1 -LocalOnly           # Run on current branch only (no comparison)
 #   pwsh scripts/benchmark.ps1 -LaunchCount 3       # Run 3 process launches per benchmark (more stable)
+#   pwsh scripts/benchmark.ps1 -MemoryRandomization:$false  # Disable heap-layout randomization (on by default)
 #   pwsh scripts/benchmark.ps1 -BaseBranch performance/foo  # Compare against a non-master base
 #   pwsh scripts/benchmark.ps1 -Filter "*Write*" -Stash -Short
 #
@@ -20,6 +21,7 @@ param(
     [switch]$Short,
     [switch]$LocalOnly,
     [int]$LaunchCount = 1,
+    [bool]$MemoryRandomization = $true,
     [string]$BaseBranch = "master"
 )
 
@@ -31,6 +33,10 @@ $ErrorActionPreference = "Stop"
 $ExtraArgs = @()
 if ($Short) { $ExtraArgs += "--job"; $ExtraArgs += "short" }
 if ($LaunchCount -gt 1) { $ExtraArgs += "--launchCount"; $ExtraArgs += "$LaunchCount" }
+# On by default: randomizes the managed heap layout between iterations so a single lucky/unlucky
+# layout cannot bias the comparison (this is a decision tool). Disable with -MemoryRandomization:$false
+# for a faster, layout-fixed run. Note: it does not randomize JIT code placement.
+if ($MemoryRandomization) { $ExtraArgs += "--memoryRandomization" }
 
 # ============ HELPER FUNCTIONS ============
 


### PR DESCRIPTION
## Summary

Makes `--memoryRandomization` the default for `scripts/benchmark.ps1`, with an opt-out via `-MemoryRandomization:$false`.

## Why

The script is a decision tool for branch-vs-master perf comparisons, and a fixed heap layout can produce false results. Without randomization, a single lucky or unlucky layout biases the numbers. In recent work this produced a "-7%" read improvement and a "+3%" write regression that were pure layout luck: both collapsed to the real -3.6% / neutral once randomization was on. For a tool whose whole job is trustworthy comparisons, the honest mode should be the default rather than something you have to remember to enable.

## Behavior

- Default: `--memoryRandomization` is passed to BenchmarkDotNet (randomizes the managed-heap layout between iterations).
- `-MemoryRandomization:$false`: fixed layout (faster, for reproducing an old number).
- `-Short` still exists for quick rough runs.

Note: memoryRandomization randomizes the managed heap, not JIT code placement, so code-alignment effects remain a separate concern.

## Change

Six lines: a `[bool]$MemoryRandomization = $true` parameter, a guarded append to `$ExtraArgs`, and usage/comment notes.
