### PR TITLE
performance: Make PropertyReference a lean readonly struct (remove the metadata cache)

### DIFF
--- a/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -115,7 +115,7 @@ namespace Namotion.Interceptor
     {
         public static System.Attribute[] GetCustomAttributesIncludingInterfaces(this System.Reflection.PropertyInfo property) { }
     }
-    public struct PropertyReference : System.IEquatable<Namotion.Interceptor.PropertyReference>
+    public readonly struct PropertyReference : System.IEquatable<Namotion.Interceptor.PropertyReference>
     {
         public static readonly Namotion.Interceptor.PropertyReference.PropertyReferenceComparer Comparer;
         public PropertyReference(Namotion.Interceptor.IInterceptorSubject subject, string name) { }

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
@@ -293,7 +293,8 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
     {
         next(ref context);
 
-        if (!context.Property.Metadata.Type.CanContainSubjects<TProperty>())
+        var metadata = context.Property.Metadata;
+        if (!metadata.Type.CanContainSubjects<TProperty>())
         {
             return;
         }
@@ -305,7 +306,7 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
             // Read the actual backing store value to handle concurrent writes correctly.
             // context.NewValue may differ from the backing store if another thread
             // overwrote the property between our next() call and lock acquisition.
-            var getValue = context.Property.Metadata.GetValue;
+            var getValue = metadata.GetValue;
             var newValue = getValue is not null
                 ? getValue(context.Property.Subject)
                 : context.NewValue;

--- a/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
@@ -198,9 +198,14 @@ public struct PropertyWriteContext<TProperty>
     /// Must only be used after the 'next()' call in the write interceptor.
     /// </summary>
     /// <returns>The property value.</returns>
-    public TProperty GetFinalValue() => Property.Metadata.IsDerived ?
-        (TProperty)Property.Metadata.GetValue?.Invoke(Property.Subject)! :
-        NewValue;
+    public TProperty GetFinalValue()
+    {
+        var property = Property;
+        var metadata = property.Metadata;
+        return metadata.IsDerived
+            ? (TProperty)metadata.GetValue?.Invoke(property.Subject)!
+            : NewValue;
+    }
 
     /// <summary>
     /// Finalizes <see cref="Origin"/> at the terminal write (right after <see cref="IsWritten"/>

--- a/src/Namotion.Interceptor/PropertyReference.cs
+++ b/src/Namotion.Interceptor/PropertyReference.cs
@@ -2,11 +2,9 @@
 
 namespace Namotion.Interceptor;
 
-public struct PropertyReference : IEquatable<PropertyReference>
+public readonly struct PropertyReference : IEquatable<PropertyReference>
 {
     public static readonly PropertyReferenceComparer Comparer = new();
-
-    private SubjectPropertyMetadata? _metadata = null;
 
     public PropertyReference(IInterceptorSubject subject, string name)
     {
@@ -18,24 +16,18 @@ public struct PropertyReference : IEquatable<PropertyReference>
 
     public string Name { get; }
 
-    public SubjectPropertyMetadata Metadata
-    {
-        get
-        {
-            if (_metadata is not null)
-            {
-                return _metadata.Value;
-            }
-
-            _metadata = Subject.Properties
-                .TryGetValue(Name, out var metadata) ? metadata :
-                throw new InvalidOperationException(
-                    $"No metadata found for property '{Name}' on {Subject.GetType().Name}. " +
-                    $"Available properties ({Subject.Properties.Count}): [{string.Join(", ", Subject.Properties.Keys)}]");
-
-            return _metadata!.Value;
-        }
-    }
+    // Resolved on each access rather than cached: PropertyReference is a value type copied all over
+    // the codebase (contexts, change events, dictionary keys, many 'in' parameters), so an embedded
+    // SubjectPropertyMetadata? cache would bloat every copy 5x (16 to 80 bytes) and force the struct
+    // to be mutable (defeating readonly-struct and adding defensive copies at every 'in' site), while
+    // the cache almost never survives the very copies that dominate its usage. The metadata dictionary
+    // is a static per-type table, so the lookup is cheap; per-operation dedup, where it pays, belongs
+    // on the by-ref context that actually persists.
+    public SubjectPropertyMetadata Metadata =>
+        Subject.Properties.TryGetValue(Name, out var metadata) ? metadata :
+            throw new InvalidOperationException(
+                $"No metadata found for property '{Name}' on {Subject.GetType().Name}. " +
+                $"Available properties ({Subject.Properties.Count}): [{string.Join(", ", Subject.Properties.Keys)}]");
 
     public void SetPropertyData(string key, object? value)
     {

--- a/src/Namotion.Interceptor/PropertyReference.cs
+++ b/src/Namotion.Interceptor/PropertyReference.cs
@@ -16,13 +16,12 @@ public readonly struct PropertyReference : IEquatable<PropertyReference>
 
     public string Name { get; }
 
-    // Resolved on each access rather than cached: PropertyReference is a value type copied all over
-    // the codebase (contexts, change events, dictionary keys, many 'in' parameters), so an embedded
-    // SubjectPropertyMetadata? cache would bloat every copy 5x (16 to 80 bytes) and force the struct
-    // to be mutable (defeating readonly-struct and adding defensive copies at every 'in' site), while
-    // the cache almost never survives the very copies that dominate its usage. The metadata dictionary
-    // is a static per-type table, so the lookup is cheap; per-operation dedup, where it pays, belongs
-    // on the by-ref context that actually persists.
+    /// <summary>
+    /// Looks up the property metadata in the subject's property table on each access; the result is not
+    /// cached, because PropertyReference is a value type copied throughout the codebase and an embedded
+    /// cache would bloat every copy and force the struct to be mutable (see the readonly-struct
+    /// declaration). The lookup is cheap, but hoist it to a local if you read it more than once in a hot path.
+    /// </summary>
     public SubjectPropertyMetadata Metadata =>
         Subject.Properties.TryGetValue(Name, out var metadata) ? metadata :
             throw new InvalidOperationException(


### PR DESCRIPTION
## Summary

`PropertyReference` embedded a lazy `SubjectPropertyMetadata?` cache. On a value type that is copied all over the codebase (contexts, change events, dictionary keys, many `in` parameters) that cache was net-negative:

- It bloated every copy 5x: `PropertyReference` measured **80 bytes** with the cache, **16 bytes** without (the embedded `SubjectPropertyMetadata?` alone is 64 bytes).
- It forced the struct to be **mutable** (the lazy getter writes a field), which prevented `readonly struct` and inserted an 80-byte defensive copy at every `in`-parameter site that read metadata, compared, or hashed.
- It **almost never fired**, because the value-type copies that defeat a struct-local cache are exactly how `PropertyReference` is used. A fresh instance is built per operation anyway.

This removes the cache, makes `PropertyReference` a lean 16-byte `readonly struct`, and hoists the two write-path sites that read metadata twice in one scope to a local.

The cache came in with #16 (2015 subject-factory work) next to the very benchmark that now exposes it; its cost is on an axis (per-copy struct size) that a casual timing run does not surface, so it went unnoticed until measured deliberately.

## Changes

- **Lean `readonly struct`**: drop `_metadata`; `Metadata` resolves via the subject property table on each access (a static per-type dictionary, so the lookup is cheap). Documented as uncached.
- **Hoist repeated reads**: `PropertyWriteContext.GetFinalValue` and `LifecycleInterceptor.WriteProperty` read metadata twice in a scope, so they now resolve it once into a local.

## Public API

`PropertyReference` gains the `readonly` modifier. This is source-compatible (it has no public mutable members) and the only public-surface change; the `PublicApi` snapshot is updated accordingly.

## Benchmarks

Full suite, branch vs `master`, CPU pinned at 3.60 GHz (no turbo), `LaunchCount=3`, `MemoryRandomization=True`. No regressions anywhere; broad improvements plus allocation reductions.

| Area | Benchmarks | Time | Allocation |
|---|---|---|---|
| Reads / writes | `Read`, `Write`, `WriteNoOp`, `WriteWithTimestampScope` | **-13% to -16%** | none (already zero-alloc) |
| Derived | `DerivedAverage`, `IncrementDerivedAverage` | **-11% to -17%** | unchanged |
| Graph / lifecycle | `ChangeAllTires`, `AddLotsOfPreviousCars` | **-9% to -15%** | **-7% to -8%** |
| Property-change subscriptions | 9 `Write*` variants | **-8% to -17%** | unchanged |
| Transactions | `CommitChanges` (Local / SingleSource / MultiSource) | **-22% to -24%** | **-21% to -28%** (source variants; `Local` unchanged) |
| Updates | `CreateCompleteUpdate` | **-11%** | unchanged |
| Controls (no `PropertyReference` copies) | `GetOrAddSubjectId`, `GenerateSubjectId`, `ReadParents`, `ServiceOrderResolver*` | flat | unchanged |

The allocation reductions on the graph and source-transaction paths come from collections that store `PropertyReference` (change captures, `_attachedSubjects`, `PropertyReferenceCollection`) now being 5x smaller per element.

### Follow-up: the LC3 wiggles are noise, not the cache

Two `SourcePathProvider` methods showed sub-2% the wrong way in the LC3 scan (`VisitPropertiesFromPaths` +1.9%, `TryGetPath` +1.4%). Removing the per-instance cache can only slow code that reads `.Metadata` twice on the same instance, and static analysis found **zero** `.Metadata` reads in either path, so there is no cache-removal mechanism. A confirming rerun at `LaunchCount=15` bears this out:

| Method | LC3 scan | LC15 confirm |
|---|---|---|
| `TryGetPath` | +1.4% | **-1.8%** (faster, sign flipped) |
| `TryGetPropertyFromPath` | +0.2% | **-0.9%** (faster) |
| `TryGetPropertyFromSegment` | -4.0% | **-2.6%** (faster) |
| `VisitPropertiesFromPaths` | +1.9% | **+1.0%** (~7 ns) |

Three of four are flat-or-faster; the lone residual (`VisitPropertiesFromPaths`, ~7 ns on a path with no metadata reads) is a JIT code-layout shift from the struct-size change, not the cache, and not something a cache could address. `SubjectSource*` are excluded: their measured loop dispatches no-op delegates and touches no `PropertyReference` at all, so the lean change cannot affect them (their large LC3 deltas in both directions are async run variance). Raw LC15 rerun data is in the second details block below.

## Testing

Full unit test suite passes across all non-integration test projects. Behavior is unchanged: metadata is looked up on each access instead of cached, and every derived path (where the old cache could have hit) still improved, so the extra lookup is a non-issue against the struct-size win.


<details>
<summary>Raw benchmark output (full suite, LaunchCount=3, MemoryRandomization=True, CPU pinned 3.60 GHz)</summary>

# Benchmark Comparison

**Date:** 2026-07-21 23:09:31
**Filter:** *
**Base branch:** master
**Compared branch:** perf/lean-property-reference

---

## perf/lean-property-reference (current):

```

BenchmarkDotNet v0.15.5, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
11th Gen Intel Core i7-11700K 3.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.100
  [Host]     : .NET 9.0.11 (9.0.11, 9.0.1125.51716), X64 RyuJIT x86-64-v4
  Job-PRCTZZ : .NET 9.0.11 (9.0.11, 9.0.1125.51716), X64 RyuJIT x86-64-v4

LaunchCount=3  MemoryRandomization=True  

```
| Type                                 | Method                                | Mode                 | Type        | Mean               | Error           | StdDev          | Median             | Ratio     | RatioSD | Gen0      | Gen1      | Gen2     | Allocated  | Alloc Ratio |
|------------------------------------- |-------------------------------------- |--------------------- |------------ |-------------------:|----------------:|----------------:|-------------------:|----------:|--------:|----------:|----------:|---------:|-----------:|------------:|
| **PropertyChangeSubscriptionsBenchmark** | **WriteIdle**                             | **?**                    | **?**           |        **172.8193 ns** |       **1.0325 ns** |       **1.9645 ns** |        **173.8581 ns** |      **1.00** |    **0.02** |         **-** |         **-** |        **-** |          **-** |          **NA** |
| ServiceOrderResolverBenchmark        | NoDependencies                        | ?                    | ?           |      1,612.2362 ns |      21.4963 ns |      40.8990 ns |      1,594.2063 ns |      9.33 |    0.26 |    0.3223 |         - |        - |     2712 B |          NA |
| SourcePathProviderBenchmark          | TryGetPropertyFromPath                | ?                    | ?           |        361.8019 ns |       6.4455 ns |      12.2633 ns |        354.8831 ns |      2.09 |    0.07 |    0.0753 |         - |        - |      632 B |          NA |
| SubjectSourceBenchmark               | WriteToRegistrySubjects               | ?                    | ?           |  3,008,280.8948 ns |  60,609.1518 ns | 123,808.4454 ns |  2,916,527.0508 ns | 17,409.29 |  736.17 |         - |         - |        - |          - |          NA |
| SubjectUpdateBenchmark               | CreateCompleteUpdate                  | ?                    | ?           |      6,974.2163 ns |      39.5139 ns |      75.1793 ns |      6,958.5351 ns |     40.36 |    0.63 |    0.7019 |    0.0153 |        - |     5904 B |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteObservableOnlyBoxed              | ?                    | ?           |        273.8030 ns |       1.9303 ns |       3.6726 ns |        273.1074 ns |      1.58 |    0.03 |    0.0057 |         - |        - |       48 B |          NA |
| ServiceOrderResolverBenchmark        | LinearChain                           | ?                    | ?           |      1,788.0950 ns |      19.2295 ns |      36.5860 ns |      1,774.4860 ns |     10.35 |    0.24 |    0.4444 |    0.0019 |        - |     3720 B |          NA |
| SourcePathProviderBenchmark          | VisitPropertiesFromPaths              | ?                    | ?           |        731.0409 ns |       6.6036 ns |      12.5640 ns |        727.4647 ns |      4.23 |    0.09 |    0.1526 |         - |        - |     1280 B |          NA |
| SubjectSourceBenchmark               | WriteToSource                         | ?                    | ?           |  1,255,571.2805 ns |  17,531.2993 ns |  79,043.2594 ns |  1,240,636.0732 ns |  7,266.14 |  463.73 |         - |         - |        - |    11988 B |          NA |
| SubjectUpdateBenchmark               | CreatePartialUpdate                   | ?                    | ?           |      2,572.4341 ns |       6.2500 ns |      11.8912 ns |      2,573.2516 ns |     14.89 |    0.18 |    0.3166 |         - |        - |     2656 B |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteBothActiveBoxed                  | ?                    | ?           |        421.7138 ns |       1.9523 ns |       3.7145 ns |        421.5954 ns |      2.44 |    0.03 |    0.0057 |         - |        - |       48 B |          NA |
| ServiceOrderResolverBenchmark        | MixedDependencies                     | ?                    | ?           |      1,804.4815 ns |      12.9708 ns |      24.6784 ns |      1,817.6401 ns |     10.44 |    0.18 |    0.3757 |    0.0019 |        - |     3144 B |          NA |
| SourcePathProviderBenchmark          | TryGetPropertyFromSegment             | ?                    | ?           |         43.8156 ns |       0.5940 ns |       1.2399 ns |         43.6119 ns |      0.25 |    0.01 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithQueueConsumer                | ?                    | ?           |        341.1313 ns |       3.9193 ns |      16.8492 ns |        338.7756 ns |      1.97 |    0.10 |         - |         - |        - |          - |          NA |
| ServiceOrderResolverBenchmark        | WithFirstLastGroups                   | ?                    | ?           |      2,077.7392 ns |       3.1483 ns |       5.9900 ns |      2,077.9063 ns |     12.02 |    0.14 |    0.4349 |         - |        - |     3656 B |          NA |
| SourcePathProviderBenchmark          | TryGetPath                            | ?                    | ?           |        267.5150 ns |       1.7722 ns |       3.3719 ns |        267.4394 ns |      1.55 |    0.03 |    0.0315 |         - |        - |      264 B |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithObservableConsumer           | ?                    | ?           |        257.8424 ns |       1.6724 ns |       3.1819 ns |        257.4649 ns |      1.49 |    0.02 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithQueueAndObservableConsumers  | ?                    | ?           |        402.7075 ns |       3.9714 ns |       7.9313 ns |        404.1196 ns |      2.33 |    0.05 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithListenerOnSameProperty       | ?                    | ?           |        231.4600 ns |       4.6055 ns |       8.9827 ns |        229.4193 ns |      1.34 |    0.05 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithListenerOnOtherProperty      | ?                    | ?           |        174.7131 ns |       2.2884 ns |       4.3539 ns |        173.6257 ns |      1.01 |    0.03 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteAfterObservableFullyUnsubscribed | ?                    | ?           |        164.7903 ns |       1.4840 ns |       2.8234 ns |        164.0775 ns |      0.95 |    0.02 |         - |         - |        - |          - |          NA |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **Local**                | **?**           |     **35,759.8632 ns** |     **202.5055 ns** |     **385.2878 ns** |     **35,543.7663 ns** |         **?** |       **?** |    **0.5493** |         **-** |        **-** |     **5072 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **SingleSource**         | **?**           |     **43,494.1530 ns** |      **88.8799 ns** |     **169.1032 ns** |     **43,525.1082 ns** |         **?** |       **?** |    **1.4648** |         **-** |        **-** |    **12296 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **Singl(...)Local [21]** | **?**           |     **42,413.6447 ns** |     **176.9073 ns** |     **336.5845 ns** |     **42,252.4010 ns** |         **?** |       **?** |    **1.4648** |         **-** |        **-** |    **12296 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **MultiSource**          | **?**           |     **49,153.0153 ns** |     **129.4374 ns** |     **246.2681 ns** |     **49,176.7305 ns** |         **?** |       **?** |    **4.8828** |    **0.1831** |        **-** |    **41088 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **RegistryBenchmark**                    | **AddLotsOfPreviousCars**                 | **?**                    | **interceptor** | **57,213,901.5160 ns** | **346,341.9766 ns** | **658,951.6572 ns** | **57,152,620.4444 ns** |         **?** |       **?** | **2888.8889** | **1888.8889** | **555.5556** | **19904618 B** |           **?** |
| RegistryBenchmark                    | IncrementDerivedAverage               | ?                    | interceptor |      6,164.1448 ns |      54.7731 ns |     104.2115 ns |      6,141.9772 ns |         ? |       ? |    0.0153 |         - |        - |      137 B |           ? |
| RegistryBenchmark                    | WriteNoOp                             | ?                    | interceptor |        421.8182 ns |       7.0936 ns |      13.8355 ns |        417.6249 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | Write                                 | ?                    | interceptor |      1,206.5508 ns |       7.6366 ns |      14.5295 ns |      1,208.8359 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | WriteWithTimestampScope               | ?                    | interceptor |      1,095.1291 ns |       9.8018 ns |      18.6489 ns |      1,087.4038 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | Read                                  | ?                    | interceptor |        527.7814 ns |       5.7345 ns |      10.9105 ns |        532.4607 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | DerivedAverage                        | ?                    | interceptor |        359.7211 ns |       3.4266 ns |       6.5195 ns |        358.7906 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | ChangeAllTires                        | ?                    | interceptor |     14,467.6151 ns |      35.4459 ns |      67.4395 ns |     14,466.8010 ns |         ? |       ? |    1.7242 |    0.0916 |        - |    14464 B |           ? |
| RegistryBenchmark                    | GetOrAddSubjectId                     | ?                    | interceptor |         33.3822 ns |       0.0276 ns |       0.0525 ns |         33.3959 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | GenerateSubjectId                     | ?                    | interceptor |      1,028.4341 ns |       1.0005 ns |       1.9035 ns |      1,028.1003 ns |         ? |       ? |    0.0076 |         - |        - |       72 B |           ? |
| RegistryBenchmark                    | KnownSubjectsSnapshot                 | ?                    | interceptor |          0.0967 ns |       0.0637 ns |       0.1286 ns |          0.0073 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | ReadParents                           | ?                    | interceptor |          0.3364 ns |       0.0021 ns |       0.0040 ns |          0.3341 ns |         ? |       ? |         - |         - |        - |          - |           ? |



---

## master branch:

```

BenchmarkDotNet v0.15.5, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
11th Gen Intel Core i7-11700K 3.60GHz (Max: 3.44GHz), 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.100
  [Host]     : .NET 9.0.11 (9.0.11, 9.0.1125.51716), X64 RyuJIT x86-64-v4
  Job-PRCTZZ : .NET 9.0.11 (9.0.11, 9.0.1125.51716), X64 RyuJIT x86-64-v4

LaunchCount=3  MemoryRandomization=True  

```
| Type                                 | Method                                | Mode                 | Type        | Mean               | Error           | StdDev          | Median             | Ratio     | RatioSD | Gen0      | Gen1      | Gen2     | Allocated  | Alloc Ratio |
|------------------------------------- |-------------------------------------- |--------------------- |------------ |-------------------:|----------------:|----------------:|-------------------:|----------:|--------:|----------:|----------:|---------:|-----------:|------------:|
| **PropertyChangeSubscriptionsBenchmark** | **WriteIdle**                             | **?**                    | **?**           |        **197.5750 ns** |       **2.9766 ns** |       **5.6634 ns** |        **195.6740 ns** |      **1.00** |    **0.04** |         **-** |         **-** |        **-** |          **-** |          **NA** |
| ServiceOrderResolverBenchmark        | NoDependencies                        | ?                    | ?           |      1,637.4634 ns |      13.7817 ns |      26.2211 ns |      1,643.0698 ns |      8.29 |    0.27 |    0.3223 |         - |        - |     2712 B |          NA |
| SourcePathProviderBenchmark          | TryGetPropertyFromPath                | ?                    | ?           |        361.2039 ns |       1.8420 ns |       3.5046 ns |        361.0420 ns |      1.83 |    0.05 |    0.0753 |         - |        - |      632 B |          NA |
| SubjectSourceBenchmark               | WriteToRegistrySubjects               | ?                    | ?           |  2,928,324.8653 ns |  28,993.9681 ns |  68,342.1991 ns |  2,912,415.4434 ns | 14,833.11 |  539.30 |         - |         - |        - |          - |          NA |
| SubjectUpdateBenchmark               | CreateCompleteUpdate                  | ?                    | ?           |      7,872.9898 ns |      50.9053 ns |      96.8526 ns |      7,827.7015 ns |     39.88 |    1.22 |    0.7019 |    0.0153 |        - |     5904 B |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteObservableOnlyBoxed              | ?                    | ?           |        331.7465 ns |       1.7260 ns |       3.2839 ns |        329.6936 ns |      1.68 |    0.05 |    0.0057 |         - |        - |       48 B |          NA |
| ServiceOrderResolverBenchmark        | LinearChain                           | ?                    | ?           |      1,806.7155 ns |      20.4317 ns |      38.8734 ns |      1,828.8292 ns |      9.15 |    0.32 |    0.4444 |    0.0019 |        - |     3720 B |          NA |
| SourcePathProviderBenchmark          | VisitPropertiesFromPaths              | ?                    | ?           |        717.3405 ns |       3.9428 ns |       7.5016 ns |        718.8160 ns |      3.63 |    0.11 |    0.1526 |         - |        - |     1280 B |          NA |
| SubjectSourceBenchmark               | WriteToSource                         | ?                    | ?           |  1,860,164.3804 ns |  38,658.6170 ns |  83,216.7577 ns |  1,868,999.7793 ns |  9,422.46 |  494.37 |         - |         - |        - |    31630 B |          NA |
| SubjectUpdateBenchmark               | CreatePartialUpdate                   | ?                    | ?           |      2,607.0712 ns |       9.7570 ns |      18.5637 ns |      2,609.4706 ns |     13.21 |    0.38 |    0.3166 |         - |        - |     2656 B |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteBothActiveBoxed                  | ?                    | ?           |        458.2483 ns |       1.7181 ns |       3.2688 ns |        457.9810 ns |      2.32 |    0.07 |    0.0057 |         - |        - |       48 B |          NA |
| ServiceOrderResolverBenchmark        | MixedDependencies                     | ?                    | ?           |      1,812.8427 ns |       1.6708 ns |       3.1789 ns |      1,813.4452 ns |      9.18 |    0.26 |    0.3757 |    0.0019 |        - |     3144 B |          NA |
| SourcePathProviderBenchmark          | TryGetPropertyFromSegment             | ?                    | ?           |         45.6221 ns |       0.6190 ns |       1.4098 ns |         45.3141 ns |      0.23 |    0.01 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithQueueConsumer                | ?                    | ?           |        393.1561 ns |       4.4756 ns |      15.0924 ns |        395.6502 ns |      1.99 |    0.09 |         - |         - |        - |          - |          NA |
| ServiceOrderResolverBenchmark        | WithFirstLastGroups                   | ?                    | ?           |      2,087.9707 ns |      20.0203 ns |      38.0906 ns |      2,082.3885 ns |     10.58 |    0.35 |    0.4349 |         - |        - |     3656 B |          NA |
| SourcePathProviderBenchmark          | TryGetPath                            | ?                    | ?           |        263.7931 ns |       1.2405 ns |       2.3603 ns |        263.3740 ns |      1.34 |    0.04 |    0.0315 |         - |        - |      264 B |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithObservableConsumer           | ?                    | ?           |        307.9888 ns |       2.3381 ns |       4.4485 ns |        307.5350 ns |      1.56 |    0.05 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithQueueAndObservableConsumers  | ?                    | ?           |        438.8143 ns |       2.9683 ns |       5.6476 ns |        439.0139 ns |      2.22 |    0.07 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithListenerOnSameProperty       | ?                    | ?           |        263.9534 ns |       2.0630 ns |       3.9251 ns |        262.5781 ns |      1.34 |    0.04 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteWithListenerOnOtherProperty      | ?                    | ?           |        191.2957 ns |       1.4777 ns |       2.8115 ns |        192.0051 ns |      0.97 |    0.03 |         - |         - |        - |          - |          NA |
| PropertyChangeSubscriptionsBenchmark | WriteAfterObservableFullyUnsubscribed | ?                    | ?           |        194.1828 ns |       3.0791 ns |       5.8583 ns |        195.5345 ns |      0.98 |    0.04 |         - |         - |        - |          - |          NA |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **Local**                | **?**           |     **45,812.7382 ns** |     **213.5887 ns** |     **406.3747 ns** |     **45,670.9684 ns** |         **?** |       **?** |    **0.5493** |         **-** |        **-** |     **5072 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **SingleSource**         | **?**           |     **57,360.2853 ns** |     **504.5806 ns** |     **960.0172 ns** |     **56,903.5137 ns** |         **?** |       **?** |    **1.8311** |         **-** |        **-** |    **15496 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **Singl(...)Local [21]** | **?**           |     **54,016.2463 ns** |     **345.6299 ns** |     **657.5968 ns** |     **53,652.6356 ns** |         **?** |       **?** |    **1.8311** |         **-** |        **-** |    **15496 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **SubjectTransactionBenchmark**          | **CommitChanges**                         | **MultiSource**          | **?**           |     **63,109.3448 ns** |     **254.3129 ns** |     **483.8567 ns** |     **62,989.0643 ns** |         **?** |       **?** |    **6.7139** |    **0.4883** |        **-** |    **56961 B** |           **?** |
|                                      |                                       |                      |             |                    |                 |                 |                    |           |         |           |           |          |            |             |
| **RegistryBenchmark**                    | **AddLotsOfPreviousCars**                 | **?**                    | **interceptor** | **63,102,786.7975 ns** | **381,516.2310 ns** | **725,874.3371 ns** | **63,017,604.7778 ns** |         **?** |       **?** | **3111.1111** | **2111.1111** | **555.5556** | **21696884 B** |           **?** |
| RegistryBenchmark                    | IncrementDerivedAverage               | ?                    | interceptor |      7,425.9981 ns |      21.7433 ns |      41.3688 ns |      7,424.2736 ns |         ? |       ? |    0.0153 |         - |        - |      137 B |           ? |
| RegistryBenchmark                    | WriteNoOp                             | ?                    | interceptor |        499.4084 ns |       6.7815 ns |      12.9025 ns |        502.7072 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | Write                                 | ?                    | interceptor |      1,418.8878 ns |      12.5948 ns |      23.9630 ns |      1,418.1223 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | WriteWithTimestampScope               | ?                    | interceptor |      1,290.8927 ns |       7.2638 ns |      13.8201 ns |      1,289.1983 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | Read                                  | ?                    | interceptor |        607.8334 ns |       2.9495 ns |       5.6117 ns |        607.6499 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | DerivedAverage                        | ?                    | interceptor |        402.2664 ns |       3.8060 ns |       7.2414 ns |        402.2176 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | ChangeAllTires                        | ?                    | interceptor |     16,995.7411 ns |     100.1971 ns |     190.6353 ns |     16,934.3166 ns |         ? |       ? |    1.8311 |    0.0916 |        - |    15488 B |           ? |
| RegistryBenchmark                    | GetOrAddSubjectId                     | ?                    | interceptor |         33.5396 ns |       0.2326 ns |       0.4426 ns |         33.3004 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | GenerateSubjectId                     | ?                    | interceptor |      1,027.6723 ns |       0.3244 ns |       0.6173 ns |      1,027.5611 ns |         ? |       ? |    0.0076 |         - |        - |       72 B |           ? |
| RegistryBenchmark                    | KnownSubjectsSnapshot                 | ?                    | interceptor |          0.2877 ns |       0.0016 ns |       0.0031 ns |          0.2865 ns |         ? |       ? |         - |         - |        - |          - |           ? |
| RegistryBenchmark                    | ReadParents                           | ?                    | interceptor |          0.3403 ns |       0.0024 ns |       0.0046 ns |          0.3420 ns |         ? |       ? |         - |         - |        - |          - |           ? |



</details>

<details>
<summary>Raw SourcePathProvider rerun (LaunchCount=15, MemoryRandomization=True, CPU pinned 3.60 GHz)</summary>

## perf/lean-property-reference (current):

| Method                    | Mean      | Error    | StdDev    | Median    | Gen0   | Allocated |
|-------------------------- |----------:|---------:|----------:|----------:|-------:|----------:|
| TryGetPropertyFromPath    | 356.05 ns | 2.216 ns |  9.971 ns | 353.19 ns | 0.0753 |     632 B |
| VisitPropertiesFromPaths  | 725.28 ns | 3.617 ns | 16.269 ns | 720.74 ns | 0.1526 |    1280 B |
| TryGetPropertyFromSegment |  44.70 ns | 0.334 ns |  2.063 ns |  44.48 ns |      - |         - |
| TryGetPath                | 262.41 ns | 1.499 ns |  6.741 ns | 266.16 ns | 0.0315 |     264 B |

## master branch:

| Method                    | Mean      | Error    | StdDev    | Median    | Gen0   | Allocated |
|-------------------------- |----------:|---------:|----------:|----------:|-------:|----------:|
| TryGetPropertyFromPath    | 359.25 ns | 0.968 ns |  4.354 ns | 359.67 ns | 0.0753 |     632 B |
| VisitPropertiesFromPaths  | 718.40 ns | 1.810 ns |  8.141 ns | 717.42 ns | 0.1526 |    1280 B |
| TryGetPropertyFromSegment |  45.88 ns | 0.336 ns |  1.865 ns |  45.62 ns |      - |         - |
| TryGetPath                | 267.17 ns | 2.293 ns | 10.571 ns | 264.30 ns | 0.0315 |     264 B |

</details>
