### PR TITLE
fix: GC-invisible references in SubjectPropertyChange inline value storage

### DIFF
--- a/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
@@ -23,7 +23,7 @@ public class SubjectPropertyChangeTests
     [InlineData("OldName", "NewName")]
     [InlineData("", "NewName")]
     [InlineData("Test", "")]
-    public void Create_WithString_StoresAndRetrievesCorrectly(string oldValue, string newValue)
+    public void WhenCreatedWithString_ThenStoresAndRetrievesCorrectly(string oldValue, string newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -36,7 +36,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullString_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithNullString_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         string? oldValue = null;
@@ -53,7 +53,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithBothStringsNull_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithBothStringsNull_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         string? oldValue = null;
@@ -73,7 +73,7 @@ public class SubjectPropertyChangeTests
     [InlineData(42, 100)]
     [InlineData(int.MinValue, int.MaxValue)]
     [InlineData(0, -1)]
-    public void Create_WithInt_StoresAndRetrievesCorrectly(int oldValue, int newValue)
+    public void WhenCreatedWithInt_ThenStoresAndRetrievesCorrectly(int oldValue, int newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -88,7 +88,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData(123456789012345L, 987654321098765L)]
     [InlineData(long.MinValue, long.MaxValue)]
-    public void Create_WithLong_StoresAndRetrievesCorrectly(long oldValue, long newValue)
+    public void WhenCreatedWithLong_ThenStoresAndRetrievesCorrectly(long oldValue, long newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -103,7 +103,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData(3.14159265358979, 2.71828182845904)]
     [InlineData(double.MinValue, double.MaxValue)]
-    public void Create_WithDouble_StoresAndRetrievesCorrectly(double oldValue, double newValue)
+    public void WhenCreatedWithDouble_ThenStoresAndRetrievesCorrectly(double oldValue, double newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -118,7 +118,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData(3.14f, 2.71f)]
     [InlineData(float.MinValue, float.MaxValue)]
-    public void Create_WithFloat_StoresAndRetrievesCorrectly(float oldValue, float newValue)
+    public void WhenCreatedWithFloat_ThenStoresAndRetrievesCorrectly(float oldValue, float newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -133,7 +133,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData(false, true)]
     [InlineData(true, false)]
-    public void Create_WithBool_StoresAndRetrievesCorrectly(bool oldValue, bool newValue)
+    public void WhenCreatedWithBool_ThenStoresAndRetrievesCorrectly(bool oldValue, bool newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -148,7 +148,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData((byte)0, (byte)255)]
     [InlineData((byte)128, (byte)64)]
-    public void Create_WithByte_StoresAndRetrievesCorrectly(byte oldValue, byte newValue)
+    public void WhenCreatedWithByte_ThenStoresAndRetrievesCorrectly(byte oldValue, byte newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -163,7 +163,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData('A', 'Z')]
     [InlineData('0', '9')]
-    public void Create_WithChar_StoresAndRetrievesCorrectly(char oldValue, char newValue)
+    public void WhenCreatedWithChar_ThenStoresAndRetrievesCorrectly(char oldValue, char newValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -186,7 +186,7 @@ public class SubjectPropertyChangeTests
 
     [Theory]
     [MemberData(nameof(LargerValueTypeTestData))]
-    public void Create_WithLargerValueTypes_StoresAndRetrievesCorrectly(object oldValue, object newValue)
+    public void WhenCreatedWithLargerValueTypes_ThenStoresAndRetrievesCorrectly(object oldValue, object newValue)
     {
         // Arrange
         var method = typeof(SubjectPropertyChange)
@@ -212,7 +212,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData(42, 100)]
     [InlineData(0, int.MaxValue)]
-    public void Create_WithNullableInt_WithValue_StoresAndRetrievesCorrectly(int oldVal, int newVal)
+    public void WhenCreatedWithNullableIntWithValue_ThenStoresAndRetrievesCorrectly(int oldVal, int newVal)
     {
         // Arrange
         int? oldValue = oldVal;
@@ -229,7 +229,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullableInt_WithNull_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithNullableIntWithNull_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         int? oldValue = null;
@@ -246,7 +246,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullableInt_BothNull_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithNullableIntBothNull_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         int? oldValue = null;
@@ -263,7 +263,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullableDecimal_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithNullableDecimal_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         decimal? oldValue = 123.456m;
@@ -299,7 +299,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithSmallCustomStruct_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithSmallCustomStruct_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         var oldValue = new SmallCustomStruct { Value1 = 1, Value2 = 2 };
@@ -320,7 +320,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithLargeCustomStruct_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithLargeCustomStruct_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         var oldValue = new LargeCustomStruct { Value1 = 111111111111L, Value2 = 222222222222L };
@@ -341,7 +341,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithOversizedCustomStruct_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithOversizedCustomStruct_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         var oldValue = new OversizedCustomStruct { Value1 = 1L, Value2 = 2L, Value3 = 3L };
@@ -364,7 +364,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void GetOldValue_WithCustomStructAsObject_ReturnsBoxedStruct()
+    public void WhenGettingOldValueOfCustomStructAsObject_ThenReturnsBoxedStruct()
     {
         // Arrange
         var oldValue = new SmallCustomStruct { Value1 = 42, Value2 = 84 };
@@ -383,7 +383,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void GetOldValue_WithOversizedStructAsObject_ReturnsBoxedStruct()
+    public void WhenGettingOldValueOfOversizedStructAsObject_ThenReturnsBoxedStruct()
     {
         // Arrange
         var oldValue = new OversizedCustomStruct { Value1 = 1L, Value2 = 2L, Value3 = 3L };
@@ -409,7 +409,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithReferenceType_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithReferenceType_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         var oldValue = new CustomClass { Id = 1, Name = "Old" };
@@ -426,7 +426,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullReferenceType_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithNullReferenceType_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         CustomClass? oldValue = null;
@@ -443,7 +443,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithIntArray_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithIntArray_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         int[] oldValue = [1, 2, 3];
@@ -460,7 +460,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullArray_StoresAndRetrievesCorrectly()
+    public void WhenCreatedWithNullArray_ThenStoresAndRetrievesCorrectly()
     {
         // Arrange
         int[]? oldValue = null;
@@ -479,7 +479,7 @@ public class SubjectPropertyChangeTests
     [Theory]
     [InlineData(42)]
     [InlineData("test")]
-    public void GetOldValue_AsObject_ReturnsValue(object oldValue)
+    public void WhenGettingOldValueAsObject_ThenReturnsValue(object oldValue)
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -492,7 +492,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void TryGetOldValue_WithWrongType_ReturnsFalse()
+    public void WhenTryGettingOldValueWithWrongType_ThenReturnsFalse()
     {
         // Arrange
         var change = SubjectPropertyChange.Create(
@@ -508,7 +508,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void TryGetNewValue_WithCorrectType_ReturnsTrue()
+    public void WhenTryGettingNewValueWithCorrectType_ThenReturnsTrue()
     {
         // Arrange
         var newValue = 42.5;
@@ -525,7 +525,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_PreservesPropertyReference()
+    public void WhenCreated_ThenPreservesPropertyReference()
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -537,7 +537,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_PreservesSource()
+    public void WhenCreated_ThenPreservesSource()
     {
         // Arrange
         var source = new object();
@@ -552,7 +552,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_PreservesTimestamps()
+    public void WhenCreated_ThenPreservesTimestamps()
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -565,7 +565,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithNullReceivedTimestamp_PreservesNull()
+    public void WhenCreatedWithNullReceivedTimestamp_ThenPreservesNull()
     {
         // Act
         var change = SubjectPropertyChange.Create(
@@ -577,7 +577,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void MergeWithNewer_WithInlineValues_KeepsOldFromEarlierAndNewFromLater()
+    public void WhenMergingWithNewerWithInlineValues_ThenKeepsOldFromEarlierAndNewFromLater()
     {
         // Arrange
         var earlierSource = new object();
@@ -603,7 +603,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void MergeWithNewer_WithStrings_KeepsOldFromEarlierAndNewFromLater()
+    public void WhenMergingWithNewerWithStrings_ThenKeepsOldFromEarlierAndNewFromLater()
     {
         // Arrange
         var earlier = SubjectPropertyChange.Create(
@@ -622,7 +622,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void MergeWithNewer_WithNullStringOldValue_PreservesNull()
+    public void WhenMergingWithNewerWithNullStringOldValue_ThenPreservesNull()
     {
         // Arrange
         var earlier = SubjectPropertyChange.Create(
@@ -641,7 +641,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void MergeWithNewer_WithBoxedReferenceTypes_KeepsOldFromEarlierAndNewFromLater()
+    public void WhenMergingWithNewerWithBoxedReferenceTypes_ThenKeepsOldFromEarlierAndNewFromLater()
     {
         // Arrange
         var oldObj = new CustomClass { Id = 1, Name = "Old" };
@@ -664,7 +664,7 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void MergeWithNewer_WithFromSourceOrigins_PreservesKindAndSource()
+    public void WhenMergingWithNewerWithFromSourceOrigins_ThenPreservesKindAndSource()
     {
         // Arrange
         var source = new object();
@@ -684,11 +684,10 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithSmallStructContainingReference_KeepsReferenceAliveForGc()
+    public void WhenCreatedWithSmallStructContainingReference_ThenKeepsReferenceAliveForGc()
     {
-        // Arrange: an 8-byte struct (fits inline storage) that carries an object reference.
-        // The arrange lives in a non-inlined helper so its locals are dead before the collection,
-        // making the retained change the value's only possible GC root.
+        // Arrange: a small ref-carrying struct; the non-inlined helper leaves the retained change
+        // as the value's only possible GC root.
         var (change, weakReference) = CreateChangeWithReferenceStruct(_property, _changedTimestamp, _receivedTimestamp);
 
         // Act
@@ -704,10 +703,9 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void Create_WithImmutableArray_KeepsBackingArrayAliveAcrossGc()
+    public void WhenCreatedWithImmutableArray_ThenKeepsBackingArrayAliveAcrossGc()
     {
-        // Arrange: ImmutableArray<T> is an 8-byte struct wrapping a T[] reference; after the
-        // property is overwritten, the change may be the backing array's only GC root.
+        // Arrange: ImmutableArray<T> wraps a T[] reference; the change may be the backing array's only GC root.
         var (change, weakBackingArray) = CreateChangeWithImmutableArray(_property, _changedTimestamp, _receivedTimestamp);
 
         // Act

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
 
@@ -679,6 +682,72 @@ public class SubjectPropertyChangeTests
         Assert.Equal(ChangeOriginKind.FromSource, merged.Origin.Kind);
         Assert.Same(source, merged.Origin.Source);
     }
+
+    [Fact]
+    public void Create_WithSmallStructContainingReference_KeepsReferenceAliveForGc()
+    {
+        // Arrange: an 8-byte struct (fits inline storage) that carries an object reference.
+        // The arrange lives in a non-inlined helper so its locals are dead before the collection,
+        // making the retained change the value's only possible GC root.
+        var (change, weakReference) = CreateChangeWithReferenceStruct(_property, _changedTimestamp, _receivedTimestamp);
+
+        // Act
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        // Assert
+        Assert.True(weakReference.IsAlive,
+            "SubjectPropertyChange must keep references inside stored values alive for the GC.");
+        Assert.Same(weakReference.Target, change.GetOldValue<SmallStructWithReference>().Reference);
+        GC.KeepAlive(change);
+    }
+
+    [Fact]
+    public void Create_WithImmutableArray_KeepsBackingArrayAliveAcrossGc()
+    {
+        // Arrange: ImmutableArray<T> is an 8-byte struct wrapping a T[] reference; after the
+        // property is overwritten, the change may be the backing array's only GC root.
+        var (change, weakBackingArray) = CreateChangeWithImmutableArray(_property, _changedTimestamp, _receivedTimestamp);
+
+        // Act
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        // Assert - the backing array survives and the value round-trips intact through the
+        // boxed object read (the path collection diffing uses)
+        Assert.True(weakBackingArray.IsAlive,
+            "SubjectPropertyChange must keep the ImmutableArray's backing array alive for the GC.");
+        var oldValue = Assert.IsType<ImmutableArray<string>>(change.GetOldValue<object?>());
+        Assert.Equal(new[] { "a", "b" }, oldValue);
+        GC.KeepAlive(change);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (SubjectPropertyChange Change, WeakReference WeakReference) CreateChangeWithReferenceStruct(
+        PropertyReference property, DateTimeOffset changedTimestamp, DateTimeOffset receivedTimestamp)
+    {
+        var referenced = new object();
+        var change = SubjectPropertyChange.Create(
+            property, origin: ChangeOrigin.Local, changedTimestamp, receivedTimestamp,
+            new SmallStructWithReference(referenced), new SmallStructWithReference(null));
+        return (change, new WeakReference(referenced));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (SubjectPropertyChange Change, WeakReference WeakBackingArray) CreateChangeWithImmutableArray(
+        PropertyReference property, DateTimeOffset changedTimestamp, DateTimeOffset receivedTimestamp)
+    {
+        var oldValue = ImmutableArray.Create("a", "b");
+        var backingArray = ImmutableCollectionsMarshal.AsArray(oldValue)!;
+        var change = SubjectPropertyChange.Create(
+            property, origin: ChangeOrigin.Local, changedTimestamp, receivedTimestamp,
+            oldValue, ImmutableArray.Create("a", "b", "c"));
+        return (change, new WeakReference(backingArray));
+    }
+
+    private readonly record struct SmallStructWithReference(object? Reference);
 
     [Fact]
     public void WhenMeasuringSubjectPropertyChange_ThenSizeStaysWithinOneAlignmentSlotOfMaster()

--- a/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
@@ -25,13 +25,10 @@ internal readonly struct InlineValueStorage
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static InlineValueStorage Create<TValue>(TValue value)
     {
-        // The raw bytes below land in long fields the GC does not scan, so a contained object
-        // reference would be invisible to the GC and could dangle. The write also spans exactly
-        // SizeOf(TValue) bytes from offset 0, and the Type field sits at offset 16, so a value
-        // larger than MaxSize would overwrite a GC-tracked reference with raw bytes. Callers must
-        // route such types to BoxedValueHolder. All three checks are JIT-time constants per
-        // instantiation, so for valid types this guard is eliminated entirely (zero cost in every
-        // configuration) while an invalid future caller fails fast instead of corrupting memory.
+        // Memory-safety invariants: no contained references (the long fields below are not GC-scanned,
+        // so a hidden reference could dangle) and SizeOf <= MaxSize (a larger write would overwrite the
+        // GC-tracked Type field at offset 16). Such types belong in BoxedValueHolder. The checks fold
+        // to JIT constants: valid types pay nothing, an invalid caller fails fast in every configuration.
         if (!typeof(TValue).IsValueType ||
             RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() ||
             Unsafe.SizeOf<TValue>() > MaxSize)

--- a/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
@@ -29,12 +29,15 @@ internal readonly struct InlineValueStorage
         // reference would be invisible to the GC and could dangle. The write also spans exactly
         // SizeOf(TValue) bytes from offset 0, and the Type field sits at offset 16, so a value
         // larger than MaxSize would overwrite a GC-tracked reference with raw bytes. Callers must
-        // route such types to BoxedValueHolder; this assert makes both invariants self-enforcing.
-        System.Diagnostics.Debug.Assert(
-            typeof(TValue).IsValueType &&
-            !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() &&
-            Unsafe.SizeOf<TValue>() <= MaxSize,
-            $"InlineValueStorage must not store '{typeof(TValue)}': it is a reference type, contains references (which the GC cannot track inside inline storage), or exceeds {MaxSize} bytes (which would overwrite the adjacent type field).");
+        // route such types to BoxedValueHolder. All three checks are JIT-time constants per
+        // instantiation, so for valid types this guard is eliminated entirely (zero cost in every
+        // configuration) while an invalid future caller fails fast instead of corrupting memory.
+        if (!typeof(TValue).IsValueType ||
+            RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() ||
+            Unsafe.SizeOf<TValue>() > MaxSize)
+        {
+            ThrowUnsupportedType<TValue>();
+        }
 
         var storage = new InlineValueStorage();
         Unsafe.AsRef(in storage._storedType) = typeof(TValue);
@@ -107,4 +110,12 @@ internal readonly struct InlineValueStorage
             return value!;
         };
     }
+
+    // Kept out of Create so the (JIT-eliminated) guard does not bloat its inlined body.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowUnsupportedType<TValue>() =>
+        throw new InvalidOperationException(
+            $"InlineValueStorage cannot store '{typeof(TValue)}': it is a reference type, contains " +
+            $"references (which the GC cannot track inside inline storage), or exceeds {MaxSize} bytes " +
+            "(which would overwrite the adjacent type field). Route this type to BoxedValueHolder.");
 }

--- a/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
@@ -26,11 +26,15 @@ internal readonly struct InlineValueStorage
     public static InlineValueStorage Create<TValue>(TValue value)
     {
         // The raw bytes below land in long fields the GC does not scan, so a contained object
-        // reference would be invisible to the GC and could dangle. Callers must route such types
-        // to BoxedValueHolder; this assert makes the invariant self-enforcing for future callers.
+        // reference would be invisible to the GC and could dangle. The write also spans exactly
+        // SizeOf(TValue) bytes from offset 0, and the Type field sits at offset 16, so a value
+        // larger than MaxSize would overwrite a GC-tracked reference with raw bytes. Callers must
+        // route such types to BoxedValueHolder; this assert makes both invariants self-enforcing.
         System.Diagnostics.Debug.Assert(
-            typeof(TValue).IsValueType && !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>(),
-            $"InlineValueStorage must not store '{typeof(TValue)}': it is a reference type or contains references, which the GC cannot track inside inline storage.");
+            typeof(TValue).IsValueType &&
+            !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() &&
+            Unsafe.SizeOf<TValue>() <= MaxSize,
+            $"InlineValueStorage must not store '{typeof(TValue)}': it is a reference type, contains references (which the GC cannot track inside inline storage), or exceeds {MaxSize} bytes (which would overwrite the adjacent type field).");
 
         var storage = new InlineValueStorage();
         Unsafe.AsRef(in storage._storedType) = typeof(TValue);

--- a/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
@@ -25,6 +25,13 @@ internal readonly struct InlineValueStorage
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static InlineValueStorage Create<TValue>(TValue value)
     {
+        // The raw bytes below land in long fields the GC does not scan, so a contained object
+        // reference would be invisible to the GC and could dangle. Callers must route such types
+        // to BoxedValueHolder; this assert makes the invariant self-enforcing for future callers.
+        System.Diagnostics.Debug.Assert(
+            typeof(TValue).IsValueType && !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>(),
+            $"InlineValueStorage must not store '{typeof(TValue)}': it is a reference type or contains references, which the GC cannot track inside inline storage.");
+
         var storage = new InlineValueStorage();
         Unsafe.AsRef(in storage._storedType) = typeof(TValue);
         Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref Unsafe.AsRef(in storage._valueData0)), value);

--- a/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
@@ -48,12 +48,9 @@ public readonly struct SubjectPropertyChange : IEquatable<SubjectPropertyChange>
         TValue oldValue,
         TValue newValue)
     {
-        // Fast path: value types that fit inline (primitives, small structs) - ZERO allocations.
-        // Must exclude structs containing object references (e.g. ImmutableArray<T>, small structs
-        // with a string field): inline storage writes raw bytes into long fields the GC does not
-        // scan, so a contained reference would be invisible to the GC and the referenced object
-        // could be collected or moved while the change still holds its stale address. All checks
-        // are JIT-time constants, so the guard costs nothing on the primitive fast path.
+        // Fast path: small ref-free value types stored inline - zero allocations. Structs containing
+        // references (e.g. ImmutableArray<T>) must be excluded: inline storage is not GC-scanned, so a
+        // contained reference could dangle. All checks fold to JIT-time constants (zero-cost guard).
         if (typeof(TValue).IsValueType &&
             !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() &&
             Unsafe.SizeOf<TValue>() <= InlineValueStorage.MaxSize)

--- a/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
@@ -48,8 +48,15 @@ public readonly struct SubjectPropertyChange : IEquatable<SubjectPropertyChange>
         TValue oldValue,
         TValue newValue)
     {
-        // Fast path: value types that fit inline (primitives, small structs) - ZERO allocations
-        if (typeof(TValue).IsValueType && Unsafe.SizeOf<TValue>() <= InlineValueStorage.MaxSize)
+        // Fast path: value types that fit inline (primitives, small structs) - ZERO allocations.
+        // Must exclude structs containing object references (e.g. ImmutableArray<T>, small structs
+        // with a string field): inline storage writes raw bytes into long fields the GC does not
+        // scan, so a contained reference would be invisible to the GC and the referenced object
+        // could be collected or moved while the change still holds its stale address. All checks
+        // are JIT-time constants, so the guard costs nothing on the primitive fast path.
+        if (typeof(TValue).IsValueType &&
+            !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() &&
+            Unsafe.SizeOf<TValue>() <= InlineValueStorage.MaxSize)
         {
             return new SubjectPropertyChange(
                 property,


### PR DESCRIPTION
## Summary

Fixes a GC-safety hole in `SubjectPropertyChange`: the zero-allocation inline value storage accepted any value type up to 16 bytes, including structs that contain object references (such as `ImmutableArray<T>` or a small struct with a `string` field). Inline storage writes the value's raw bytes into `long` fields with explicit layout, which the GC does not scan, so a contained reference was invisible to the GC. If the change was the referenced object's only remaining root, the object could be collected (or moved by a compacting GC) while the change still held its stale address; reading the value back then reconstituted a dangling reference.

The fix adds the missing guard to the inline fast-path predicate:

```csharp
if (typeof(TValue).IsValueType &&
    !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() &&
    Unsafe.SizeOf<TValue>() <= InlineValueStorage.MaxSize)
```

Ref-containing structs now take the existing `BoxedValueHolder` path, which roots them correctly.

## Changes

1. **The fix**: `SubjectPropertyChange.Create<TValue>` guards the inline fast path with `!RuntimeHelpers.IsReferenceOrContainsReferences<TValue>()`, routing ref-containing small structs to the GC-visible `BoxedValueHolder` path.
2. **Regression tests**: two deterministic tests (non-inlined arrange, forced compacting GC, `WeakReference` assertions) that fail on the previous code in both Debug and Release and pin the rooting contract permanently.
3. **Self-enforcing storage invariants**: `InlineValueStorage.Create` fail-fast throws (via a non-inlined helper) if a caller ever passes a type that is not a value type, contains references, or exceeds the 16-byte data region (which would overwrite the GC-tracked `Type` field at offset 16). This layer protects future maintainers in every configuration, including CI which tests Release; it started as a `Debug.Assert` and was upgraded to a throw once the guard was shown to be free.

## How it was found

The `test` job on #383 failed once with `ArgumentNullException: Value cannot be null. (Parameter 'key')` in `SubjectUpdateReadOnlyTypesTests.WhenImmutableArrayItemAdded_ThenInsertOperationIsCreated`, thrown from `CollectionDiffBuilder.GetCollectionChanges` while indexing old collection items. A rerun of the identical commit passed, and the test passed 13 of 13 local runs.

Root-cause trace: the null element came from `change.GetOldValue<object?>()` for an `ImmutableArray` old value. `ImmutableArray<T>` is an 8-byte value type wrapping a `T[]` reference, so it passed the size-only inline check; after the property was overwritten, the only reference to the old backing array was the raw bytes inside the change. A Gen0 collection in the window between the write and the update build (frequent on a loaded 2-core CI runner, rare on a quiet local machine) reclaimed the array; the later read reinterpreted the reclaimed memory as the array and saw a null element. This is not a thread race: a single-threaded run can hit it with unlucky GC timing, which is why it presented as an unreproducible CI-only flake.

Introduced with the inline storage in #58 and extended in #113; latent since.

## Impact

Every subscription consumer (observable, queue subscription, connectors) was exposed for any property whose type is a value type up to 16 bytes containing references. The queue path had the largest window, since `ChangeQueueProcessor` retains changes across flush intervals. Because a compacting GC can move objects rather than collect them, the failure mode includes silently wrong values and, as an independent review empirically demonstrated with a standalone replica of the pre-fix mechanism, a fatal AccessViolationException (uncatchable process crash) when the reconstituted reference is dereferenced after compaction. The observed CI failure was the mild presentation.

## Tests

Two new deterministic tests in `SubjectPropertyChangeTests` prove rooting without relying on undefined behavior: the arrange runs in a non-inlined helper (so its locals are dead), a full compacting collection is forced, and a `WeakReference` asserts the change keeps the stored value's references alive. Both fail on the previous code and pass with the fix. Full non-integration suite passes.

## Performance

None. `typeof(TValue).IsValueType`, `RuntimeHelpers.IsReferenceOrContainsReferences<TValue>()`, and `Unsafe.SizeOf<TValue>()` are all JIT intrinsics that fold to constants per generic instantiation, so the guard adds zero instructions to the primitive fast path (int, bool, decimal, DateTimeOffset, and so on stay zero-allocation inline). Ref-containing small structs now pay the two `BoxedValueHolder` allocations of the existing slow path, which is the price of being visible to the GC.

Both the predicate guard and the storage's fail-fast throw were verified by disassembly, not only by reasoning: with full JIT optimization, the compiled hot loop that inlines `Create<decimal>` contains no trace of the checks, the throw helper, or any exception construction; the constant-false guard is eliminated entirely, so the compiled hot path is identical to code with no guard at all.

## Bug-class audit

A sweep for the same class of bug (references laundered into GC-unscanned memory) across the whole solution found no other instance:

- Reinterpretation APIs (`Unsafe.WriteUnaligned/ReadUnaligned/As/AsRef`, `MemoryMarshal.*`) exist in exactly two files: `InlineValueStorage` (this fix) and `BoxedValueHolder`, which is safe (its value lives in a properly typed `T` field the GC scans, and its `Unsafe.As<T, TValue>` is guarded by `typeof(T) == typeof(TValue)`, an identity cast).
- The only `LayoutKind.Explicit` union in the solution is `InlineValueStorage`, and its layout is non-overlapping (data at offsets 0/8, the `Type` reference at 16); the hazard was solely the ungated ref-containing payload.
- All `stackalloc`/span usages are primitive byte/char buffers (hashing, id formatting, MQTT); no `GCHandle`, `NativeMemory`, or `fixed` anywhere.

As defense in depth, `InlineValueStorage.Create` now enforces its invariants itself (no contained references, size within the 16-byte data region that precedes the GC-tracked `Type` field) with a fail-fast throw. Because all checks are JIT-time constants per instantiation, the guard is eliminated entirely for valid types (zero cost in every configuration), while an invalid future caller fails fast in Debug, Release, and CI alike instead of corrupting memory. Note this layer protects future library maintainers only; consumers were never exposed, since `InlineValueStorage` is internal and its single production caller carries the release-active guard.


Release-notes flag: external consumers with properties typed as small ref-containing structs (such as `ImmutableArray<T>`) now pay the two `BoxedValueHolder` allocations per change that large structs always paid; no production property type in this repository is affected.
