### PR TITLE
docs: Tidy interception-layer docs left by the ThreadStatic and GC-safety PRs

### DIFF
--- a/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/Performance/InlineValueStorage.cs
@@ -25,10 +25,12 @@ internal readonly struct InlineValueStorage
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static InlineValueStorage Create<TValue>(TValue value)
     {
-        // Memory-safety invariants: no contained references (the long fields below are not GC-scanned,
-        // so a hidden reference could dangle) and SizeOf <= MaxSize (a larger write would overwrite the
-        // GC-tracked Type field at offset 16). Such types belong in BoxedValueHolder. The checks fold
-        // to JIT constants: valid types pay nothing, an invalid caller fails fast in every configuration.
+        // Memory-safety invariants: no references, neither TValue itself nor contained ones (the long
+        // fields below are not GC-scanned, so a hidden reference could dangle), and SizeOf <= MaxSize
+        // (a larger write would overwrite the GC-tracked Type field at offset 16). Such types belong in
+        // BoxedValueHolder. The IsValueType leg is redundant with IsReferenceOrContainsReferences and
+        // kept for symmetry with the caller's predicate. All checks fold to JIT constants: valid types
+        // pay nothing, an invalid caller fails fast in every configuration.
         if (!typeof(TValue).IsValueType ||
             RuntimeHelpers.IsReferenceOrContainsReferences<TValue>() ||
             Unsafe.SizeOf<TValue>() > MaxSize)

--- a/src/Namotion.Interceptor/IInterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/IInterceptorSubjectContext.cs
@@ -1,11 +1,10 @@
 using System.Collections.Immutable;
-using Namotion.Interceptor.Interceptors;
 
 namespace Namotion.Interceptor;
 
 /// <summary>
-/// The central context for managing services and intercepting property/method access on interceptor subjects.
-/// Provides service registration, retrieval, and execution of intercepted operations through middleware chains.
+/// The central context for interceptor subjects: service registration, retrieval, and fallback-context
+/// composition. Execution of intercepted operations is an internal concern of the implementation.
 /// </summary>
 public interface IInterceptorSubjectContext
 {


### PR DESCRIPTION
## Summary

Three cosmetic leftovers flagged as non-blocking by the reviews of #383 and #390:

1. `IInterceptorSubjectContext.cs`: remove the `using Namotion.Interceptor.Interceptors;` that became unused when the `ExecuteIntercepted*` trio moved off the interface.
2. Same file: align the interface summary with the narrowed contract (service registration, retrieval, and fallback composition; execution of intercepted operations is an internal concern of the implementation).
3. `InlineValueStorage.cs`: the guard comment now accounts for all three predicate legs, noting the `IsValueType` check is redundant with `IsReferenceOrContainsReferences` and kept for symmetry with the caller's predicate.

Comments and one using only; no code or public API change (PublicApi snapshot test passes unchanged).