### PR TITLE
Add batched OPC UA browse/read session primitives and split status classification

### DIFF
--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSessionExtensionsTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSessionExtensionsTests.cs
@@ -1,0 +1,447 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Namotion.Interceptor.OpcUa.Client;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+/// <summary>
+/// Tests for the bad-status handling in <see cref="OpcUaSessionExtensions"/>.
+/// Browse aborts on a transient per-NodeId status by throwing
+/// <see cref="OpcUaTransientServiceException"/> so the structural graph is never
+/// loaded incomplete; permanent statuses are logged and skipped. The read path is
+/// a best-effort primitive: it never classifies or throws, returning every result
+/// positionally so each caller applies its own policy (value loads keep the good
+/// values, type resolution aborts on transient itself).
+/// </summary>
+public class OpcUaSessionExtensionsTests
+{
+    [Fact]
+    public async Task WhenBrowseReturnsTransientBadStatus_ThenThrowsTransientServiceException()
+    {
+        // Arrange
+        var nodeId = new NodeId(2001, 2);
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult
+                    {
+                        StatusCode = StatusCodes.BadCommunicationError,
+                        References = []
+                    }
+                ],
+                DiagnosticInfos = []
+            });
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<OpcUaTransientServiceException>(() =>
+            mockSession.Object.BrowseNodesAsync(
+                [nodeId],
+                maxReferencesPerNode: 1000,
+                maxContinuationRounds: 100,
+                NullLogger<OpcUaSessionExtensionsTests>.Instance,
+                CancellationToken.None));
+
+        Assert.Equal("Browse", exception.Operation);
+        Assert.Equal(nodeId, exception.NodeId);
+        Assert.Equal((StatusCode)StatusCodes.BadCommunicationError, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task WhenBrowseReturnsPermanentBadStatus_ThenSkipsNodeAndContinues()
+    {
+        // Arrange: NodeId 1 returns BadNodeIdUnknown (permanent), NodeId 2 returns good results.
+        // The browse must skip the unknown NodeId and continue with the rest of the batch.
+        var unknownNodeId = new NodeId(1001, 2);
+        var goodNodeId = new NodeId(1002, 2);
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, ViewDescription _, uint _, BrowseDescriptionCollection descriptions, CancellationToken _) =>
+            {
+                var results = new BrowseResultCollection();
+                foreach (var desc in descriptions)
+                {
+                    if (desc.NodeId == unknownNodeId)
+                    {
+                        results.Add(new BrowseResult
+                        {
+                            StatusCode = StatusCodes.BadNodeIdUnknown,
+                            References = []
+                        });
+                    }
+                    else
+                    {
+                        results.Add(new BrowseResult
+                        {
+                            References =
+                            [
+                                new ReferenceDescription { BrowseName = new QualifiedName("Child"), NodeId = new ExpandedNodeId(new NodeId(3001, 2)) }
+                            ]
+                        });
+                    }
+                }
+                return new BrowseResponse { Results = results, DiagnosticInfos = [] };
+            });
+
+        // Act
+        var result = await mockSession.Object.BrowseNodesAsync(
+            [unknownNodeId, goodNodeId],
+            maxReferencesPerNode: 1000,
+            maxContinuationRounds: 100,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert: the permanent-bad NodeId is omitted; the good NodeId is present.
+        // Omission (not "present with empty refs") is the contract that lets the cache
+        // re-attempt the bad NodeId on the next load.
+        Assert.False(result.ContainsKey(unknownNodeId));
+        Assert.True(result.ContainsKey(goodNodeId));
+        Assert.Single(result[goodNodeId]);
+    }
+
+    [Fact]
+    public async Task WhenBrowseNextReturnsTransientBadStatus_ThenThrowsTransientServiceException()
+    {
+        // Arrange: initial browse returns a continuation point; BrowseNext returns a transient bad status.
+        var nodeId = new NodeId(1, 0);
+        var continuationToken = new byte[] { 0xCA, 0xFE };
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult
+                    {
+                        References =
+                        [
+                            new ReferenceDescription { BrowseName = new QualifiedName("X"), NodeId = new ExpandedNodeId(new NodeId(2001, 2)) }
+                        ],
+                        ContinuationPoint = continuationToken
+                    }
+                ],
+                DiagnosticInfos = []
+            });
+
+        mockSession
+            .Setup(s => s.BrowseNextAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<bool>(),
+                It.IsAny<ByteStringCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseNextResponse
+            {
+                Results =
+                [
+                    new BrowseResult
+                    {
+                        StatusCode = StatusCodes.BadTimeout,
+                        References = []
+                    }
+                ],
+                DiagnosticInfos = []
+            });
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<OpcUaTransientServiceException>(() =>
+            mockSession.Object.BrowseNodesAsync(
+                [nodeId],
+                maxReferencesPerNode: 1000,
+                maxContinuationRounds: 100,
+                NullLogger<OpcUaSessionExtensionsTests>.Instance,
+                CancellationToken.None));
+
+        Assert.Equal("BrowseNext", exception.Operation);
+        Assert.Equal(nodeId, exception.NodeId);
+        Assert.Equal((StatusCode)StatusCodes.BadTimeout, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task WhenReadReturnsTransientBadStatus_ThenPassesResultThroughToCaller()
+    {
+        // Arrange: the read path is best-effort and never throws, even on a transient
+        // status (BadServerNotConnected). The bad status passes through for the caller to handle.
+        var nodeId = new NodeId(5001, 2);
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.ReadAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<double>(),
+                It.IsAny<TimestampsToReturn>(),
+                It.IsAny<ReadValueIdCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReadResponse
+            {
+                Results = [new DataValue { StatusCode = StatusCodes.BadServerNotConnected }],
+                DiagnosticInfos = []
+            });
+
+        var nodesToRead = new ReadValueIdCollection
+        {
+            new ReadValueId { NodeId = nodeId, AttributeId = Opc.Ua.Attributes.Value }
+        };
+
+        // Act
+        var results = await mockSession.Object.ReadNodesAsync(
+            nodesToRead,
+            TimestampsToReturn.Neither,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Single(results);
+        Assert.Equal(StatusCodes.BadServerNotConnected, results[0].StatusCode);
+    }
+
+    [Fact]
+    public async Task WhenReadMixesGoodAndNotReadyValues_ThenReturnsAllWithoutThrowing()
+    {
+        // Arrange: regression for one not-ready node cancelling the whole load.
+        // BadWaitingForInitialData (a startup status) must not throw or drop the good value read with it.
+        var goodNodeId = new NodeId(8001, 2);
+        var notReadyNodeId = new NodeId(8002, 2);
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.ReadAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<double>(),
+                It.IsAny<TimestampsToReturn>(),
+                It.IsAny<ReadValueIdCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReadResponse
+            {
+                Results =
+                [
+                    new DataValue { Value = 42, StatusCode = StatusCodes.Good },
+                    new DataValue { StatusCode = StatusCodes.BadWaitingForInitialData }
+                ],
+                DiagnosticInfos = []
+            });
+
+        var nodesToRead = new ReadValueIdCollection
+        {
+            new ReadValueId { NodeId = goodNodeId, AttributeId = Opc.Ua.Attributes.Value },
+            new ReadValueId { NodeId = notReadyNodeId, AttributeId = Opc.Ua.Attributes.Value }
+        };
+
+        // Act
+        var results = await mockSession.Object.ReadNodesAsync(
+            nodesToRead,
+            TimestampsToReturn.Source,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert: both slots returned and aligned; the good value survives the not-ready one.
+        Assert.Equal(2, results.Count);
+        Assert.True(StatusCode.IsGood(results[0].StatusCode));
+        Assert.Equal(42, results[0].Value);
+        Assert.Equal(StatusCodes.BadWaitingForInitialData, results[1].StatusCode);
+    }
+
+    [Fact]
+    public async Task WhenReadReturnsPermanentBadStatus_ThenPassesResultThroughToCaller()
+    {
+        // Arrange: BadUserAccessDenied is permanent. The read returns successfully and the
+        // bad DataValue passes through to the caller, which decides per-property how to handle it.
+        var nodeId = new NodeId(5001, 2);
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.ReadAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<double>(),
+                It.IsAny<TimestampsToReturn>(),
+                It.IsAny<ReadValueIdCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReadResponse
+            {
+                Results = [new DataValue { StatusCode = StatusCodes.BadUserAccessDenied }],
+                DiagnosticInfos = []
+            });
+
+        var nodesToRead = new ReadValueIdCollection
+        {
+            new ReadValueId { NodeId = nodeId, AttributeId = Opc.Ua.Attributes.Value }
+        };
+
+        // Act
+        var results = await mockSession.Object.ReadNodesAsync(
+            nodesToRead,
+            TimestampsToReturn.Neither,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Single(results);
+        Assert.Equal(StatusCodes.BadUserAccessDenied, results[0].StatusCode);
+    }
+
+    [Fact]
+    public async Task WhenBrowseReturnsFewerResultsThanRequested_ThenThrowsTransientServiceException()
+    {
+        // Arrange: two nodes requested but the server returns only one BrowseResult. The missing
+        // node must surface as a transient failure so the load retries, rather than silently
+        // loading that subject with zero children.
+        var returnedNodeId = new NodeId(1001, 2);
+        var missingNodeId = new NodeId(1002, 2);
+        var mockSession = CreateMockSession();
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results = [new BrowseResult { References = [] }],
+                DiagnosticInfos = []
+            });
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<OpcUaTransientServiceException>(() =>
+            mockSession.Object.BrowseNodesAsync(
+                [returnedNodeId, missingNodeId],
+                maxReferencesPerNode: 1000,
+                maxContinuationRounds: 100,
+                NullLogger<OpcUaSessionExtensionsTests>.Instance,
+                CancellationToken.None));
+
+        Assert.Equal("Browse", exception.Operation);
+        Assert.Equal(missingNodeId, exception.NodeId);
+    }
+
+    [Fact]
+    public async Task WhenBrowseNextReturnsFewerResultsThanRequested_ThenThrowsTransientServiceException()
+    {
+        // Arrange: the initial browse returns two nodes, each with a continuation point. The
+        // follow-up BrowseNext is sent both continuation points but the server returns only one
+        // result. The missing node must surface as a transient failure (mirroring the initial
+        // Browse path) so the load retries, rather than silently truncating that node's children
+        // and leaking its continuation point.
+        var returnedNodeId = new NodeId(1001, 2);
+        var missingNodeId = new NodeId(1002, 2);
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult { References = [], ContinuationPoint = [0xAA] },
+                    new BrowseResult { References = [], ContinuationPoint = [0xBB] }
+                ],
+                DiagnosticInfos = []
+            });
+
+        mockSession
+            .Setup(s => s.BrowseNextAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<bool>(),
+                It.IsAny<ByteStringCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseNextResponse
+            {
+                Results = [new BrowseResult { References = [] }],
+                DiagnosticInfos = []
+            });
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<OpcUaTransientServiceException>(() =>
+            mockSession.Object.BrowseNodesAsync(
+                [returnedNodeId, missingNodeId],
+                maxReferencesPerNode: 1000,
+                maxContinuationRounds: 100,
+                NullLogger<OpcUaSessionExtensionsTests>.Instance,
+                CancellationToken.None));
+
+        Assert.Equal("BrowseNext", exception.Operation);
+        Assert.Equal(missingNodeId, exception.NodeId);
+    }
+
+    [Fact]
+    public async Task WhenServerReportsIntOverflowingOperationLimit_ThenBrowseUsesDefaultBatchLimit()
+    {
+        // Arrange: a buggy or hostile server can report MaxNodesPerBrowse above int.MaxValue;
+        // an unclamped uint-to-int cast would produce a negative batch size and corrupt the
+        // batching loop math.
+        var firstNodeId = new NodeId(1001, 2);
+        var secondNodeId = new NodeId(1002, 2);
+        var mockSession = CreateMockSession();
+        mockSession.SetupGet(s => s.OperationLimits).Returns(new OperationLimits { MaxNodesPerBrowse = uint.MaxValue });
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, ViewDescription _, uint _, BrowseDescriptionCollection descriptions, CancellationToken _) =>
+            {
+                var results = new BrowseResultCollection();
+                foreach (var _ in descriptions)
+                {
+                    results.Add(new BrowseResult
+                    {
+                        References =
+                        [
+                            new ReferenceDescription { BrowseName = new QualifiedName("Child"), NodeId = new ExpandedNodeId(new NodeId(3001, 2)) }
+                        ]
+                    });
+                }
+                return new BrowseResponse { Results = results, DiagnosticInfos = [] };
+            });
+
+        // Act
+        var result = await mockSession.Object.BrowseNodesAsync(
+            [firstNodeId, secondNodeId],
+            maxReferencesPerNode: 1000,
+            maxContinuationRounds: 100,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.ContainsKey(firstNodeId));
+        Assert.True(result.ContainsKey(secondNodeId));
+    }
+
+    private static Mock<ISession> CreateMockSession()
+    {
+        var mockSession = new Mock<ISession>();
+        var namespaceTable = new NamespaceTable();
+        namespaceTable.Append("urn:test");
+        mockSession.SetupGet(s => s.NamespaceUris).Returns(namespaceTable);
+        mockSession.SetupGet(s => s.OperationLimits).Returns(new OperationLimits());
+        return mockSession;
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSessionExtensionsTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSessionExtensionsTests.cs
@@ -435,6 +435,278 @@ public class OpcUaSessionExtensionsTests
         Assert.True(result.ContainsKey(secondNodeId));
     }
 
+    [Fact]
+    public async Task WhenServerLimitsBrowseContinuationPoints_ThenBrowseBatchesToThatQuota()
+    {
+        // Arrange: the continuation-point quota (2) is far below the operation limit (100).
+        // Batching by the operation limit would open more continuation points than the server
+        // allows, which fails permanently and identically on every reconnect retry.
+        var nodeIds = Enumerable.Range(1, 5).Select(index => new NodeId((uint)(1000 + index), 2)).ToArray();
+        var mockSession = CreateMockSession();
+        mockSession.SetupGet(s => s.OperationLimits).Returns(new OperationLimits { MaxNodesPerBrowse = 100 });
+        mockSession.SetupGet(s => s.ServerCapabilities).Returns(new ServerCapabilities { MaxBrowseContinuationPoints = 2 });
+
+        var batchSizes = new List<int>();
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, ViewDescription _, uint _, BrowseDescriptionCollection descriptions, CancellationToken _) =>
+            {
+                batchSizes.Add(descriptions.Count);
+                var results = new BrowseResultCollection();
+                foreach (var _ in descriptions)
+                {
+                    results.Add(new BrowseResult { References = [] });
+                }
+                return new BrowseResponse { Results = results, DiagnosticInfos = [] };
+            });
+
+        // Act
+        var result = await mockSession.Object.BrowseNodesAsync(
+            nodeIds,
+            maxReferencesPerNode: 1000,
+            maxContinuationRounds: 100,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal([2, 2, 1], batchSizes);
+        Assert.Equal(5, result.Count);
+    }
+
+    [Fact]
+    public async Task WhenBrowseRejectsBatchAsTooLarge_ThenSplitsAndRetriesUntilAccepted()
+    {
+        // Arrange: the server rejects any batch above one node with BadRequestTooLarge. Halving
+        // must recurse until every node is browsed rather than failing the whole load.
+        var nodeIds = Enumerable.Range(1, 4).Select(index => new NodeId((uint)(1000 + index), 2)).ToArray();
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, ViewDescription _, uint _, BrowseDescriptionCollection descriptions, CancellationToken _) =>
+            {
+                if (descriptions.Count > 1)
+                {
+                    throw new ServiceResultException(StatusCodes.BadRequestTooLarge);
+                }
+                return new BrowseResponse
+                {
+                    Results = [new BrowseResult { References = [] }],
+                    DiagnosticInfos = []
+                };
+            });
+
+        // Act
+        var result = await mockSession.Object.BrowseNodesAsync(
+            nodeIds,
+            maxReferencesPerNode: 1000,
+            maxContinuationRounds: 100,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(4, result.Count);
+        Assert.All(nodeIds, nodeId => Assert.True(result.ContainsKey(nodeId)));
+    }
+
+    [Fact]
+    public async Task WhenBrowseAbortsAfterCollectingContinuationPoints_ThenReleasesThem()
+    {
+        // Arrange: the first node pages (continuation point handed out), the second returns a
+        // transient bad status that aborts the load. The first node's continuation point must be
+        // released, otherwise every aborted load burns one of the server's scarce slots.
+        var pagingNodeId = new NodeId(1001, 2);
+        var failingNodeId = new NodeId(1002, 2);
+        var continuationToken = new byte[] { 0xAA };
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult { References = [], ContinuationPoint = continuationToken },
+                    new BrowseResult { StatusCode = StatusCodes.BadCommunicationError, References = [] }
+                ],
+                DiagnosticInfos = []
+            });
+
+        var releasedTokens = new List<byte[]>();
+        mockSession
+            .Setup(s => s.BrowseNextAsync(
+                It.IsAny<RequestHeader>(),
+                true,
+                It.IsAny<ByteStringCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, bool _, ByteStringCollection points, CancellationToken _) =>
+            {
+                releasedTokens.AddRange(points);
+                return new BrowseNextResponse { Results = [], DiagnosticInfos = [] };
+            });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OpcUaTransientServiceException>(() =>
+            mockSession.Object.BrowseNodesAsync(
+                [pagingNodeId, failingNodeId],
+                maxReferencesPerNode: 1000,
+                maxContinuationRounds: 100,
+                NullLogger<OpcUaSessionExtensionsTests>.Instance,
+                CancellationToken.None));
+
+        Assert.Equal([continuationToken], releasedTokens);
+    }
+
+    [Fact]
+    public async Task WhenContinuationRoundCapIsReached_ThenPartiallyPagedNodeIsOmitted()
+    {
+        // Arrange: the server never stops handing out continuation points. Hitting the round cap
+        // leaves the node's child list truncated, so it must be reported as failed this round
+        // rather than as a successfully browsed node with fewer children than it really has.
+        var nodeId = new NodeId(1001, 2);
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult
+                    {
+                        References =
+                        [
+                            new ReferenceDescription { BrowseName = new QualifiedName("First"), NodeId = new ExpandedNodeId(new NodeId(3001, 2)) }
+                        ],
+                        ContinuationPoint = [0xAA]
+                    }
+                ],
+                DiagnosticInfos = []
+            });
+
+        mockSession
+            .Setup(s => s.BrowseNextAsync(
+                It.IsAny<RequestHeader>(),
+                false,
+                It.IsAny<ByteStringCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseNextResponse
+            {
+                Results =
+                [
+                    new BrowseResult
+                    {
+                        References =
+                        [
+                            new ReferenceDescription { BrowseName = new QualifiedName("Next"), NodeId = new ExpandedNodeId(new NodeId(3002, 2)) }
+                        ],
+                        ContinuationPoint = [0xBB]
+                    }
+                ],
+                DiagnosticInfos = []
+            });
+
+        var releasedTokens = new List<byte[]>();
+        mockSession
+            .Setup(s => s.BrowseNextAsync(
+                It.IsAny<RequestHeader>(),
+                true,
+                It.IsAny<ByteStringCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RequestHeader _, bool _, ByteStringCollection points, CancellationToken _) =>
+            {
+                releasedTokens.AddRange(points);
+                return new BrowseNextResponse { Results = [], DiagnosticInfos = [] };
+            });
+
+        // Act
+        var result = await mockSession.Object.BrowseNodesAsync(
+            [nodeId],
+            maxReferencesPerNode: 1000,
+            maxContinuationRounds: 2,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+        Assert.Single(releasedTokens);
+    }
+
+    [Fact]
+    public async Task WhenBrowseNextReturnsPermanentBadStatus_ThenPartiallyPagedNodeIsOmitted()
+    {
+        // Arrange: the first page arrives, the second fails permanently. The node has a truncated
+        // child list either way, so it is omitted rather than reported as fully browsed.
+        var nodeId = new NodeId(1001, 2);
+        var mockSession = CreateMockSession();
+
+        mockSession
+            .Setup(s => s.BrowseAsync(
+                It.IsAny<RequestHeader>(),
+                It.IsAny<ViewDescription>(),
+                It.IsAny<uint>(),
+                It.IsAny<BrowseDescriptionCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseResponse
+            {
+                Results =
+                [
+                    new BrowseResult
+                    {
+                        References =
+                        [
+                            new ReferenceDescription { BrowseName = new QualifiedName("First"), NodeId = new ExpandedNodeId(new NodeId(3001, 2)) }
+                        ],
+                        ContinuationPoint = [0xAA]
+                    }
+                ],
+                DiagnosticInfos = []
+            });
+
+        mockSession
+            .Setup(s => s.BrowseNextAsync(
+                It.IsAny<RequestHeader>(),
+                false,
+                It.IsAny<ByteStringCollection>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BrowseNextResponse
+            {
+                Results = [new BrowseResult { StatusCode = StatusCodes.BadNodeIdUnknown, References = [] }],
+                DiagnosticInfos = []
+            });
+
+        // Act
+        var result = await mockSession.Object.BrowseNodesAsync(
+            [nodeId],
+            maxReferencesPerNode: 1000,
+            maxContinuationRounds: 100,
+            NullLogger<OpcUaSessionExtensionsTests>.Instance,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
     private static Mock<ISession> CreateMockSession()
     {
         var mockSession = new Mock<ISession>();

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaStatusCodeClassifierTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaStatusCodeClassifierTests.cs
@@ -4,10 +4,11 @@ using Opc.Ua;
 namespace Namotion.Interceptor.OpcUa.Tests.Client;
 
 /// <summary>
-/// Tests for the shared OPC UA status code classifier. One permanent list backs every
-/// callsite, so a single classifier covers the write and subscription-health paths.
-/// Verifies that the classifier treats codes consistently regardless of the operation
-/// context they appear in.
+/// Tests for the OPC UA status code classifier. It answers two questions that the access-scoped
+/// codes answer oppositely: <see cref="OpcUaStatusCodeClassifier.IsTransientError"/> (can this
+/// recover without a new session?) backs the subscribe and write paths, and
+/// <see cref="OpcUaStatusCodeClassifier.ThrowIfTransientError"/> (would reloading now help?) backs
+/// the browse and read paths, where access-scoped codes are skipped rather than retried.
 /// </summary>
 public class OpcUaStatusCodeClassifierTests
 {
@@ -20,7 +21,7 @@ public class OpcUaStatusCodeClassifierTests
     [InlineData(StatusCodes.BadSecurityModeInsufficient)]
     [InlineData(StatusCodes.BadNotWritable)]
     [InlineData(StatusCodes.BadWriteNotSupported)]
-    public void WhenStatusIsPermanentBadCode_ThenIsTransientErrorReturnsFalse(uint statusCode)
+    public void WhenStatusIsSessionPermanent_ThenIsTransientErrorReturnsFalse(uint statusCode)
     {
         // Arrange
         var status = new StatusCode(statusCode);
@@ -97,5 +98,45 @@ public class OpcUaStatusCodeClassifierTests
 
         // Act & Assert
         Assert.False(OpcUaStatusCodeClassifier.IsTransientError(status));
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.BadTimeout)]
+    [InlineData(StatusCodes.BadOutOfService)]
+    [InlineData(StatusCodes.BadTooManyMonitoredItems)]
+    [InlineData(StatusCodes.BadServerNotConnected)]
+    public void WhenBrowseStatusCanClearOnReload_ThenThrowIfTransientErrorThrows(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act & Assert
+        var exception = Assert.Throws<OpcUaTransientServiceException>(
+            () => OpcUaStatusCodeClassifier.ThrowIfTransientError(status, "Browse", new NodeId(1)));
+        Assert.Equal("Browse", exception.Operation);
+        Assert.Equal(status, exception.StatusCode);
+    }
+
+    [Theory]
+    // Permanent design-time codes: reloading repeats the failure, so the caller skips the node.
+    [InlineData(StatusCodes.BadNodeIdUnknown)]
+    [InlineData(StatusCodes.BadTypeMismatch)]
+    [InlineData(StatusCodes.BadSecurityModeInsufficient)]
+    // Access-scoped codes: transient over a longer horizon, but deterministic for this session, so
+    // a browse/read reload would crash-loop. They must NOT throw here even though IsTransientError
+    // classifies them transient for the subscribe path.
+    [InlineData(StatusCodes.BadUserAccessDenied)]
+    [InlineData(StatusCodes.BadNotReadable)]
+    [InlineData(StatusCodes.BadNotImplemented)]
+    // Non-bad statuses never throw.
+    [InlineData(StatusCodes.Good)]
+    [InlineData(StatusCodes.Uncertain)]
+    public void WhenBrowseStatusWouldRepeatOnReload_ThenThrowIfTransientErrorDoesNotThrow(uint statusCode)
+    {
+        // Arrange
+        var status = new StatusCode(statusCode);
+
+        // Act & Assert (does not throw)
+        OpcUaStatusCodeClassifier.ThrowIfTransientError(status, "Browse", new NodeId(1));
     }
 }

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -161,6 +161,13 @@ namespace Namotion.Interceptor.OpcUa.Client
         public Opc.Ua.Client.ISession? CurrentSession { get; }
         public Opc.Ua.Client.ISession? PreviousSession { get; }
     }
+    public sealed class OpcUaTransientServiceException : System.Exception
+    {
+        public OpcUaTransientServiceException(string operation, Opc.Ua.NodeId? nodeId, Opc.Ua.StatusCode statusCode) { }
+        public Opc.Ua.NodeId? NodeId { get; }
+        public string Operation { get; }
+        public Opc.Ua.StatusCode StatusCode { get; }
+    }
     public class OpcUaTypeResolver
     {
         public OpcUaTypeResolver(Microsoft.Extensions.Logging.ILogger logger) { }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSessionExtensions.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSessionExtensions.cs
@@ -1,0 +1,500 @@
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Namotion.Interceptor.OpcUa.Client;
+
+internal static class OpcUaSessionExtensions
+{
+    private const uint NodeClassMask = (uint)NodeClass.Variable | (uint)NodeClass.Object;
+
+    // Soft cap when a server reports 0/null (or an int-overflowing value) for its
+    // per-call operation limit. The upper clamp keeps a hostile or buggy server from
+    // producing a negative batch size, which would corrupt the batching loop math.
+    private const int DefaultBatchLimit = 256;
+
+    private static int ToBatchLimit(uint? limit) => limit is > 0 and <= int.MaxValue ? (int)limit : DefaultBatchLimit;
+
+    private static int GetMaxNodesPerBrowse(ISession session) => ToBatchLimit(session.OperationLimits?.MaxNodesPerBrowse);
+
+    private static int GetMaxNodesPerRead(ISession session) => ToBatchLimit(session.OperationLimits?.MaxNodesPerRead);
+
+    /// <summary>
+    /// Browses multiple nodes in batched calls, collecting all references including
+    /// continuation-point pages. Deduplicates input NodeIds; NodeIds whose browse
+    /// returns a permanent bad status are omitted from the result so callers can
+    /// distinguish "browsed successfully (possibly empty)" from "failed this round".
+    /// </summary>
+    public static async Task<Dictionary<NodeId, ReferenceDescriptionCollection>> BrowseNodesAsync(
+        this ISession session,
+        IReadOnlyCollection<NodeId> nodeIds,
+        uint maxReferencesPerNode,
+        int maxContinuationRounds,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<NodeId, ReferenceDescriptionCollection>(nodeIds.Count);
+        if (nodeIds.Count == 0)
+        {
+            return result;
+        }
+
+        var seen = new HashSet<NodeId>(nodeIds.Count);
+        var uniqueNodeIds = new List<NodeId>(nodeIds.Count);
+        foreach (var nodeId in nodeIds)
+        {
+            if (seen.Add(nodeId))
+            {
+                uniqueNodeIds.Add(nodeId);
+            }
+        }
+
+        var batchSize = GetMaxNodesPerBrowse(session);
+
+        for (var offset = 0; offset < uniqueNodeIds.Count; offset += batchSize)
+        {
+            var end = Math.Min(offset + batchSize, uniqueNodeIds.Count);
+            await BrowseBatchAsync(session, uniqueNodeIds, offset, end, maxReferencesPerNode, maxContinuationRounds, result, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Reads multiple node attributes in batched calls with split-and-retry on
+    /// <c>BadTooManyOperations</c>. Returns a positionally aligned
+    /// <see cref="DataValueCollection"/> where <c>allResults[i]</c> corresponds to
+    /// <paramref name="nodesToRead"/>[i]. Short server responses are padded with
+    /// <c>BadUnexpectedError</c> to maintain alignment. Best-effort: bad statuses are
+    /// never thrown here, so each caller decides how to handle them.
+    /// </summary>
+    public static async Task<DataValueCollection> ReadNodesAsync(
+        this ISession session,
+        ReadValueIdCollection nodesToRead,
+        TimestampsToReturn timestampsToReturn,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var allResults = new DataValueCollection(nodesToRead.Count);
+        if (nodesToRead.Count == 0)
+        {
+            return allResults;
+        }
+
+        var maxBatchSize = GetMaxNodesPerRead(session);
+        for (var batchStart = 0; batchStart < nodesToRead.Count; batchStart += maxBatchSize)
+        {
+            var batchEnd = Math.Min(batchStart + maxBatchSize, nodesToRead.Count);
+            await ReadSingleBatchAsync(session, nodesToRead, batchStart, batchEnd, timestampsToReturn, allResults, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        return allResults;
+    }
+
+    /// <summary>
+    /// Deduplicates browse references by resolving each <see cref="ExpandedNodeId"/>
+    /// to a canonical <see cref="NodeId"/> via the session's namespace table.
+    /// References with unresolvable namespace URIs, missing BrowseName, or a duplicate
+    /// resolved NodeId are skipped (each skip is logged) so downstream consumers can
+    /// safely access <c>Reference.BrowseName.Name</c>. Because skips shorten the result,
+    /// consumers that align it positionally (e.g. collection child reuse) can shift.
+    /// </summary>
+    public static List<(ReferenceDescription Reference, NodeId NodeId)> DistinctByResolvedNodeId(
+        this ISession session,
+        IReadOnlyCollection<ReferenceDescription> references,
+        ILogger logger)
+    {
+        var seen = new HashSet<NodeId>(references.Count);
+        var result = new List<(ReferenceDescription, NodeId)>(references.Count);
+        foreach (var reference in references)
+        {
+            if (string.IsNullOrEmpty(reference.BrowseName?.Name))
+            {
+                logger.LogWarning(
+                    "Skipping browse reference with missing BrowseName (NodeId '{NodeId}').",
+                    reference.NodeId);
+                continue;
+            }
+            var nodeId = ExpandedNodeId.ToNodeId(reference.NodeId, session.NamespaceUris);
+            if (nodeId is null)
+            {
+                logger.LogWarning(
+                    "Skipping browse reference '{BrowseName}' with unresolvable NodeId '{NodeId}': namespace URI is not registered in the session's NamespaceTable.",
+                    reference.BrowseName.Name, reference.NodeId);
+                continue;
+            }
+            if (!seen.Add(nodeId))
+            {
+                logger.LogWarning(
+                    "Skipping duplicate browse reference '{BrowseName}' resolving to already-seen NodeId '{NodeId}'.",
+                    reference.BrowseName.Name, nodeId);
+                continue;
+            }
+            result.Add((reference, nodeId));
+        }
+        return result;
+    }
+
+    private static async Task BrowseBatchAsync(
+        ISession session,
+        IReadOnlyList<NodeId> nodeIds,
+        int offset,
+        int end,
+        uint maxReferencesPerNode,
+        int maxContinuationRounds,
+        Dictionary<NodeId, ReferenceDescriptionCollection> result,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var count = end - offset;
+        var browseDescriptions = new BrowseDescriptionCollection(count);
+        for (var i = offset; i < end; i++)
+        {
+            browseDescriptions.Add(new BrowseDescription
+            {
+                NodeId = nodeIds[i],
+                BrowseDirection = BrowseDirection.Forward,
+                ReferenceTypeId = ReferenceTypeIds.HierarchicalReferences,
+                IncludeSubtypes = true,
+                NodeClassMask = NodeClassMask,
+                ResultMask = (uint)BrowseResultMask.All
+            });
+        }
+
+        BrowseResponse response;
+        try
+        {
+            response = await session.BrowseAsync(
+                null, null,
+                maxReferencesPerNode,
+                browseDescriptions,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (ServiceResultException ex) when (count > 1 && OpcUaStatusCodeClassifier.IsBatchTooLarge(ex))
+        {
+            logger.LogWarning(
+                "BrowseAsync rejected batch of {Count} nodes ({StatusCode}). Splitting into smaller batches.",
+                count, ex.StatusCode);
+
+            var midpoint = offset + count / 2;
+            await BrowseBatchAsync(session, nodeIds, offset, midpoint, maxReferencesPerNode, maxContinuationRounds, result, logger, cancellationToken).ConfigureAwait(false);
+            await BrowseBatchAsync(session, nodeIds, midpoint, end, maxReferencesPerNode, maxContinuationRounds, result, logger, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var actual = response.Results.Count;
+        if (actual != count)
+        {
+            logger.LogWarning(
+                "BrowseAsync returned {Actual} results but {Expected} were requested. Clamping to preserve positional alignment.",
+                actual, count);
+        }
+        // Collect continuation points from good in-range results upfront so they can be
+        // released if ThrowIfTransientError aborts during result processing.
+        var continuationPoints = new List<(NodeId NodeId, byte[] ContinuationPoint)>();
+        await CollectContinuationPointsAsync(session, response.Results, count, i => nodeIds[offset + i], continuationPoints, logger).ConfigureAwait(false);
+
+        try
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var nodeId = nodeIds[offset + i];
+                if (i >= actual)
+                {
+                    // Missing result for a requested node: this slot has no result at all. Abort
+                    // so the load retries instead of loading the subject with zero children.
+                    throw new OpcUaTransientServiceException("Browse", nodeId, (StatusCode)StatusCodes.BadUnexpectedError);
+                }
+
+                var browseResult = response.Results[i];
+                if (!StatusCode.IsGood(browseResult.StatusCode))
+                {
+                    OpcUaStatusCodeClassifier.ThrowIfTransientError(browseResult.StatusCode, "Browse", nodeId);
+                    logger.LogWarning(
+                        "BrowseAsync returned permanent bad status for {NodeId} ({StatusCode}); skipping (this NodeId cannot be browsed).",
+                        nodeId, browseResult.StatusCode);
+                    continue;
+                }
+                var bucket = GetOrCreateBucket(result, nodeId);
+                if (browseResult.References is { Count: > 0 })
+                {
+                    bucket.AddRange(browseResult.References);
+                }
+            }
+        }
+        catch
+        {
+            await ReleaseContinuationPointsAsync(session, continuationPoints, logger).ConfigureAwait(false);
+            throw;
+        }
+
+        await ProcessContinuationPointsAsync(session, continuationPoints, maxContinuationRounds, result, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ReferenceDescriptionCollection GetOrCreateBucket(
+        Dictionary<NodeId, ReferenceDescriptionCollection> result, NodeId nodeId)
+    {
+        if (!result.TryGetValue(nodeId, out var bucket))
+        {
+            bucket = new ReferenceDescriptionCollection();
+            result[nodeId] = bucket;
+        }
+        return bucket;
+    }
+
+    private static async Task ProcessContinuationPointsAsync(
+        ISession session,
+        List<(NodeId NodeId, byte[] ContinuationPoint)> initialPoints,
+        int maxContinuationRounds,
+        Dictionary<NodeId, ReferenceDescriptionCollection> result,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var current = initialPoints;
+        var next = new List<(NodeId NodeId, byte[] ContinuationPoint)>();
+        var round = 0;
+        var batchSize = GetMaxNodesPerBrowse(session);
+        try
+        {
+            while (current.Count > 0)
+            {
+                // One round drains every currently-pending continuation point, possibly
+                // in multiple BrowseNextAsync calls (the inner loop batches by
+                // GetMaxNodesPerBrowse). The cap therefore bounds pagination *depth*,
+                // i.e. how many times the server can keep handing out fresh continuation
+                // points before we give up. It does not bound BrowseNext call count,
+                // which legitimately scales with the number of in-flight continuation
+                // points per round.
+                if (++round > maxContinuationRounds)
+                {
+                    logger.LogWarning(
+                        "Aborting BrowseNext after {MaxRounds} rounds with {Remaining} continuation points still pending. Possible server bug.",
+                        maxContinuationRounds, current.Count);
+                    break;
+                }
+
+                for (var offset = 0; offset < current.Count; offset += batchSize)
+                {
+                    var end = Math.Min(offset + batchSize, current.Count);
+                    await BrowseNextBatchAsync(session, current, offset, end, result, next, logger, cancellationToken).ConfigureAwait(false);
+                }
+
+                (current, next) = (next, current);
+                next.Clear();
+            }
+        }
+        catch
+        {
+            await ReleaseContinuationPointsAsync(session, current, logger).ConfigureAwait(false);
+            await ReleaseContinuationPointsAsync(session, next, logger).ConfigureAwait(false);
+            throw;
+        }
+
+        // Only non-empty when the round cap broke out of the loop early; no-op otherwise.
+        await ReleaseContinuationPointsAsync(session, current, logger).ConfigureAwait(false);
+    }
+
+    private static async Task ReleaseContinuationPointsAsync(
+        ISession session,
+        List<(NodeId NodeId, byte[] ContinuationPoint)> continuationPoints,
+        ILogger logger)
+    {
+        if (continuationPoints.Count == 0)
+        {
+            return;
+        }
+
+        using var releaseTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var batchSize = GetMaxNodesPerBrowse(session);
+        for (var offset = 0; offset < continuationPoints.Count; offset += batchSize)
+        {
+            try
+            {
+                var end = Math.Min(offset + batchSize, continuationPoints.Count);
+                var collection = new ByteStringCollection(end - offset);
+                for (var i = offset; i < end; i++)
+                {
+                    collection.Add(continuationPoints[i].ContinuationPoint);
+                }
+                await session.BrowseNextAsync(null, true, collection, releaseTimeout.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Best-effort release of continuation points failed at offset {Offset}.", offset);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Routes continuation points from a browse or browse-next response: good in-range results go to
+    /// <paramref name="goodPoints"/> (the caller releases these if it later aborts), while bad-status
+    /// results and any extras the server returned beyond <paramref name="count"/> are released
+    /// immediately so unfollowed pages do not leak server-side.
+    /// </summary>
+    private static async Task CollectContinuationPointsAsync(
+        ISession session,
+        BrowseResultCollection results,
+        int count,
+        Func<int, NodeId> nodeIdAt,
+        List<(NodeId NodeId, byte[] ContinuationPoint)> goodPoints,
+        ILogger logger)
+    {
+        List<(NodeId NodeId, byte[] ContinuationPoint)>? orphanedPoints = null;
+        for (var i = 0; i < results.Count; i++)
+        {
+            if (results[i].ContinuationPoint is { Length: > 0 } continuationPoint)
+            {
+                if (i < count && StatusCode.IsGood(results[i].StatusCode))
+                {
+                    goodPoints.Add((nodeIdAt(i), continuationPoint));
+                }
+                else
+                {
+                    (orphanedPoints ??= []).Add((i < count ? nodeIdAt(i) : NodeId.Null, continuationPoint));
+                }
+            }
+        }
+
+        if (orphanedPoints is { Count: > 0 })
+        {
+            await ReleaseContinuationPointsAsync(session, orphanedPoints, logger).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task BrowseNextBatchAsync(
+        ISession session,
+        List<(NodeId NodeId, byte[] ContinuationPoint)> current,
+        int offset,
+        int end,
+        Dictionary<NodeId, ReferenceDescriptionCollection> result,
+        List<(NodeId NodeId, byte[] ContinuationPoint)> next,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var count = end - offset;
+        var continuationPointCollection = new ByteStringCollection(count);
+        for (var i = offset; i < end; i++)
+        {
+            continuationPointCollection.Add(current[i].ContinuationPoint);
+        }
+
+        BrowseNextResponse nextResponse;
+        try
+        {
+            nextResponse = await session.BrowseNextAsync(
+                null, false, continuationPointCollection, cancellationToken).ConfigureAwait(false);
+        }
+        catch (ServiceResultException ex) when (count > 1 && OpcUaStatusCodeClassifier.IsBatchTooLarge(ex))
+        {
+            logger.LogWarning(
+                "BrowseNextAsync rejected batch of {Count} continuation points ({StatusCode}). Splitting into smaller batches.",
+                count, ex.StatusCode);
+
+            var midpoint = offset + count / 2;
+            await BrowseNextBatchAsync(session, current, offset, midpoint, result, next, logger, cancellationToken).ConfigureAwait(false);
+            await BrowseNextBatchAsync(session, current, midpoint, end, result, next, logger, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var actual = nextResponse.Results.Count;
+        if (actual != count)
+        {
+            logger.LogWarning(
+                "BrowseNextAsync returned {Actual} results but {Expected} were requested. Clamping to preserve positional alignment.",
+                actual, count);
+        }
+
+        // Collect fresh continuation points into `next` (the caller releases them on abort)
+        // before the processing loop can throw.
+        await CollectContinuationPointsAsync(session, nextResponse.Results, count, i => current[offset + i].NodeId, next, logger).ConfigureAwait(false);
+
+        for (var i = 0; i < count; i++)
+        {
+            var nodeId = current[offset + i].NodeId;
+            if (i >= actual)
+            {
+                // Server returned fewer results than continuation points sent: this slot has no
+                // result at all. Abort so the load retries instead of silently truncating this
+                // node's children. The caller's catch releases the continuation point still
+                // pending in `current` for this slot.
+                throw new OpcUaTransientServiceException("BrowseNext", nodeId, (StatusCode)StatusCodes.BadUnexpectedError);
+            }
+
+            var browseResult = nextResponse.Results[i];
+            if (!StatusCode.IsGood(browseResult.StatusCode))
+            {
+                OpcUaStatusCodeClassifier.ThrowIfTransientError(browseResult.StatusCode, "BrowseNext", nodeId);
+                logger.LogWarning(
+                    "BrowseNextAsync returned permanent bad status for {NodeId} ({StatusCode}); the partial result so far is retained.",
+                    nodeId, browseResult.StatusCode);
+                continue;
+            }
+            if (browseResult.References is { Count: > 0 })
+            {
+                GetOrCreateBucket(result, nodeId).AddRange(browseResult.References);
+            }
+        }
+    }
+
+    private static async Task ReadSingleBatchAsync(
+        ISession session,
+        ReadValueIdCollection nodesToRead,
+        int batchStart,
+        int batchEnd,
+        TimestampsToReturn timestampsToReturn,
+        DataValueCollection allResults,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var count = batchEnd - batchStart;
+        var chunk = new ReadValueIdCollection(count);
+        for (var i = batchStart; i < batchEnd; i++)
+        {
+            chunk.Add(nodesToRead[i]);
+        }
+
+        ReadResponse response;
+        try
+        {
+            response = await session.ReadAsync(null, 0, timestampsToReturn, chunk, cancellationToken).ConfigureAwait(false);
+        }
+        catch (ServiceResultException ex) when (count > 1 && OpcUaStatusCodeClassifier.IsBatchTooLarge(ex))
+        {
+            logger.LogWarning(
+                "ReadAsync rejected batch of {Count} items ({StatusCode}). Splitting into smaller batches.",
+                count, ex.StatusCode);
+
+            // Halving may split a caller's logical pair (e.g. DataType+ValueRank) across
+            // two batches. That's safe: each sub-batch is independently padded to its
+            // requested length, so the flat allResults stays aligned with nodesToRead.
+            var midpoint = batchStart + count / 2;
+            await ReadSingleBatchAsync(session, nodesToRead, batchStart, midpoint, timestampsToReturn, allResults, logger, cancellationToken).ConfigureAwait(false);
+            await ReadSingleBatchAsync(session, nodesToRead, midpoint, batchEnd, timestampsToReturn, allResults, logger, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var actual = response.Results.Count;
+        if (actual == count)
+        {
+            allResults.AddRange(response.Results);
+        }
+        else
+        {
+            logger.LogWarning(
+                "ReadAsync returned {Actual} results but {Expected} were requested. Padding to preserve positional alignment.",
+                actual, count);
+
+            var take = Math.Min(actual, count);
+            for (var i = 0; i < take; i++)
+            {
+                allResults.Add(response.Results[i]);
+            }
+            // Pad missing trailing slots so allResults stays aligned with nodesToRead.
+            // This primitive never throws; callers classify the bad status themselves.
+            for (var i = take; i < count; i++)
+            {
+                allResults.Add(new DataValue { StatusCode = StatusCodes.BadUnexpectedError });
+            }
+        }
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSessionExtensions.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSessionExtensions.cs
@@ -20,10 +20,32 @@ internal static class OpcUaSessionExtensions
     private static int GetMaxNodesPerRead(ISession session) => ToBatchLimit(session.OperationLimits?.MaxNodesPerRead);
 
     /// <summary>
+    /// Batch size for calls that can leave continuation points open. The continuation-point quota
+    /// is a separate and much smaller limit than the per-call operation limit (SDK servers default
+    /// to 10 against a MaxNodesPerBrowse of 2500), and a batch larger than the quota either fails
+    /// with <c>BadNoContinuationPoints</c> or has its oldest points evicted and then fails
+    /// BrowseNext with <c>BadContinuationPointInvalid</c>. Both are permanent for the load, so
+    /// retrying with the same batch size would fail identically: capping is what makes it converge.
+    /// Mirrors what <c>Opc.Ua.Client.Browser</c> does for the same reason.
+    /// </summary>
+    private static int GetBrowseBatchSize(ISession session)
+    {
+        var operationLimit = GetMaxNodesPerBrowse(session);
+
+        // Declared non-nullable by ISession, but a partially initialized or mocked session can
+        // still hand back null, and a server that does not expose the node reports 0.
+        int continuationPointLimit = session.ServerCapabilities?.MaxBrowseContinuationPoints ?? 0;
+        return continuationPointLimit > 0 && continuationPointLimit < operationLimit
+            ? continuationPointLimit
+            : operationLimit;
+    }
+
+    /// <summary>
     /// Browses multiple nodes in batched calls, collecting all references including
-    /// continuation-point pages. Deduplicates input NodeIds; NodeIds whose browse
-    /// returns a permanent bad status are omitted from the result so callers can
-    /// distinguish "browsed successfully (possibly empty)" from "failed this round".
+    /// continuation-point pages. Deduplicates input NodeIds. A NodeId present in the result was
+    /// browsed to completion (possibly to an empty reference list); one that failed this round,
+    /// whether the first page returned a permanent bad status or pagination stopped part-way, is
+    /// omitted rather than reported with a truncated child list.
     /// </summary>
     public static async Task<Dictionary<NodeId, ReferenceDescriptionCollection>> BrowseNodesAsync(
         this ISession session,
@@ -49,7 +71,7 @@ internal static class OpcUaSessionExtensions
             }
         }
 
-        var batchSize = GetMaxNodesPerBrowse(session);
+        var batchSize = GetBrowseBatchSize(session);
 
         for (var offset = 0; offset < uniqueNodeIds.Count; offset += batchSize)
         {
@@ -125,7 +147,9 @@ internal static class OpcUaSessionExtensions
             }
             if (!seen.Add(nodeId))
             {
-                logger.LogWarning(
+                // Debug, not Warning: a node reachable through more than one hierarchical
+                // reference is normal in OPC UA address spaces, so this is expected traffic.
+                logger.LogDebug(
                     "Skipping duplicate browse reference '{BrowseName}' resolving to already-seen NodeId '{NodeId}'.",
                     reference.BrowseName.Name, nodeId);
                 continue;
@@ -185,8 +209,10 @@ internal static class OpcUaSessionExtensions
         var actual = response.Results.Count;
         if (actual != count)
         {
+            // Extras are ignored (their continuation points are still released below); a short
+            // response aborts the load once the processing loop reaches the first missing slot.
             logger.LogWarning(
-                "BrowseAsync returned {Actual} results but {Expected} were requested. Clamping to preserve positional alignment.",
+                "BrowseAsync returned {Actual} results but {Expected} were requested.",
                 actual, count);
         }
         // Collect continuation points from good in-range results upfront so they can be
@@ -253,14 +279,14 @@ internal static class OpcUaSessionExtensions
         var current = initialPoints;
         var next = new List<(NodeId NodeId, byte[] ContinuationPoint)>();
         var round = 0;
-        var batchSize = GetMaxNodesPerBrowse(session);
+        var batchSize = GetBrowseBatchSize(session);
         try
         {
             while (current.Count > 0)
             {
                 // One round drains every currently-pending continuation point, possibly
                 // in multiple BrowseNextAsync calls (the inner loop batches by
-                // GetMaxNodesPerBrowse). The cap therefore bounds pagination *depth*,
+                // GetBrowseBatchSize). The cap therefore bounds pagination *depth*,
                 // i.e. how many times the server can keep handing out fresh continuation
                 // points before we give up. It does not bound BrowseNext call count,
                 // which legitimately scales with the number of in-flight continuation
@@ -270,6 +296,15 @@ internal static class OpcUaSessionExtensions
                     logger.LogWarning(
                         "Aborting BrowseNext after {MaxRounds} rounds with {Remaining} continuation points still pending. Possible server bug.",
                         maxContinuationRounds, current.Count);
+
+                    // Those nodes are still mid-pagination, so what was collected is a prefix of
+                    // their children. Drop it: the contract is that a NodeId present in the result
+                    // was browsed completely, and a truncated child list would make positional
+                    // consumers replace a collection with a shortened one.
+                    foreach (var (nodeId, _) in current)
+                    {
+                        result.Remove(nodeId);
+                    }
                     break;
                 }
 
@@ -304,12 +339,16 @@ internal static class OpcUaSessionExtensions
             return;
         }
 
-        using var releaseTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        // Releasing frees continuation points rather than consuming them, so the quota does not
+        // apply and the plain operation limit is the right batch size here.
         var batchSize = GetMaxNodesPerBrowse(session);
         for (var offset = 0; offset < continuationPoints.Count; offset += batchSize)
         {
             try
             {
+                // Per batch, not shared: one shared budget would let a slow first batch consume
+                // the whole timeout and cancel every remaining release without ever calling.
+                using var releaseTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                 var end = Math.Min(offset + batchSize, continuationPoints.Count);
                 var collection = new ByteStringCollection(end - offset);
                 for (var i = offset; i < end; i++)
@@ -399,8 +438,9 @@ internal static class OpcUaSessionExtensions
         var actual = nextResponse.Results.Count;
         if (actual != count)
         {
+            // Same handling as Browse: extras are released as orphans, a short response aborts.
             logger.LogWarning(
-                "BrowseNextAsync returned {Actual} results but {Expected} were requested. Clamping to preserve positional alignment.",
+                "BrowseNextAsync returned {Actual} results but {Expected} were requested.",
                 actual, count);
         }
 
@@ -425,8 +465,9 @@ internal static class OpcUaSessionExtensions
             {
                 OpcUaStatusCodeClassifier.ThrowIfTransientError(browseResult.StatusCode, "BrowseNext", nodeId);
                 logger.LogWarning(
-                    "BrowseNextAsync returned permanent bad status for {NodeId} ({StatusCode}); the partial result so far is retained.",
+                    "BrowseNextAsync returned permanent bad status for {NodeId} ({StatusCode}); dropping the pages collected so far because the child list would be truncated.",
                     nodeId, browseResult.StatusCode);
+                result.Remove(nodeId);
                 continue;
             }
             if (browseResult.References is { Count: > 0 })
@@ -447,10 +488,21 @@ internal static class OpcUaSessionExtensions
         CancellationToken cancellationToken)
     {
         var count = batchEnd - batchStart;
-        var chunk = new ReadValueIdCollection(count);
-        for (var i = batchStart; i < batchEnd; i++)
+
+        ReadValueIdCollection chunk;
+        if (count == nodesToRead.Count)
         {
-            chunk.Add(nodesToRead[i]);
+            // Everything fits in one call, which is the common case: send the caller's collection
+            // as-is rather than copying it. ReadAsync does not mutate the request.
+            chunk = nodesToRead;
+        }
+        else
+        {
+            chunk = new ReadValueIdCollection(count);
+            for (var i = batchStart; i < batchEnd; i++)
+            {
+                chunk.Add(nodesToRead[i]);
+            }
         }
 
         ReadResponse response;

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaStatusCodeClassifier.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaStatusCodeClassifier.cs
@@ -3,32 +3,40 @@ using Opc.Ua;
 namespace Namotion.Interceptor.OpcUa.Client;
 
 /// <summary>
-/// Classifies OPC UA <see cref="StatusCode"/>s as transient (worth retrying) or permanent.
-/// A single shared list backs every callsite, so a code is classified the same way whether
-/// it surfaced from a write or from a subscription.
+/// Classifies OPC UA <see cref="StatusCode"/>s for retry decisions. Two questions are asked at
+/// different callsites, and the access-scoped codes answer them oppositely, so there are two
+/// predicates rather than one shared list.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Permanent means <em>the answer cannot change without a new session</em>, not merely that
-/// re-issuing the request right now returns the same status. Access-scoped codes such as
-/// <c>BadUserAccessDenied</c>, <c>BadNotReadable</c> and <c>BadNotImplemented</c> are therefore
-/// treated as transient: role permissions and the <c>AccessLevel</c> attribute are mutable
-/// server-side, so the same request can start succeeding mid-session. <c>BadSecurityModeInsufficient</c>
-/// is permanent because it is bound to the SecureChannel's <c>MessageSecurityMode</c>, which can
-/// only change by establishing a new channel, and reconnect re-attempts everything anyway.
+/// <see cref="IsTransientError"/> answers <em>can this recover without a new session?</em> It backs
+/// the subscribe and write paths. Access-scoped codes (<c>BadUserAccessDenied</c>,
+/// <c>BadNotReadable</c>, <c>BadNotImplemented</c>) are transient here: role permissions and the
+/// <c>AccessLevel</c> attribute are mutable server-side, so a monitored item can start succeeding
+/// mid-session and must be kept for retry rather than dropped. <c>BadSecurityModeInsufficient</c> is
+/// permanent because it is bound to the SecureChannel's <c>MessageSecurityMode</c>, which can only
+/// change by opening a new channel, and reconnect re-attempts everything anyway.
 /// </para>
 /// <para>
-/// This type only classifies; each caller decides the disposition. Subscription setup acts on it
-/// via <c>FailedMonitoredItemDisposition</c>, where a permanent code drops the monitored item and
-/// forfeits both in-session recovery routes (health-monitor healing and escalation to polling).
-/// The write path currently uses it for diagnostics only: <c>WriteResult.FailedChanges</c> must
-/// stay complete for the retry queue and the transaction writer, so permanently-failed writes are
-/// still requeued (#332).
+/// <see cref="ThrowIfTransientError"/> answers <em>would aborting and reloading now help?</em> It
+/// backs the browse and read paths, where a transient status aborts the load so reconnect retries
+/// and a permanent one is logged and skipped. Here the access-scoped codes are permanent: they
+/// repeat immediately on reload (the session's identity and permissions have not changed), so
+/// throwing would crash-loop the whole load instead of skipping the one unreachable node. That
+/// makes the load-skip set a superset of the session-permanent set by exactly those three codes.
+/// </para>
+/// <para>
+/// The write path uses <see cref="IsTransientError"/> for diagnostics only:
+/// <c>WriteResult.FailedChanges</c> must stay complete for the retry queue and the transaction
+/// writer, so permanently-failed writes are still requeued (#332).
 /// </para>
 /// </remarks>
 internal static class OpcUaStatusCodeClassifier
 {
-    private static readonly HashSet<uint> PermanentCodes =
+    /// <summary>
+    /// Bad statuses that cannot recover without a new session. Used by the subscribe and write paths.
+    /// </summary>
+    private static readonly HashSet<uint> SessionPermanentCodes =
     [
         StatusCodes.BadNodeIdUnknown,
         StatusCodes.BadNodeIdInvalid,
@@ -41,12 +49,49 @@ internal static class OpcUaStatusCodeClassifier
     ];
 
     /// <summary>
-    /// True iff <paramref name="statusCode"/> is a bad status that could succeed on
-    /// retry (e.g. transport glitch, server-side resource exhaustion). Returns false
-    /// for good and uncertain statuses, and for permanent design-time errors.
+    /// Bad statuses where reloading the structure now cannot help, so the browse/read caller skips
+    /// the node instead of aborting the load. Superset of <see cref="SessionPermanentCodes"/> by the
+    /// access-scoped codes, which are deterministic for the current session even though they may
+    /// recover over a longer horizon.
+    /// </summary>
+    private static readonly HashSet<uint> LoadSkipCodes =
+    [
+        .. SessionPermanentCodes,
+        StatusCodes.BadUserAccessDenied,
+        StatusCodes.BadNotReadable,
+        StatusCodes.BadNotImplemented
+    ];
+
+    /// <summary>
+    /// True iff <paramref name="statusCode"/> is a bad status that could recover without a new
+    /// session (e.g. transport glitch, server-side resource exhaustion, a later permission grant).
+    /// Returns false for good and uncertain statuses. Used by the subscribe and write paths.
     /// </summary>
     public static bool IsTransientError(StatusCode statusCode)
     {
-        return StatusCode.IsBad(statusCode) && !PermanentCodes.Contains(statusCode.Code);
+        return StatusCode.IsBad(statusCode) && !SessionPermanentCodes.Contains(statusCode.Code);
     }
+
+    /// <summary>
+    /// Throws <see cref="OpcUaTransientServiceException"/> if <paramref name="statusCode"/> is a bad
+    /// status that a fresh load could clear, so the browse/read caller aborts and lets reconnect
+    /// retry. Statuses that would repeat immediately on reload (permanent design-time and
+    /// access-scoped codes) and non-bad statuses are ignored, so the caller logs and skips the node.
+    /// </summary>
+    public static void ThrowIfTransientError(StatusCode statusCode, string operation, NodeId? nodeId)
+    {
+        if (StatusCode.IsBad(statusCode) && !LoadSkipCodes.Contains(statusCode.Code))
+        {
+            throw new OpcUaTransientServiceException(operation, nodeId, statusCode);
+        }
+    }
+
+    /// <summary>
+    /// True iff the <see cref="ServiceResultException"/> indicates the server rejected
+    /// the batch size rather than the operation itself.
+    /// </summary>
+    public static bool IsBatchTooLarge(ServiceResultException exception) =>
+        exception.StatusCode is StatusCodes.BadTooManyOperations
+            or StatusCodes.BadEncodingLimitsExceeded
+            or StatusCodes.BadResponseTooLarge;
 }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaStatusCodeClassifier.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaStatusCodeClassifier.cs
@@ -93,5 +93,6 @@ internal static class OpcUaStatusCodeClassifier
     public static bool IsBatchTooLarge(ServiceResultException exception) =>
         exception.StatusCode is StatusCodes.BadTooManyOperations
             or StatusCodes.BadEncodingLimitsExceeded
+            or StatusCodes.BadRequestTooLarge
             or StatusCodes.BadResponseTooLarge;
 }

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaTransientServiceException.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaTransientServiceException.cs
@@ -1,0 +1,32 @@
+using Opc.Ua;
+
+namespace Namotion.Interceptor.OpcUa.Client;
+
+/// <summary>
+/// Thrown when a per-NodeId OPC UA operation (browse, browse-next, read) returns a
+/// transient bad status during session work. The owning subject source treats this
+/// as a load failure and lets the session reconnect logic retry from scratch.
+/// Permanent bad statuses do not raise this exception; they are logged and skipped.
+/// </summary>
+/// <remarks>
+/// External callers can observe instances of this type via <c>OpcUaClientDiagnostics.LastError</c>
+/// and through the hosting framework's error pipeline when initial connect or reconnect fails.
+/// The type is public so consumers can branch on it (vs. fatal exceptions) when deciding how
+/// to surface OPC UA errors in their own observability surface.
+/// </remarks>
+public sealed class OpcUaTransientServiceException : Exception
+{
+    public string Operation { get; }
+
+    public NodeId? NodeId { get; }
+
+    public StatusCode StatusCode { get; }
+
+    public OpcUaTransientServiceException(string operation, NodeId? nodeId, StatusCode statusCode)
+        : base($"OPC UA {operation} returned transient status {statusCode} for NodeId {nodeId}. The load will be aborted and retried via session reconnect.")
+    {
+        Operation = operation;
+        NodeId = nodeId;
+        StatusCode = statusCode;
+    }
+}


### PR DESCRIPTION
## Summary

First of three stacked PRs splitting #357. This one carries the protocol-level layer only, with no behavior change: nothing on master calls the new primitives yet, so it is purely additive.

- **`OpcUaSessionExtensions`** (internal): `BrowseNodesAsync` and `ReadNodesAsync` batch by the server's reported operation limits, follow BrowseNext continuation points under a bounded round cap, split and retry when the server rejects the batch size, and keep results positionally aligned with the request by padding short responses. Continuation points are released on every abort path so unfollowed pages do not leak server-side. `DistinctByResolvedNodeId` resolves and deduplicates browse references so consumers can rely on a non-null `BrowseName`.
- **`OpcUaStatusCodeClassifier`**: splits the single permanent-code set into `SessionPermanentCodes` and `LoadSkipCodes`. The access-scoped codes (`BadUserAccessDenied`, `BadNotReadable`, `BadNotImplemented`) answer the two questions oppositely. A monitored item must be retried because role permissions and `AccessLevel` can change mid-session, but a browse or read must skip the node rather than crash-loop the whole load. `IsTransientError` keeps its existing behavior and code set; `ThrowIfTransientError` and `IsBatchTooLarge` are new.
- **`OpcUaTransientServiceException`**: carries operation, node id, and status code so consumers can branch on transient load failures via `OpcUaClientDiagnostics.LastError`.

### Browse batches are capped by the continuation-point quota, not just the operation limit

`MaxNodesPerBrowse` is not the binding constraint for a browse that pages. The server's continuation-point quota is a separate and much smaller limit (SDK servers default to 10, against a `MaxNodesPerBrowse` of 2500), enforced both per Browse call and per session. Sizing a batch by the operation limit alone means holding more continuation points open than the server allows, which either fails the call with `BadNoContinuationPoints` or silently evicts the oldest points so the follow-up BrowseNext fails with `BadContinuationPointInvalid`. Neither is in `LoadSkipCodes`, so the load aborts, reconnect retries with the identical batch size, and it fails the same way: a loop that never converges.

Browse and BrowseNext batches are therefore sized at `min(MaxNodesPerBrowse, MaxBrowseContinuationPoints)`, which is what `Opc.Ua.Client.Browser` does for the same reason. Release calls still use the plain operation limit, since releasing frees continuation points rather than consuming them.

### Result contract

A NodeId present in the browse result was browsed to completion, possibly to an empty reference list. A NodeId that failed this round is omitted rather than reported with a truncated child list. That covers three cases: a permanent bad status on the first page, pagination stopping at the round cap, and a permanent bad status on a BrowseNext page. Consumers align collection children positionally, so a short list would replace a collection with the wrong contents instead of leaving it alone for the next load to retry.

## Public API

One additive type, `OpcUaTransientServiceException`. No removals, no signature changes. Snapshot updated.

## Test Plan

- [x] `dotnet build src/Namotion.Interceptor.slnx` clean
- [x] OPC UA test project: 313 passed
- [x] `OpcUaSessionExtensionsTests` cover the continuation-point quota cap, split-and-retry, continuation-point release on abort, both partial-pagination drops, multi-round paging, short-response padding, and transient-versus-permanent status handling
- [x] Public API snapshot accepted

Note: `OpcUaDataTypesTests.NullableGuidType_ShouldSyncBothDirections` is a pre-existing flake on `master` (one failure in four runs on an unmodified master worktree), not introduced by this stack.

## Stack

1. **This PR**: session primitives and status classification
2. #398: subscription callback gating and sweep ordering
3. #357: the four-phase loader itself
