### PR TITLE
Gate OPC UA data-change callbacks during subscription setup and sweep before read-after-write

### DIFF
--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionCallbackGatingTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionCallbackGatingTests.cs
@@ -1,0 +1,27 @@
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+public class OpcUaSubscriptionCallbackGatingTests
+{
+    [Fact]
+    public void WhenDataChangeArrivesBeforeSetupCompletes_ThenNotificationIsIgnored()
+    {
+        // Arrange
+        var harness = SubscriptionManagerTestHarness.Create();
+        harness.RegisterMonitoredItem(clientHandle: 7, propertyName: "Value");
+
+        var timestamp = DateTimeOffset.UtcNow;
+
+        // Act - apply before gate is open (_callbacksEnabled is false)
+        harness.Manager.ApplyDataChange(7, timestamp, 42d);
+
+        // Assert - gate blocked the write
+        Assert.NotEqual(42d, harness.GetValue("Value"));
+
+        // Act - open the gate, then apply the same change
+        harness.Manager.EnableCallbacksForTesting();
+        harness.Manager.ApplyDataChange(7, timestamp, 42d);
+
+        // Assert - write is now applied
+        Assert.Equal(42d, harness.GetValue("Value"));
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionCallbackGatingTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionCallbackGatingTests.cs
@@ -1,3 +1,5 @@
+using Opc.Ua;
+
 namespace Namotion.Interceptor.OpcUa.Tests.Client;
 
 public class OpcUaSubscriptionCallbackGatingTests
@@ -9,19 +11,35 @@ public class OpcUaSubscriptionCallbackGatingTests
         var harness = SubscriptionManagerTestHarness.Create();
         harness.RegisterMonitoredItem(clientHandle: 7, propertyName: "Value");
 
-        var timestamp = DateTimeOffset.UtcNow;
+        var notification = CreateNotification(clientHandle: 7, value: 42d);
 
-        // Act - apply before gate is open (_callbacksEnabled is false)
-        harness.Manager.ApplyDataChange(7, timestamp, 42d);
+        // Act: deliver before setup completes, so the gate is still closed
+        harness.Manager.OnFastDataChangeForTesting(notification);
 
-        // Assert - gate blocked the write
+        // Assert
         Assert.NotEqual(42d, harness.GetValue("Value"));
 
-        // Act - open the gate, then apply the same change
-        harness.Manager.EnableCallbacksForTesting();
-        harness.Manager.ApplyDataChange(7, timestamp, 42d);
+        // Act: complete setup (which opens the gate) and deliver the same notification
+        harness.Manager.CompleteSetupForTesting([]);
+        harness.Manager.OnFastDataChangeForTesting(notification);
 
-        // Assert - write is now applied
+        // Assert
         Assert.Equal(42d, harness.GetValue("Value"));
+    }
+
+    private static DataChangeNotification CreateNotification(uint clientHandle, object value)
+    {
+        return new DataChangeNotification
+        {
+            MonitoredItems =
+            [
+                new MonitoredItemNotification
+                {
+                    ClientHandle = clientHandle,
+                    Value = new DataValue(new Variant(value), StatusCodes.Good, DateTime.UtcNow)
+                }
+            ],
+            DiagnosticInfos = []
+        };
     }
 }

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionSweepOrderingTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionSweepOrderingTests.cs
@@ -1,0 +1,34 @@
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+public class OpcUaSubscriptionSweepOrderingTests
+{
+    [Fact]
+    public void WhenSubjectDetachesDuringSetup_ThenItIsSweptAndNeverRegisteredForReadAfterWrite()
+    {
+        // Arrange
+        var harness = SubscriptionManagerTestHarness.CreateWithReadAfterWriteSpy();
+
+        var survivorProperty = harness.RegisterMonitoredItem(clientHandle: 1, propertyName: "Kept");
+        var detachedProperty = harness.RegisterMonitoredItemThenDetachSubject(clientHandle: 2, propertyName: "Gone");
+
+        // Build the snapshot BEFORE the sweep so both handles are still present
+        // (matching how production gathers monitoredItems after ApplyChanges but before sweep).
+        var snapshotBeforeSweep = new[]
+        {
+            CreatedMonitoredItem.Create(1, new Opc.Ua.NodeId(1u, 2), 0, survivorProperty),
+            CreatedMonitoredItem.Create(2, new Opc.Ua.NodeId(2u, 2), 0, detachedProperty)
+        };
+
+        // Act
+        harness.Manager.SweepDetachedSubjectsForTesting();
+        harness.Manager.RegisterSurvivorsForReadAfterWriteForTesting(snapshotBeforeSweep);
+
+        // Assert: the sweep removed the detached subject's handle (2) and kept the survivor (1)
+        Assert.False(harness.Manager.MonitoredItemsForTesting.ContainsKey(2));
+        Assert.True(harness.Manager.MonitoredItemsForTesting.ContainsKey(1));
+
+        // Assert: only the survivor is registered for read-after-write
+        Assert.Contains(survivorProperty, harness.ReadAfterWriteSpy!.RegisteredSubjects);
+        Assert.DoesNotContain(detachedProperty, harness.ReadAfterWriteSpy!.RegisteredSubjects);
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionSweepOrderingTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaSubscriptionSweepOrderingTests.cs
@@ -11,17 +11,17 @@ public class OpcUaSubscriptionSweepOrderingTests
         var survivorProperty = harness.RegisterMonitoredItem(clientHandle: 1, propertyName: "Kept");
         var detachedProperty = harness.RegisterMonitoredItemThenDetachSubject(clientHandle: 2, propertyName: "Gone");
 
-        // Build the snapshot BEFORE the sweep so both handles are still present
-        // (matching how production gathers monitoredItems after ApplyChanges but before sweep).
-        var snapshotBeforeSweep = new[]
+        // The item list is built before setup completes, so it still contains both handles. This
+        // matches production, where the list comes from the SDK subscriptions and the sweep only
+        // prunes the manager's own dictionary.
+        var itemsFromSubscriptions = new[]
         {
             CreatedMonitoredItem.Create(1, new Opc.Ua.NodeId(1u, 2), 0, survivorProperty),
             CreatedMonitoredItem.Create(2, new Opc.Ua.NodeId(2u, 2), 0, detachedProperty)
         };
 
-        // Act
-        harness.Manager.SweepDetachedSubjectsForTesting();
-        harness.Manager.RegisterSurvivorsForReadAfterWriteForTesting(snapshotBeforeSweep);
+        // Act: the whole completion sequence, so reordering sweep and registration fails the test
+        harness.Manager.CompleteSetupForTesting(itemsFromSubscriptions);
 
         // Assert: the sweep removed the detached subject's handle (2) and kept the survivor (1)
         Assert.False(harness.Manager.MonitoredItemsForTesting.ContainsKey(2));

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/SubscriptionManagerTestHarness.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/SubscriptionManagerTestHarness.cs
@@ -1,0 +1,241 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Dynamic;
+using Namotion.Interceptor.OpcUa.Client;
+using Namotion.Interceptor.OpcUa.Client.Connection;
+using Namotion.Interceptor.OpcUa.Client.ReadAfterWrite;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Abstractions;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Lifecycle;
+using Opc.Ua;
+using Opc.Ua.Client;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Client;
+
+/// <summary>
+/// Shared test harness for SubscriptionManager unit tests.
+/// Wires up a DynamicSubject, OpcUaSubjectClientSource, and SubscriptionManager
+/// without a live OPC UA session. The SubjectPropertyWriter is put into the
+/// applying (non-buffering) state by calling StartBuffering + LoadInitialStateAndResumeAsync
+/// against a mock ISubjectSource that returns null initial state.
+/// </summary>
+internal sealed class SubscriptionManagerTestHarness
+{
+    private readonly IInterceptorSubject _subject;
+
+    public SubscriptionManager Manager { get; }
+    public OpcUaSubjectClientSource Source { get; }
+    public SubjectPropertyWriter PropertyWriter { get; }
+
+    /// <summary>
+    /// Read-after-write spy injected by <see cref="CreateWithReadAfterWriteSpy"/>.
+    /// Null when built with <see cref="Create"/>.
+    /// </summary>
+    public ReadAfterWriteRegistrarSpy? ReadAfterWriteSpy { get; }
+
+    private SubscriptionManagerTestHarness(
+        IInterceptorSubject subject,
+        OpcUaSubjectClientSource source,
+        SubjectPropertyWriter propertyWriter,
+        SubscriptionManager manager,
+        ReadAfterWriteRegistrarSpy? readAfterWriteSpy = null)
+    {
+        _subject = subject;
+        Source = source;
+        PropertyWriter = propertyWriter;
+        Manager = manager;
+        ReadAfterWriteSpy = readAfterWriteSpy;
+    }
+
+    public static SubscriptionManagerTestHarness Create()
+        => Build(readAfterWriteRegistrar: null);
+
+    /// <summary>
+    /// Builds the harness with a recording <see cref="ReadAfterWriteRegistrarSpy"/> injected
+    /// as the SubscriptionManager's read-after-write registrar.
+    /// The spy records every <c>RegisterProperty</c> call unconditionally (no filter).
+    /// </summary>
+    public static SubscriptionManagerTestHarness CreateWithReadAfterWriteSpy()
+    {
+        var spy = new ReadAfterWriteRegistrarSpy();
+        return Build(spy, spy);
+    }
+
+    private static SubscriptionManagerTestHarness Build(
+        IReadAfterWriteRegistrar? readAfterWriteRegistrar,
+        ReadAfterWriteRegistrarSpy? spy = null)
+    {
+        var context = InterceptorSubjectContext.Create().WithRegistry().WithLifecycle();
+        var subject = new DynamicSubject(context);
+
+        var configuration = new OpcUaClientConfiguration
+        {
+            ServerUrl = "opc.tcp://localhost:4840",
+            TypeResolver = new OpcUaTypeResolver(NullLogger<OpcUaSubjectClientSource>.Instance),
+            ValueConverter = new OpcUaValueConverter(),
+            SubjectFactory = new OpcUaSubjectFactory(new DefaultSubjectFactory()),
+            ShouldAddDynamicProperty = static (_, _) => Task.FromResult(false)
+        };
+
+        var source = new OpcUaSubjectClientSource(subject, configuration, NullLogger<OpcUaSubjectClientSource>.Instance);
+
+        // The SubjectPropertyWriter buffers updates until LoadInitialStateAndResumeAsync is called
+        // (its _updates field starts as a non-null list at construction). We need it in the
+        // applying state (i.e., _updates == null) so that ApplyDataChange actually updates subjects
+        // in tests. We back the writer with a mock ISubjectSource that returns null initial state
+        // so that LoadInitialStateAndResumeAsync succeeds without a live session.
+        var mockSource = new Mock<ISubjectSource>();
+        mockSource
+            .Setup(s => s.LoadInitialStateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Action?)null);
+
+        var propertyWriter = new SubjectPropertyWriter(mockSource.Object, NullLogger.Instance);
+        propertyWriter.StartBuffering();
+        propertyWriter.LoadInitialStateAndResumeAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+        var manager = new SubscriptionManager(
+            source,
+            propertyWriter,
+            pollingManager: null,
+            readAfterWriteManager: readAfterWriteRegistrar,
+            configuration,
+            NullLogger<OpcUaSubjectClientSource>.Instance);
+
+        return new SubscriptionManagerTestHarness(subject, source, propertyWriter, manager, spy);
+    }
+
+    /// <summary>
+    /// Adds a dynamic double property to the subject and registers it in the manager's
+    /// monitored items dictionary under the given client handle.
+    /// </summary>
+    public RegisteredSubjectProperty RegisterMonitoredItem(uint clientHandle, string propertyName)
+    {
+        var registeredSubject = _subject.TryGetRegisteredSubject()
+            ?? throw new InvalidOperationException("Subject has no registered subject. Ensure context has WithRegistry().");
+
+        double storedValue = 0d;
+        var property = registeredSubject.AddProperty<double>(
+            propertyName,
+            getValue: _ => storedValue,
+            setValue: (_, value) => storedValue = value is double d ? d : 0d);
+
+        Manager.MonitoredItemsForTesting[clientHandle] = property;
+
+        return property;
+    }
+
+    /// <summary>
+    /// Registers a monitored item for a new child subject, then immediately detaches that
+    /// child subject from the registry so that <c>TryGetRegisteredSubject()</c> returns null.
+    /// Returns the property whose subject is now detached.
+    /// </summary>
+    public RegisteredSubjectProperty RegisterMonitoredItemThenDetachSubject(uint clientHandle, string propertyName)
+    {
+        var context = InterceptorSubjectContext.Create().WithRegistry().WithLifecycle();
+        var childSubject = new DynamicSubject(context);
+
+        var registeredChild = childSubject.TryGetRegisteredSubject()
+            ?? throw new InvalidOperationException("Child subject has no registered subject.");
+
+        double storedValue = 0d;
+        var property = registeredChild.AddProperty<double>(
+            propertyName,
+            getValue: _ => storedValue,
+            setValue: (_, value) => storedValue = value is double d ? d : 0d);
+
+        Manager.MonitoredItemsForTesting[clientHandle] = property;
+
+        // Detach the child subject from its context so TryGetRegisteredSubject() returns null.
+        context.TryGetLifecycleInterceptor()!.DetachSubjectFromContext(childSubject);
+
+        return property;
+    }
+
+    /// <summary>
+    /// Returns the current SDK MonitoredItem collection to pass to
+    /// <c>RegisterSurvivorsForReadAfterWriteForTesting</c>. Items are created via
+    /// <see cref="CreatedMonitoredItem"/> so that <c>Status.Created</c> is true.
+    /// Call this after registering all items with <see cref="RegisterMonitoredItem"/>
+    /// and <see cref="RegisterMonitoredItemThenDetachSubject"/>.
+    /// </summary>
+    public IReadOnlyCollection<MonitoredItem> MonitoredItemSnapshot()
+    {
+        // Build a fake created MonitoredItem for every entry in the manager's dictionary.
+        // The snapshot is called AFTER Sweep, so detached handles may already be absent,
+        // but we build it from all registered handles for test flexibility.
+        var items = new List<MonitoredItem>();
+        foreach (var (clientHandle, property) in Manager.MonitoredItemsForTesting)
+        {
+            items.Add(CreatedMonitoredItem.Create(clientHandle, new NodeId(clientHandle, 2), 0, property));
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Reads the current value of a dynamic property by name.
+    /// </summary>
+    public object? GetValue(string name)
+    {
+        var registeredSubject = _subject.TryGetRegisteredSubject()
+            ?? throw new InvalidOperationException("Subject has no registered subject.");
+
+        return registeredSubject.TryGetProperty(name)?.GetValue();
+    }
+}
+
+/// <summary>
+/// Records every <c>RegisterProperty</c> call. Does not apply any filter.
+/// </summary>
+internal sealed class ReadAfterWriteRegistrarSpy : IReadAfterWriteRegistrar
+{
+    private readonly List<RegisteredSubjectProperty> _registeredSubjects = [];
+
+    public IReadOnlyList<RegisteredSubjectProperty> RegisteredSubjects => _registeredSubjects;
+
+    public void RegisterProperty(NodeId nodeId, RegisteredSubjectProperty property, int? requestedSamplingInterval, TimeSpan revisedSamplingInterval)
+    {
+        _registeredSubjects.Add(property);
+    }
+}
+
+/// <summary>
+/// A MonitoredItem subclass that calls <c>SetCreateResult</c> in its constructor so that
+/// <c>Status.Created</c> is true and <c>ClientHandle</c> matches the supplied value.
+/// Used only in tests to build snapshot items without a live OPC UA session.
+/// </summary>
+internal sealed class CreatedMonitoredItem : MonitoredItem
+{
+    private CreatedMonitoredItem(uint clientHandle, NodeId nodeId, double revisedIntervalMs, object handle)
+        : base(clientHandle, NullTelemetryContext.Instance)
+    {
+        Handle = handle;
+        StartNodeId = nodeId;
+
+        var request = new MonitoredItemCreateRequest
+        {
+            ItemToMonitor = new ReadValueId
+            {
+                NodeId = nodeId,
+                AttributeId = Opc.Ua.Attributes.Value
+            },
+            RequestedParameters = new MonitoringParameters
+            {
+                ClientHandle = clientHandle,
+                SamplingInterval = revisedIntervalMs
+            }
+        };
+        var result = new MonitoredItemCreateResult
+        {
+            StatusCode = StatusCodes.Good,
+            MonitoredItemId = clientHandle == 0 ? 1u : clientHandle,
+            RevisedSamplingInterval = revisedIntervalMs
+        };
+
+        SetCreateResult(request, result, 0, new DiagnosticInfoCollection(), new ResponseHeader());
+    }
+
+    public static CreatedMonitoredItem Create(uint clientHandle, NodeId nodeId, double revisedIntervalMs, object handle)
+        => new(clientHandle, nodeId, revisedIntervalMs, handle);
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/SubscriptionManagerTestHarness.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/SubscriptionManagerTestHarness.cs
@@ -26,8 +26,6 @@ internal sealed class SubscriptionManagerTestHarness
     private readonly IInterceptorSubject _subject;
 
     public SubscriptionManager Manager { get; }
-    public OpcUaSubjectClientSource Source { get; }
-    public SubjectPropertyWriter PropertyWriter { get; }
 
     /// <summary>
     /// Read-after-write spy injected by <see cref="CreateWithReadAfterWriteSpy"/>.
@@ -37,20 +35,16 @@ internal sealed class SubscriptionManagerTestHarness
 
     private SubscriptionManagerTestHarness(
         IInterceptorSubject subject,
-        OpcUaSubjectClientSource source,
-        SubjectPropertyWriter propertyWriter,
         SubscriptionManager manager,
-        ReadAfterWriteRegistrarSpy? readAfterWriteSpy = null)
+        ReadAfterWriteRegistrarSpy? readAfterWriteSpy)
     {
         _subject = subject;
-        Source = source;
-        PropertyWriter = propertyWriter;
         Manager = manager;
         ReadAfterWriteSpy = readAfterWriteSpy;
     }
 
     public static SubscriptionManagerTestHarness Create()
-        => Build(readAfterWriteRegistrar: null);
+        => Build(readAfterWriteSpy: null);
 
     /// <summary>
     /// Builds the harness with a recording <see cref="ReadAfterWriteRegistrarSpy"/> injected
@@ -58,14 +52,9 @@ internal sealed class SubscriptionManagerTestHarness
     /// The spy records every <c>RegisterProperty</c> call unconditionally (no filter).
     /// </summary>
     public static SubscriptionManagerTestHarness CreateWithReadAfterWriteSpy()
-    {
-        var spy = new ReadAfterWriteRegistrarSpy();
-        return Build(spy, spy);
-    }
+        => Build(new ReadAfterWriteRegistrarSpy());
 
-    private static SubscriptionManagerTestHarness Build(
-        IReadAfterWriteRegistrar? readAfterWriteRegistrar,
-        ReadAfterWriteRegistrarSpy? spy = null)
+    private static SubscriptionManagerTestHarness Build(ReadAfterWriteRegistrarSpy? readAfterWriteSpy)
     {
         var context = InterceptorSubjectContext.Create().WithRegistry().WithLifecycle();
         var subject = new DynamicSubject(context);
@@ -83,9 +72,9 @@ internal sealed class SubscriptionManagerTestHarness
 
         // The SubjectPropertyWriter buffers updates until LoadInitialStateAndResumeAsync is called
         // (its _updates field starts as a non-null list at construction). We need it in the
-        // applying state (i.e., _updates == null) so that ApplyDataChange actually updates subjects
-        // in tests. We back the writer with a mock ISubjectSource that returns null initial state
-        // so that LoadInitialStateAndResumeAsync succeeds without a live session.
+        // applying state (i.e., _updates == null) so that a delivered notification actually
+        // updates subjects in tests. We back the writer with a mock ISubjectSource that returns
+        // null initial state so LoadInitialStateAndResumeAsync succeeds without a live session.
         var mockSource = new Mock<ISubjectSource>();
         mockSource
             .Setup(s => s.LoadInitialStateAsync(It.IsAny<CancellationToken>()))
@@ -99,11 +88,11 @@ internal sealed class SubscriptionManagerTestHarness
             source,
             propertyWriter,
             pollingManager: null,
-            readAfterWriteManager: readAfterWriteRegistrar,
+            readAfterWriteManager: readAfterWriteSpy,
             configuration,
             NullLogger<OpcUaSubjectClientSource>.Instance);
 
-        return new SubscriptionManagerTestHarness(subject, source, propertyWriter, manager, spy);
+        return new SubscriptionManagerTestHarness(subject, manager, readAfterWriteSpy);
     }
 
     /// <summary>
@@ -151,26 +140,6 @@ internal sealed class SubscriptionManagerTestHarness
         context.TryGetLifecycleInterceptor()!.DetachSubjectFromContext(childSubject);
 
         return property;
-    }
-
-    /// <summary>
-    /// Returns the current SDK MonitoredItem collection to pass to
-    /// <c>RegisterSurvivorsForReadAfterWriteForTesting</c>. Items are created via
-    /// <see cref="CreatedMonitoredItem"/> so that <c>Status.Created</c> is true.
-    /// Call this after registering all items with <see cref="RegisterMonitoredItem"/>
-    /// and <see cref="RegisterMonitoredItemThenDetachSubject"/>.
-    /// </summary>
-    public IReadOnlyCollection<MonitoredItem> MonitoredItemSnapshot()
-    {
-        // Build a fake created MonitoredItem for every entry in the manager's dictionary.
-        // The snapshot is called AFTER Sweep, so detached handles may already be absent,
-        // but we build it from all registered handles for test flexibility.
-        var items = new List<MonitoredItem>();
-        foreach (var (clientHandle, property) in Manager.MonitoredItemsForTesting)
-        {
-            items.Add(CreatedMonitoredItem.Create(clientHandle, new NodeId(clientHandle, 2), 0, property));
-        }
-        return items;
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -178,20 +178,32 @@ internal class SubscriptionManager : IAsyncDisposable
             _subscriptions.TryAdd(subscription, 0);
         }
 
-        // Sweep before read-after-write registration so a subject that detached during setup
-        // is never registered. Callbacks stay gated until after both the sweep and survivor
-        // registration complete, so no notification can reach a subject during setup.
+        CompleteSetup(_subscriptions.Keys.SelectMany(subscription => subscription.MonitoredItems));
+    }
+
+    /// <summary>
+    /// Finishes subscription setup: drops monitored items whose subject detached while the
+    /// subscriptions were being created, registers what survived for read-after-write tracking,
+    /// then opens the callback gate.
+    /// </summary>
+    /// <remarks>
+    /// The order is the point of this method, which is why it is one unit rather than three
+    /// statements at the call site. Sweeping first is what keeps a detached subject out of the
+    /// read-after-write index, and the gate stays closed across both steps so no notification can
+    /// reach a subject mid-setup. Notifications arriving after the gate opens but before the
+    /// initial state load are not lost: the caller starts the property writer's buffering before
+    /// setup and replays it afterwards.
+    /// </remarks>
+    private void CompleteSetup(IEnumerable<MonitoredItem> monitoredItems)
+    {
         SweepDetachedSubjects();
+        RegisterSurvivors(monitoredItems);
 
-        RegisterSurvivors(_subscriptions.Keys.SelectMany(s => s.MonitoredItems));
-
-        // Open the gate only after the sweep and survivor registration are complete.
-        _callbacksEnabled = true;
+        // Never re-open a gate that DisposeAsync closed: it may have run concurrently with setup.
+        _callbacksEnabled = !_shuttingDown;
     }
 
     // Inbound notifications are dropped while shutting down or before the setup gate opens.
-    // OnFastDataChange and the ApplyDataChange test seam share this predicate so the gating
-    // test exercises the same flag the live callback checks.
     private bool AreCallbacksSuppressed => _shuttingDown || !_callbacksEnabled;
 
     private void OnFastDataChange(Subscription subscription, DataChangeNotification notification, IList<string> stringTable)
@@ -315,7 +327,7 @@ internal class SubscriptionManager : IAsyncDisposable
                 continue;
             }
 
-            var statusCode = monitoredItem.Status?.Error?.StatusCode ?? StatusCodes.Good;
+            var statusCode = monitoredItem.Status.Error?.StatusCode ?? StatusCodes.Good;
 
             switch (ClassifyFailedItem(statusCode, pollingEnabled))
             {
@@ -453,6 +465,13 @@ internal class SubscriptionManager : IAsyncDisposable
 
             foreach (var monitoredItem in subscription.MonitoredItems)
             {
+                if (!_monitoredItems.ContainsKey(monitoredItem.ClientHandle))
+                {
+                    // Swept because its subject detached, but the SDK subscription still holds it.
+                    // Escalating would resurrect it into polling under a subject nobody tracks.
+                    continue;
+                }
+
                 if (!SubscriptionHealthMonitor.IsUnhealthy(monitoredItem))
                 {
                     if (!_healAttempts.IsEmpty)
@@ -522,11 +541,19 @@ internal class SubscriptionManager : IAsyncDisposable
     /// </summary>
     private void SweepDetachedSubjects()
     {
-        var swept = new HashSet<IInterceptorSubject>();
-        foreach (var property in _monitoredItems.Values)
+        if (_monitoredItems.IsEmpty)
         {
-            var subject = property.Reference.Subject;
-            if (subject.TryGetRegisteredSubject() is null && swept.Add(subject))
+            return;
+        }
+
+        // Enumerate the dictionary rather than its Values property, which takes every bucket lock
+        // and copies. Testing the seen-set first also keeps the registry lookup to one per distinct
+        // subject instead of one per monitored item.
+        var seen = new HashSet<IInterceptorSubject>();
+        foreach (var entry in _monitoredItems)
+        {
+            var subject = entry.Value.Reference.Subject;
+            if (seen.Add(subject) && subject.TryGetRegisteredSubject() is null)
             {
                 RemoveItemsForSubject(subject);
                 _pollingManager?.RemoveItemsForSubject(subject);
@@ -574,41 +601,16 @@ internal class SubscriptionManager : IAsyncDisposable
         return _configuration.DefaultSamplingInterval;
     }
 
-    /// <summary>
-    /// Applies a single data change for the given client handle. No-ops when gated or shutting
-    /// down, and when the handle is not in the monitored items dictionary. Intended as a
-    /// unit-testable seam: it runs the same gate check and the same <see cref="ApplyChanges"/>
-    /// write path as the live callback, without requiring an OPC UA SDK Subscription.
-    /// </summary>
-    internal void ApplyDataChange(uint clientHandle, DateTimeOffset timestamp, object? value)
-    {
-        if (AreCallbacksSuppressed)
-        {
-            return;
-        }
-
-        if (!_monitoredItems.TryGetValue(clientHandle, out var property))
-        {
-            return;
-        }
-
-        var changes = ChangesPool.Rent();
-        changes.Add(new PropertyUpdate
-        {
-            Property = property,
-            Value = _configuration.ValueConverter.ConvertToPropertyValue(value, property),
-            Timestamp = timestamp
-        });
-
-        ApplyChanges(changes, DateTimeOffset.UtcNow);
-    }
-
-    internal bool AreCallbacksEnabledForTesting => _callbacksEnabled;
-    internal void EnableCallbacksForTesting() => _callbacksEnabled = true;
     internal IDictionary<uint, RegisteredSubjectProperty> MonitoredItemsForTesting => _monitoredItems;
 
-    internal void SweepDetachedSubjectsForTesting() => SweepDetachedSubjects();
-    internal void RegisterSurvivorsForReadAfterWriteForTesting(IEnumerable<MonitoredItem> monitoredItems) => RegisterSurvivors(monitoredItems);
+    internal void CompleteSetupForTesting(IEnumerable<MonitoredItem> monitoredItems) => CompleteSetup(monitoredItems);
+
+    /// <summary>
+    /// Drives the live data-change callback without an SDK <see cref="Subscription"/>. The callback
+    /// reads neither the subscription nor the string table, so this exercises the production path
+    /// including its gate check rather than a parallel copy of it.
+    /// </summary>
+    internal void OnFastDataChangeForTesting(DataChangeNotification notification) => OnFastDataChange(null!, notification, []);
 
     public async ValueTask DisposeAsync()
     {
@@ -635,7 +637,7 @@ internal class SubscriptionManager : IAsyncDisposable
                 var disposalTimeout = _configuration.SessionDisposalTimeout;
                 try
                 {
-                    await session.RemoveSubscriptionsAsync(subscriptions, CancellationToken.None)
+                    await session.RemoveSubscriptionsAsync(subscriptions, default)
                         .WaitAsync(disposalTimeout).ConfigureAwait(false);
                 }
                 catch (Exception ex)

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -4,6 +4,7 @@ using Namotion.Interceptor.Connectors;
 using Namotion.Interceptor.OpcUa.Client.ReadAfterWrite;
 using Namotion.Interceptor.OpcUa.Client.Polling;
 using Namotion.Interceptor.OpcUa.Client.Resilience;
+using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Registry.Abstractions;
 using Namotion.Interceptor.Tracking.Performance;
 using Namotion.Interceptor.Tracking.Change;
@@ -36,7 +37,7 @@ internal class SubscriptionManager : IAsyncDisposable
     private readonly OpcUaSubjectClientSource _source;
     private readonly SubjectPropertyWriter _propertyWriter;
     private readonly PollingManager? _pollingManager;
-    private readonly ReadAfterWriteManager? _readAfterWriteManager;
+    private readonly IReadAfterWriteRegistrar? _readAfterWriteManager;
     private readonly OpcUaClientConfiguration _configuration;
     private readonly ILogger _logger;
 
@@ -50,6 +51,7 @@ internal class SubscriptionManager : IAsyncDisposable
     internal const int MaxHealAttemptsBeforeEscalation = 3;
 
     private volatile bool _shuttingDown; // Prevents new callbacks during cleanup
+    private volatile bool _callbacksEnabled; // Gated to false until subscription setup completes
 
     /// <summary>
     /// Gets the current list of subscriptions (thread-safe collection).
@@ -84,7 +86,7 @@ internal class SubscriptionManager : IAsyncDisposable
         OpcUaSubjectClientSource source,
         SubjectPropertyWriter propertyWriter,
         PollingManager? pollingManager,
-        ReadAfterWriteManager? readAfterWriteManager,
+        IReadAfterWriteRegistrar? readAfterWriteManager,
         OpcUaClientConfiguration configuration,
         ILogger logger)
     {
@@ -101,6 +103,11 @@ internal class SubscriptionManager : IAsyncDisposable
         Session session,
         CancellationToken cancellationToken)
     {
+        // Close the callback gate first so a reconnection re-setup cannot let an in-flight or
+        // newly-entering notification pass on the previous setup's stale-true flag. The gate
+        // reopens only as the final statement, after the detached-subject sweep.
+        _callbacksEnabled = false;
+
         // Clear any existing subscriptions and monitored items from previous session (reconnection scenario).
         // Old subscriptions are orphaned (belong to dead session), so we just need to remove our references.
         foreach (var oldSubscription in _subscriptions.Keys)
@@ -167,17 +174,29 @@ internal class SubscriptionManager : IAsyncDisposable
 
             await FilterOutFailedMonitoredItemsAsync(subscription, cancellationToken).ConfigureAwait(false);
 
-            // Register properties with ReadAfterWriteManager now that we know revised sampling intervals
-            RegisterPropertiesWithReadAfterWriteManager(subscription);
-
             // Add to collection AFTER initialization (temporal separation - health monitor never sees partial state)
             _subscriptions.TryAdd(subscription, 0);
         }
+
+        // Sweep before read-after-write registration so a subject that detached during setup
+        // is never registered. Callbacks stay gated until after both the sweep and survivor
+        // registration complete, so no notification can reach a subject during setup.
+        SweepDetachedSubjects();
+
+        RegisterSurvivors(_subscriptions.Keys.SelectMany(s => s.MonitoredItems));
+
+        // Open the gate only after the sweep and survivor registration are complete.
+        _callbacksEnabled = true;
     }
+
+    // Inbound notifications are dropped while shutting down or before the setup gate opens.
+    // OnFastDataChange and the ApplyDataChange test seam share this predicate so the gating
+    // test exercises the same flag the live callback checks.
+    private bool AreCallbacksSuppressed => _shuttingDown || !_callbacksEnabled;
 
     private void OnFastDataChange(Subscription subscription, DataChangeNotification notification, IList<string> stringTable)
     {
-        if (_shuttingDown)
+        if (AreCallbacksSuppressed)
         {
             return;
         }
@@ -215,36 +234,45 @@ internal class SubscriptionManager : IAsyncDisposable
             throw;
         }
 
-        if (changes.Count > 0)
-        {
-            _source.IncomingThroughput.Add(changes.Count);
+        ApplyChanges(changes, receivedTimestamp);
+    }
 
-            // Pool item returned inside callback. Safe because ApplyUpdate never throws:
-            // It wraps callback execution in try-catch and only throws on catastrophic failures (lock/memory corruption).
-            var state = (source: _source, subscription, receivedTimestamp, changes, logger: _logger);
-            _propertyWriter.Write(state, static s =>
-            {
-                for (var i = 0; i < s.changes.Count; i++)
-                {
-                    var change = s.changes[i];
-                    try
-                    {
-                        change.Property.SetValueFromSource(s.source, change.Timestamp, s.receivedTimestamp, change.Value);
-                    }
-                    catch (Exception e)
-                    {
-                        s.logger.LogError(e, "Failed to apply change for property {PropertyName}.", change.Property.Name);
-                    }
-                }
-
-                s.changes.Clear();
-                ChangesPool.Return(s.changes);
-            });
-        }
-        else
+    /// <summary>
+    /// Writes a batch of property updates through the property writer and returns the pooled
+    /// list, whether or not the batch was empty. A single property write that throws is logged
+    /// and the remaining changes in the batch still apply.
+    /// </summary>
+    private void ApplyChanges(List<PropertyUpdate> changes, DateTimeOffset receivedTimestamp)
+    {
+        if (changes.Count == 0)
         {
             ChangesPool.Return(changes);
+            return;
         }
+
+        _source.IncomingThroughput.Add(changes.Count);
+
+        // Pool item returned inside callback. Safe because ApplyUpdate never throws:
+        // It wraps callback execution in try-catch and only throws on catastrophic failures (lock/memory corruption).
+        var state = (source: _source, receivedTimestamp, changes, logger: _logger);
+        _propertyWriter.Write(state, static s =>
+        {
+            for (var i = 0; i < s.changes.Count; i++)
+            {
+                var change = s.changes[i];
+                try
+                {
+                    change.Property.SetValueFromSource(s.source, change.Timestamp, s.receivedTimestamp, change.Value);
+                }
+                catch (Exception e)
+                {
+                    s.logger.LogError(e, "Failed to apply change for property {PropertyName}.", change.Property.Name);
+                }
+            }
+
+            s.changes.Clear();
+            ChangesPool.Return(s.changes);
+        });
     }
 
     /// <summary>
@@ -287,7 +315,7 @@ internal class SubscriptionManager : IAsyncDisposable
                 continue;
             }
 
-            var statusCode = monitoredItem.Status.Error?.StatusCode ?? StatusCodes.Good;
+            var statusCode = monitoredItem.Status?.Error?.StatusCode ?? StatusCodes.Good;
 
             switch (ClassifyFailedItem(statusCode, pollingEnabled))
             {
@@ -490,23 +518,44 @@ internal class SubscriptionManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Registers all successfully created monitored items with ReadAfterWriteManager.
-    /// Called after ApplyChangesAsync when we know the revised sampling intervals.
+    /// Removes monitored items for every subject that is no longer in the registry.
     /// </summary>
-    private void RegisterPropertiesWithReadAfterWriteManager(Subscription subscription)
+    private void SweepDetachedSubjects()
+    {
+        var swept = new HashSet<IInterceptorSubject>();
+        foreach (var property in _monitoredItems.Values)
+        {
+            var subject = property.Reference.Subject;
+            if (subject.TryGetRegisteredSubject() is null && swept.Add(subject))
+            {
+                RemoveItemsForSubject(subject);
+                _pollingManager?.RemoveItemsForSubject(subject);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers read-after-write tracking for monitored items whose subject survived the sweep.
+    /// Only items that are created on the server and still present in <c>_monitoredItems</c>
+    /// (the sweep removed detached subjects' handles) are registered.
+    /// </summary>
+    private void RegisterSurvivors(IEnumerable<MonitoredItem> monitoredItems)
     {
         if (_readAfterWriteManager is null)
         {
             return;
         }
 
-        foreach (var item in subscription.MonitoredItems)
+        foreach (var item in monitoredItems)
         {
-            if (item.Handle is RegisteredSubjectProperty property && item.Status?.Created == true)
+            if (item is { Handle: RegisteredSubjectProperty property, Status.Created: true } &&
+                _monitoredItems.ContainsKey(item.ClientHandle))
             {
-                var requestedInterval = GetRequestedSamplingInterval(property);
-                var revisedInterval = TimeSpan.FromMilliseconds(item.Status.SamplingInterval);
-                _readAfterWriteManager.RegisterProperty(item.StartNodeId, property, requestedInterval, revisedInterval);
+                _readAfterWriteManager.RegisterProperty(
+                    item.StartNodeId,
+                    property,
+                    GetRequestedSamplingInterval(property),
+                    TimeSpan.FromMilliseconds(item.Status.SamplingInterval));
             }
         }
     }
@@ -525,9 +574,46 @@ internal class SubscriptionManager : IAsyncDisposable
         return _configuration.DefaultSamplingInterval;
     }
 
+    /// <summary>
+    /// Applies a single data change for the given client handle. No-ops when gated or shutting
+    /// down, and when the handle is not in the monitored items dictionary. Intended as a
+    /// unit-testable seam: it runs the same gate check and the same <see cref="ApplyChanges"/>
+    /// write path as the live callback, without requiring an OPC UA SDK Subscription.
+    /// </summary>
+    internal void ApplyDataChange(uint clientHandle, DateTimeOffset timestamp, object? value)
+    {
+        if (AreCallbacksSuppressed)
+        {
+            return;
+        }
+
+        if (!_monitoredItems.TryGetValue(clientHandle, out var property))
+        {
+            return;
+        }
+
+        var changes = ChangesPool.Rent();
+        changes.Add(new PropertyUpdate
+        {
+            Property = property,
+            Value = _configuration.ValueConverter.ConvertToPropertyValue(value, property),
+            Timestamp = timestamp
+        });
+
+        ApplyChanges(changes, DateTimeOffset.UtcNow);
+    }
+
+    internal bool AreCallbacksEnabledForTesting => _callbacksEnabled;
+    internal void EnableCallbacksForTesting() => _callbacksEnabled = true;
+    internal IDictionary<uint, RegisteredSubjectProperty> MonitoredItemsForTesting => _monitoredItems;
+
+    internal void SweepDetachedSubjectsForTesting() => SweepDetachedSubjects();
+    internal void RegisterSurvivorsForReadAfterWriteForTesting(IEnumerable<MonitoredItem> monitoredItems) => RegisterSurvivors(monitoredItems);
+
     public async ValueTask DisposeAsync()
     {
         _shuttingDown = true;
+        _callbacksEnabled = false;
 
         var subscriptions = _subscriptions.Keys.ToArray();
         _subscriptions.Clear();
@@ -549,7 +635,7 @@ internal class SubscriptionManager : IAsyncDisposable
                 var disposalTimeout = _configuration.SessionDisposalTimeout;
                 try
                 {
-                    await session.RemoveSubscriptionsAsync(subscriptions, default)
+                    await session.RemoveSubscriptionsAsync(subscriptions, CancellationToken.None)
                         .WaitAsync(disposalTimeout).ConfigureAwait(false);
                 }
                 catch (Exception ex)

--- a/src/Namotion.Interceptor.OpcUa/Client/ReadAfterWrite/IReadAfterWriteRegistrar.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/ReadAfterWrite/IReadAfterWriteRegistrar.cs
@@ -1,0 +1,9 @@
+using Namotion.Interceptor.Registry.Abstractions;
+using Opc.Ua;
+
+namespace Namotion.Interceptor.OpcUa.Client.ReadAfterWrite;
+
+internal interface IReadAfterWriteRegistrar
+{
+    void RegisterProperty(NodeId nodeId, RegisteredSubjectProperty property, int? requestedSamplingInterval, TimeSpan revisedSamplingInterval);
+}

--- a/src/Namotion.Interceptor.OpcUa/Client/ReadAfterWrite/ReadAfterWriteManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/ReadAfterWrite/ReadAfterWriteManager.cs
@@ -12,7 +12,7 @@ namespace Namotion.Interceptor.OpcUa.Client.ReadAfterWrite;
 /// Maintains a NodeId-to-property index for O(1) lookups and handles automatic cleanup.
 /// Thread-safe. All state is protected by a single lock for simplicity.
 /// </summary>
-internal sealed class ReadAfterWriteManager : IAsyncDisposable
+internal sealed class ReadAfterWriteManager : IReadAfterWriteRegistrar, IAsyncDisposable
 {
     private readonly Func<ISession?> _sessionProvider;
     private readonly ISubjectSource _source;


### PR DESCRIPTION
## Summary

Second of three stacked PRs splitting #357. Stacked on #397. Two ordering bugs in subscription setup, both of which let work reach a subject that is not ready for it.

**Callback gating.** Data-change notifications could be applied while subscription setup was still running, including during reconnection re-setup. A `_callbacksEnabled` flag now closes at the start of `CreateBatchedSubscriptionsAsync` and opens only as the final statement, so a notification can never write into a subject mid-setup. Closing it first also prevents an in-flight notification from passing on the previous setup's stale-true flag. It reopens only when the manager is not shutting down, so a `DisposeAsync` racing with setup cannot have its gate closure undone.

**Sweep before registration.** Read-after-write was registered per subscription inside the creation loop, so a subject that detached during setup could still be registered. Registration now happens once, after `SweepDetachedSubjects` has removed monitored items for subjects no longer in the registry, and only for handles that survived the sweep.

The sweep, the registration, and the gate opening are one method, `CompleteSetup`, because the ordering is the whole point and three statements at a call site invite reordering.

Also: `EscalatePersistentlyFailedItemsAsync` now skips items the sweep already dropped. They remain in the SDK subscription, so escalation could otherwise resurrect a detached subject's item into polling.

## Notes for review

The tests drive production code paths rather than parallel copies. `OnFastDataChangeForTesting` calls the real `FastDataChangeCallback` handler (it reads neither the subscription nor the string table, so there is nothing to fake), which means deleting the gate check in production fails the gating test. The ordering test calls `CompleteSetupForTesting`, so swapping the sweep and the registration in production fails it too, which was verified by making that swap.

`IReadAfterWriteRegistrar` is extracted purely so a recording spy can be injected in tests. Both it and `SubscriptionManager` are internal, so there is no public API change.

`SweepDetachedSubjects` enumerates the monitored-item dictionary directly instead of its `Values` property, which takes every bucket lock and allocates a copy, and checks its seen-set before the registry lookup so the lookup runs once per distinct subject rather than once per monitored item.

## Test Plan

- [x] `dotnet build src/Namotion.Interceptor.slnx` clean
- [x] OPC UA test project: 315 passed
- [x] New tests: `OpcUaSubscriptionCallbackGatingTests` (notification before the gate opens is dropped, applied after), `OpcUaSubscriptionSweepOrderingTests` (detached subject is swept and never registered)
- [x] Mutation-checked: reversing the sweep and registration order fails the ordering test

Note: `OpcUaDataTypesTests.NullableGuidType_ShouldSyncBothDirections` is a pre-existing flake on `master` (one failure in four runs on an unmodified master worktree), not introduced by this stack.

## Stack

1. #397: session primitives and status classification
2. **This PR**: subscription callback gating and sweep ordering
3. #357: the four-phase loader itself
