### PR TITLE
Restrict context inheritance to preserve reference identity

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/ChangeQueueProcessorTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/ChangeQueueProcessorTests.cs
@@ -13,7 +13,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenMultipleChangesToSameProperty_ThenOnlyLastValueIsWritten()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -54,7 +54,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenChangesToDifferentProperties_ThenAllAreWritten()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -93,7 +93,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenDeduplicating_ThenOrderOfLastOccurrencesIsPreservedAndValuesAreMerged()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -138,7 +138,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenEmptyQueue_ThenNoWriteHandlerCalled()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -170,7 +170,7 @@ public class ChangeQueueProcessorTests
     public void WhenDisposed_ThenResourcesAreCleaned()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -192,7 +192,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenFlushInProgress_ThenConcurrentFlushSkipsToAvoidContention()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -242,7 +242,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenBoundedQueueOverflows_ThenOldestChangesAreDropped()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 
@@ -285,7 +285,7 @@ public class ChangeQueueProcessorTests
     public async Task WhenUnbounded_ThenNoChangesAreDropped()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.WithPropertyChangeSubscriptions();
 

--- a/src/Namotion.Interceptor.Connectors.Tests/DefaultSubjectFactoryTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/DefaultSubjectFactoryTests.cs
@@ -37,7 +37,7 @@ public class DefaultSubjectFactoryTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddSingleton<object>(42);
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.AddService(serviceCollection.BuildServiceProvider());
 
         var person = new Person(context);
@@ -60,7 +60,7 @@ public class DefaultSubjectFactoryTests
     public void WhenCreatingSubjectCollection_ThenItWorks()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
 
         var person = new Person(context);
         var property = new RegisteredSubjectProperty(

--- a/src/Namotion.Interceptor.Connectors.Tests/Paths/FluentPathProviderTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Paths/FluentPathProviderTests.cs
@@ -17,7 +17,7 @@ public class FluentPathProviderTests
         registry.AddPropertyMetadata(typeof(FluentPathTestSensor), "Temperature", "temp", new Meta());
         var provider = new FluentPathProvider<Meta>(registry, '/');
 
-        var subject = new FluentPathTestSensor(new InterceptorSubjectContext());
+        var subject = new FluentPathTestSensor(InterceptorSubjectContext.Create());
         var registered = new RegisteredSubject(subject);
         var property = registered.TryGetProperty("Temperature")!;
 
@@ -38,7 +38,7 @@ public class FluentPathProviderTests
         registry.AddPropertyMetadata(typeof(FluentPathTestSensor), "Temperature", segment: null, new Meta());
         var provider = new FluentPathProvider<Meta>(registry);
 
-        var subject = new FluentPathTestSensor(new InterceptorSubjectContext());
+        var subject = new FluentPathTestSensor(InterceptorSubjectContext.Create());
         var registered = new RegisteredSubject(subject);
         var property = registered.TryGetProperty("Temperature")!;
 
@@ -56,7 +56,7 @@ public class FluentPathProviderTests
         var registry = new FluentMappingRegistry<Meta>();
         var provider = new FluentPathProvider<Meta>(registry);
 
-        var subject = new FluentPathTestSensor(new InterceptorSubjectContext());
+        var subject = new FluentPathTestSensor(InterceptorSubjectContext.Create());
         var registered = new RegisteredSubject(subject);
         var property = registered.TryGetProperty("Temperature")!;
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceBaseTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceBaseTests.cs
@@ -67,7 +67,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 
@@ -113,7 +113,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 
@@ -153,7 +153,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 
@@ -193,7 +193,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 
@@ -251,7 +251,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 
@@ -290,7 +290,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 
@@ -346,7 +346,7 @@ public class SubjectSourceBaseTests
         // Arrange
         var propertyChangedChannel = new PropertyChangeInterceptor();
 
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
         context.WithRegistry();
         context.AddService(propertyChangedChannel);
 

--- a/src/Namotion.Interceptor.Mqtt.Tests/Mapping/MqttAttributeMapperTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Mapping/MqttAttributeMapperTests.cs
@@ -15,7 +15,7 @@ public class MqttAttributeMapperTests
     {
         // Arrange
         var mapper = new MqttAttributeMapper();
-        var subject = new MqttAttributeTestSensor(new InterceptorSubjectContext());
+        var subject = new MqttAttributeTestSensor(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Temperature")!;
 
@@ -33,7 +33,7 @@ public class MqttAttributeMapperTests
     {
         // Arrange
         var mapper = new MqttAttributeMapper();
-        var subject = new MqttAttributeTestSensor(new InterceptorSubjectContext());
+        var subject = new MqttAttributeTestSensor(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Unmapped")!;
 
@@ -49,7 +49,7 @@ public class MqttAttributeMapperTests
     {
         // Arrange
         var mapper = new MqttAttributeMapper();
-        var subject = new MqttAttributeTestSensor(new InterceptorSubjectContext());
+        var subject = new MqttAttributeTestSensor(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Humidity")!;
 
@@ -68,7 +68,7 @@ public class MqttAttributeMapperTests
     {
         // Arrange
         var mapper = new MqttAttributeMapper();
-        var subject = new MqttAttributeTestSensor(new InterceptorSubjectContext());
+        var subject = new MqttAttributeTestSensor(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Temperature")!;
 
@@ -85,7 +85,7 @@ public class MqttAttributeMapperTests
     {
         // Arrange
         var mapper = new MqttAttributeMapper("other-connector");
-        var subject = new MqttAttributeTestSensor(new InterceptorSubjectContext());
+        var subject = new MqttAttributeTestSensor(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Temperature")!;
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/DataChangeFilterTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/DataChangeFilterTests.cs
@@ -34,7 +34,7 @@ public class DataChangeFilterTests
     {
         // Arrange - Counter has no filter settings in attribute, config has no defaults
         var config = CreateValidConfiguration();
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -51,7 +51,7 @@ public class DataChangeFilterTests
     {
         // Arrange - Temperature has [OpcUaNode] with DeadbandType.Absolute and DeadbandValue=0.5
         var config = CreateValidConfiguration();
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Temperature")!;
         var nodeId = new NodeId("Temperature", 2);
@@ -72,7 +72,7 @@ public class DataChangeFilterTests
     {
         // Arrange - Pressure has [OpcUaNode] with DeadbandType.Percent and DeadbandValue=2.5
         var config = CreateValidConfiguration();
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Pressure")!;
         var nodeId = new NodeId("Pressure", 2);
@@ -93,7 +93,7 @@ public class DataChangeFilterTests
     {
         // Arrange - Status has [OpcUaNode] with DataChangeTrigger.StatusValueTimestamp
         var config = CreateValidConfiguration();
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Status")!;
         var nodeId = new NodeId("Status", 2);
@@ -113,7 +113,7 @@ public class DataChangeFilterTests
     {
         // Arrange - Signal has [OpcUaNode] with SamplingInterval=0
         var config = CreateValidConfiguration();
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Signal")!;
         var nodeId = new NodeId("Signal", 2);
@@ -138,7 +138,7 @@ public class DataChangeFilterTests
             DefaultDeadbandType = DeadbandType.Percent,  // Config says Percent
             DefaultDeadbandValue = 10.0                   // Config says 10.0
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         // Temperature has [OpcUaNode] with DeadbandType.Absolute and DeadbandValue=0.5
         var property = registeredSubject.TryGetProperty("Temperature")!;
@@ -168,7 +168,7 @@ public class DataChangeFilterTests
             DefaultDeadbandType = DeadbandType.Percent,
             DefaultDeadbandValue = 5.0
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -196,7 +196,7 @@ public class DataChangeFilterTests
             SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),
             DefaultQueueSize = 10
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -220,7 +220,7 @@ public class DataChangeFilterTests
             SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),
             DefaultDiscardOldest = false
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -244,7 +244,7 @@ public class DataChangeFilterTests
             SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),
             DefaultDataChangeTrigger = DataChangeTrigger.Status // Status = 0
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -272,7 +272,7 @@ public class DataChangeFilterTests
             DefaultDeadbandType = DeadbandType.None, // None = 0
             DefaultDeadbandValue = 1.0 // Need a value to trigger filter creation
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -299,7 +299,7 @@ public class DataChangeFilterTests
             SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),
             DefaultSamplingInterval = -1 // Server decides
         };
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Counter")!;
         var nodeId = new NodeId("Counter", 2);
@@ -316,7 +316,7 @@ public class DataChangeFilterTests
     {
         // Arrange - Temperature has multiple settings: DeadbandType, DeadbandValue
         var config = CreateValidConfiguration();
-        var subject = new TestSensorData(new InterceptorSubjectContext());
+        var subject = new TestSensorData(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Temperature")!;
         var nodeId = new NodeId("Temperature", 2);

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/ReadAfterWrite/ReadAfterWriteManagerTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/ReadAfterWrite/ReadAfterWriteManagerTests.cs
@@ -23,7 +23,7 @@ public class ReadAfterWriteManagerTests : IAsyncDisposable
 
     public ReadAfterWriteManagerTests()
     {
-        _testSubject = new TestPerson(new InterceptorSubjectContext());
+        _testSubject = new TestPerson(InterceptorSubjectContext.Create());
         var configuration = new OpcUaClientConfiguration
         {
             ServerUrl = "opc.tcp://localhost:4840",

--- a/src/Namotion.Interceptor.OpcUa.Tests/Mapping/OpcUaAttributeMapperTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Mapping/OpcUaAttributeMapperTests.cs
@@ -13,7 +13,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("SimpleProp")!;
 
@@ -30,7 +30,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("MonitoredProp")!;
 
@@ -47,7 +47,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("FilteredProp")!;
 
@@ -65,7 +65,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("QueueProp")!;
 
@@ -81,7 +81,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("TypedProp")!;
 
@@ -98,7 +98,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("RefProp")!;
 
@@ -114,7 +114,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange - use AttributeMapperVariableChild which has [OpcUaNode(NodeClass = OpcUaNodeClass.Variable)]
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperVariableChild(new InterceptorSubjectContext());
+        var subject = new AttributeMapperVariableChild(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Value")!;
 
@@ -130,7 +130,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("MandatoryProp")!;
 
@@ -146,7 +146,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("VariableClassProp")!;
 
@@ -162,7 +162,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("PlainProp")!;
 
@@ -175,7 +175,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange - SimpleProp has OpcUaNode but no explicit SamplingInterval (uses default int.MinValue)
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("SimpleProp")!;
 
@@ -191,7 +191,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("EventNotifierZeroProp")!;
 
@@ -207,7 +207,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange - property with [OpcUaValue] but class doesn't have NodeClass = Variable
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperInvalidValueModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperInvalidValueModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("InvalidValue")!;
 
@@ -222,7 +222,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperCollectionParent(new InterceptorSubjectContext());
+        var subject = new AttributeMapperCollectionParent(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Items")!;
 
@@ -238,7 +238,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperCollectionParent(new InterceptorSubjectContext());
+        var subject = new AttributeMapperCollectionParent(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("ItemsByKey")!;
 
@@ -254,7 +254,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperCollectionParent(new InterceptorSubjectContext());
+        var subject = new AttributeMapperCollectionParent(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("ItemsArray")!;
 
@@ -272,7 +272,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -301,7 +301,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -328,7 +328,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -355,7 +355,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -380,7 +380,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange - use default namespace that matches the node
         var mapper = new OpcUaAttributeMapper(defaultNamespaceUri: "http://default/");
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -412,7 +412,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("DataTypeProp")!;
 
@@ -429,7 +429,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("RefAttrProp")!;
 
@@ -446,7 +446,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper();
-        var subject = new AttributeMapperTestModel(new InterceptorSubjectContext());
+        var subject = new AttributeMapperTestModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("CollectionProp")!;
 
@@ -467,7 +467,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper("opc");
-        var subject = new ConnectorNameFilterModel(new InterceptorSubjectContext());
+        var subject = new ConnectorNameFilterModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var fooProperty = registeredSubject.TryGetProperty("Foo")!;
 
@@ -484,7 +484,7 @@ public class OpcUaAttributeMapperTests
     {
         // Arrange
         var mapper = new OpcUaAttributeMapper("opc");
-        var subject = new ConnectorNameFilterModel(new InterceptorSubjectContext());
+        var subject = new ConnectorNameFilterModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var barProperty = registeredSubject.TryGetProperty("Bar")!;
 
@@ -502,7 +502,7 @@ public class OpcUaAttributeMapperTests
         // Arrange
         var opcMapper = new OpcUaAttributeMapper("opc");
         var otherMapper = new OpcUaAttributeMapper("other");
-        var subject = new ConnectorNameFilterModel(new InterceptorSubjectContext());
+        var subject = new ConnectorNameFilterModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var fooProperty = registeredSubject.TryGetProperty("Foo")!;
         var barProperty = registeredSubject.TryGetProperty("Bar")!;

--- a/src/Namotion.Interceptor.OpcUa.Tests/Mapping/OpcUaCompositeMapperTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Mapping/OpcUaCompositeMapperTests.cs
@@ -15,7 +15,7 @@ public class OpcUaCompositeMapperTests
     {
         // Arrange
         var composite = new OpcUaCompositeMapper();
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("SimpleProp")!;
 
@@ -29,7 +29,7 @@ public class OpcUaCompositeMapperTests
         // Arrange
         var attributeMapper = new OpcUaAttributeMapper();
         var composite = new OpcUaCompositeMapper(attributeMapper);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("SimpleProp")!;
 
@@ -51,7 +51,7 @@ public class OpcUaCompositeMapperTests
 
         // Attribute mapper is second, so it wins for overlapping fields
         var composite = new OpcUaCompositeMapper(pathMapper, attributeMapper);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("MonitoredProp")!;
 
@@ -73,7 +73,7 @@ public class OpcUaCompositeMapperTests
         var attributeMapper = new OpcUaAttributeMapper();
 
         var composite = new OpcUaCompositeMapper(pathMapper, attributeMapper);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("SimpleProp")!;
 
@@ -95,7 +95,7 @@ public class OpcUaCompositeMapperTests
         var pathMapper = new OpcUaPathProviderMapper(pathProvider);
 
         var composite = new OpcUaCompositeMapper(attributeMapper, pathMapper);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         // PlainProp has no Path or OpcUaNode attributes, so both return null
         var property = registeredSubject.TryGetProperty("PlainProp")!;
@@ -114,7 +114,7 @@ public class OpcUaCompositeMapperTests
 
         // PathMapper first, then AttributeMapper (AttributeMapper wins for overlapping)
         var composite = new OpcUaCompositeMapper(pathMapper, attributeMapper);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         // MonitoredProp has both OpcUaNode with sampling settings
         var property = registeredSubject.TryGetProperty("MonitoredProp")!;
@@ -142,7 +142,7 @@ public class OpcUaCompositeMapperTests
 
         // Three mappers: pathMapper1, pathMapper2, attributeMapper (last wins)
         var composite = new OpcUaCompositeMapper(pathMapper1, pathMapper2, attributeMapper);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         // FilteredProp has OpcUaNode with filter settings
         var property = registeredSubject.TryGetProperty("FilteredProp")!;
@@ -172,7 +172,7 @@ public class OpcUaCompositeMapperTests
             new OpcUaAttributeMapper(),
             fluent.Build('.'));
 
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("SimpleProp")!;
 
@@ -196,7 +196,7 @@ public class OpcUaCompositeMapperTests
         var attributeMapper = new OpcUaAttributeMapper();
 
         var composite = new OpcUaCompositeMapper(pathMapper1, pathMapper2, attributeMapper);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -229,7 +229,7 @@ public class OpcUaCompositeMapperTests
 
         // AttributeMapper is last, so it wins
         var composite = new OpcUaCompositeMapper(pathMapper, attributeMapper);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -261,7 +261,7 @@ public class OpcUaCompositeMapperTests
         var attributeMapper = new OpcUaAttributeMapper();
 
         var composite = new OpcUaCompositeMapper(pathMapper, attributeMapper);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();

--- a/src/Namotion.Interceptor.OpcUa.Tests/Mapping/OpcUaPathProviderMapperTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Mapping/OpcUaPathProviderMapperTests.cs
@@ -16,7 +16,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestRoot.Name has [Path("opc", "Name")]
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Name")!;
 
@@ -33,7 +33,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestNodeMapperModel.PlainProp has no [Path] attribute
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("PlainProp")!;
 
@@ -47,7 +47,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestRoot.Name has [Path("opc", "Name")] but we use "mqtt" provider
         var pathProvider = new AttributeBasedPathProvider("mqtt");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Name")!;
 
@@ -61,7 +61,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestRoot.Connected has [Path("opc", "Connected")]
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Connected")!;
 
@@ -78,7 +78,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestRoot.Person has [Path("opc", "Person")]
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Person")!;
 
@@ -95,7 +95,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestRoot.ScalarNumbers has [Path("opc", "ScalarNumbers")]
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("ScalarNumbers")!;
 
@@ -112,7 +112,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - PathProvider only sets BrowseName, nothing else
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Name")!;
 
@@ -134,7 +134,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - Number_Unit is a PropertyAttribute (IsAttribute = true)
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         // Get the Number property and then its attribute
@@ -156,7 +156,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - Name is a regular property (IsAttribute = false)
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
         var property = registeredSubject.TryGetProperty("Name")!;
 
@@ -175,7 +175,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TryGetPropertyAsync should skip properties that are attributes
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -203,7 +203,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - TestRoot.Name has [Path("opc", "Name")]
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestRoot(new InterceptorSubjectContext());
+        var subject = new TestRoot(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();
@@ -230,7 +230,7 @@ public class OpcUaPathProviderMapperTests
         // Arrange - PlainProp has no [Path] attribute, so is excluded
         var pathProvider = new AttributeBasedPathProvider("opc");
         var mapper = new OpcUaPathProviderMapper(pathProvider);
-        var subject = new TestNodeMapperModel(new InterceptorSubjectContext());
+        var subject = new TestNodeMapperModel(InterceptorSubjectContext.Create());
         var registeredSubject = new RegisteredSubject(subject);
 
         var namespaceUris = new NamespaceTable();

--- a/src/Namotion.Interceptor.Tests/ContextRecursionTests.cs
+++ b/src/Namotion.Interceptor.Tests/ContextRecursionTests.cs
@@ -8,8 +8,8 @@ public class ContextRecursionTests
     public void WhenContextsHaveCircularDependency_ThenOnContextChangedDoesNotStackOverflow()
     {
         // Arrange
-        var context1 = new InterceptorSubjectContext();
-        var context2 = new InterceptorSubjectContext();
+        var context1 = InterceptorSubjectContext.Create();
+        var context2 = InterceptorSubjectContext.Create();
 
         // Create circular dependency
         context1.AddFallbackContext(context2);

--- a/src/Namotion.Interceptor.Tests/InterceptorSubjectContextTests.cs
+++ b/src/Namotion.Interceptor.Tests/InterceptorSubjectContextTests.cs
@@ -8,7 +8,7 @@ public class InterceptorSubjectContextTests
     public void WhenAddingSingleService_ThenItCanBeRetrieved()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
 
         // Act
         context.AddService(1);
@@ -21,7 +21,7 @@ public class InterceptorSubjectContextTests
     public void WhenAddingTwoServices_ThenListCanBeRetrieved()
     {
         // Arrange
-        var context = new InterceptorSubjectContext();
+        var context = InterceptorSubjectContext.Create();
 
         // Act
         context.AddService(1);
@@ -43,8 +43,8 @@ public class InterceptorSubjectContextTests
     public void WhenCollectionHasSubCollection_ThenServicesAreInherited()
     {
         // Arrange
-        var context1 = new InterceptorSubjectContext();
-        var context2 = new InterceptorSubjectContext();
+        var context1 = InterceptorSubjectContext.Create();
+        var context2 = InterceptorSubjectContext.Create();
         
         context2.AddFallbackContext(context1);
 
@@ -64,9 +64,9 @@ public class InterceptorSubjectContextTests
         // Arrange: the duplicate in the first fallback enumerates before the constrainer
         // in the second, so last-index binding leaves it unordered (issue #380); relies on
         // fallback enumeration following HashSet insertion order (true in practice, not contractual)
-        var parent = new InterceptorSubjectContext();
-        var fallback1 = new InterceptorSubjectContext();
-        var fallback2 = new InterceptorSubjectContext();
+        var parent = InterceptorSubjectContext.Create();
+        var fallback1 = InterceptorSubjectContext.Create();
+        var fallback2 = InterceptorSubjectContext.Create();
 
         var duplicate0 = new DuplicateOrderedService();
         var constrainer = new ConstrainerOrderedService();

--- a/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -81,7 +81,6 @@ namespace Namotion.Interceptor
     }
     public class InterceptorSubjectContext : Namotion.Interceptor.IInterceptorSubjectContext
     {
-        public InterceptorSubjectContext() { }
         public virtual bool AddFallbackContext(Namotion.Interceptor.IInterceptorSubjectContext context) { }
         public void AddService<TService>(TService service) { }
         public System.Collections.Immutable.ImmutableArray<TInterface> GetServices<TInterface>() { }
@@ -193,7 +192,7 @@ namespace Namotion.Interceptor.Interceptors
     {
         void WriteProperty<TProperty>(ref Namotion.Interceptor.Interceptors.PropertyWriteContext<TProperty> context, Namotion.Interceptor.Interceptors.WriteInterceptionDelegate<TProperty> next);
     }
-    public class InterceptorExecutor : Namotion.Interceptor.InterceptorSubjectContext, Namotion.Interceptor.IInterceptorSubjectContext, Namotion.Interceptor.Interceptors.IInterceptorExecutor
+    public sealed class InterceptorExecutor : Namotion.Interceptor.InterceptorSubjectContext, Namotion.Interceptor.IInterceptorSubjectContext, Namotion.Interceptor.Interceptors.IInterceptorExecutor
     {
         public InterceptorExecutor(Namotion.Interceptor.IInterceptorSubject subject) { }
         public override bool AddFallbackContext(Namotion.Interceptor.IInterceptorSubjectContext context) { }

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -32,6 +32,18 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
     private InterceptorSubjectContext? _noServicesSingleFallbackContext;
 
+    /// <summary>
+    /// Restricts context inheritance to this assembly because topology tracking requires context
+    /// reference identity.
+    /// </summary>
+    private protected InterceptorSubjectContext()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new interceptor subject context.
+    /// </summary>
+    /// <returns>The newly created context.</returns>
     public static InterceptorSubjectContext Create()
     {
         return new InterceptorSubjectContext();

--- a/src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs
+++ b/src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs
@@ -2,7 +2,7 @@
 
 namespace Namotion.Interceptor.Interceptors;
 
-public class InterceptorExecutor : InterceptorSubjectContext, IInterceptorExecutor
+public sealed class InterceptorExecutor : InterceptorSubjectContext, IInterceptorExecutor
 {
     private readonly IInterceptorSubject _subject;
 


### PR DESCRIPTION
## Summary

* Restrict `InterceptorSubjectContext` construction to derived implementations in the core assembly.
* Seal `InterceptorExecutor` to close the remaining external inheritance path.
* Replace direct test construction with the documented `InterceptorSubjectContext.Create()` factory and update the public API snapshot.

## Rationale

Context topology treats each context as a reference identity. External subclasses could override `Equals` and `GetHashCode`, causing distinct contexts to collapse in reverse-usage and traversal sets. That can omit an invalidation and leave a cache permanently stale.

The library has no supported external context subclassing scenario. `InterceptorExecutor` is the only implementation subclass, and it remains supported through the `private protected` constructor. The constructor XML documentation records why the hierarchy is restricted.

This issue was found while reviewing #400, but it exists on `master` independently of the copy-on-write rewrite. Keeping the fix separate lets #400 consume it through an ordinary merge or rebase.

## Breaking change

Direct `new InterceptorSubjectContext()` construction and external subclasses no longer compile. The README, samples, production code, and user-facing documentation already use `InterceptorSubjectContext.Create()`.

## Performance

There are no query-path changes or additional allocations. Sealing `InterceptorExecutor` may permit devirtualization where the runtime knows the concrete type.

## Verification

* `Namotion.Interceptor.Tests`: 84 passed
* `Namotion.Interceptor.Connectors.Tests`: 450 passed with integration tests excluded
* `Namotion.Interceptor.Mqtt.Tests`: 63 passed with integration tests excluded
* `Namotion.Interceptor.OpcUa.Tests`: 260 passed with integration tests excluded