### PR TITLE
test: Make the recorder buffer reuse test actually assert reuse

### DIFF
--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRecorderTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyRecorderTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
 
@@ -237,21 +239,43 @@ public class DerivedPropertyRecorderTests
         var person = new Person(context);
         var recorder = CreateRecorder();
 
-        // Act - multiple sessions
-        for (var session = 0; session < 10; session++)
+        // Act - the first session is the one that rents the pooled buffer
+        recorder.StartRecording(CreateSelf(person));
+        TouchProperties(recorder, person, count: 5);
+        var firstRecording = recorder.FinishRecording();
+
+        // Identity of the backing storage is what proves reuse. Asserting on the recorded
+        // values instead would pass just as happily if every session rented a fresh buffer,
+        // which is the regression this test exists to catch.
+        ref var firstSlot = ref MemoryMarshal.GetReference(firstRecording);
+
+        Assert.Equal(5, firstRecording.Length);
+
+        // Act - every later session stays within the rented capacity, so none may rent again
+        for (var session = 1; session < 10; session++)
         {
             recorder.StartRecording(CreateSelf(person));
-            for (var i = 0; i < 5; i++)
-            {
-                var property = new PropertyReference(person, $"Prop{i}");
-                recorder.TouchProperty(ref property);
-            }
-            var recorded = recorder.FinishRecording();
-            Assert.Equal(5, recorded.Length);
+            TouchProperties(recorder, person, count: 5);
+            var recording = recorder.FinishRecording();
+
+            // Assert
+            Assert.Equal(5, recording.Length);
+            Assert.True(
+                Unsafe.AreSame(ref firstSlot, ref MemoryMarshal.GetReference(recording)),
+                $"Session {session} rented a new buffer instead of reusing the first session's.");
         }
 
-        // Assert - should not throw, buffers reused
+        // Assert
         Assert.False(recorder.IsRecording);
+    }
+
+    private static void TouchProperties(DerivedPropertyRecorder recorder, IInterceptorSubject subject, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var property = new PropertyReference(subject, $"Prop{i}");
+            recorder.TouchProperty(ref property);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
`MultipleRecordingSessions_ReuseBuffers` did not test buffer reuse.

It ran ten recording sessions and then asserted only that recording had stopped:

```csharp
// Assert - should not throw, buffers reused
Assert.False(recorder.IsRecording);
```

Nothing in the body observed a buffer. The test passed just as happily if every session rented a fresh pooled array, so the allocation-free steady state that `DerivedPropertyRecorder` documents on `StartRecording` was not covered by anything.

## What the test does now

It compares the backing storage of each session's recording against the first session's:

```csharp
ref var firstSlot = ref MemoryMarshal.GetReference(firstRecording);
...
Assert.True(
    Unsafe.AreSame(ref firstSlot, ref MemoryMarshal.GetReference(recording)),
    $"Session {session} rented a new buffer instead of reusing the first session's.");
```

Address identity is the load-bearing part. Asserting on the recorded values would pass even if every session rented a fresh buffer, which is precisely the regression this test exists to catch.

Each session touches 5 properties against a buffer rented at 8, so it stays within the rented capacity and the growth path in `TouchProperty` never runs. That is what makes "no session after the first may rent again" a valid expectation.

## Verification

The test was checked against a deliberately broken implementation, not just observed to pass. Replacing the null-coalescing rent in `StartRecording`:

```csharp
frame.Buffer ??= _pool.Rent(8);   // reuses
frame.Buffer = _pool.Rent(8);     // rents every time
```

makes it fail with `Session 1 rented a new buffer instead of reusing the first session's`. Production code is unchanged in this PR; that edit was reverted after the check.

All 412 `Namotion.Interceptor.Tracking.Tests` pass.

## Note

This was found while reviewing test names against the `When<Condition>_Then<ExpectedBehavior>` convention. The old name promised more than the body delivered, which turned out to be a reliable signal. Renaming is deliberately not part of this PR so the diff stays about the assertion.
