### PR TITLE
Ordered exactly-once property change delivery [Design]

### DIFF
--- a/docs/superpowers/plans/2026-07-30-ordered-delivery-phase2-findings.md
+++ b/docs/superpowers/plans/2026-07-30-ordered-delivery-phase2-findings.md
@@ -1,0 +1,333 @@
+# Phase 2 ordered delivery: chain-build findings
+
+Investigation output of Task 2 of `2026-07-30-ordered-delivery-phase2.md`. No production code changed.
+
+**Method:** code reading of `src/Namotion.Interceptor/InterceptorSubjectContext.cs`,
+`Cache/WriteInterceptorFactory.cs`, `Interceptors/InterceptorExecutor.cs`,
+`src/Namotion.Interceptor.Tracking/InterceptorSubjectContextExtensions.cs` and
+`Change/PropertyChangeInterceptor.cs`, plus a throwaway probe program (outside the repository) that
+exercised the same paths through the public API and read the private cache fields by reflection.
+Every "observed" line below is probe output, not inference.
+
+---
+
+## Q1. Can the ordered registry be fetched from the same consistent service snapshot as the interceptors, and under which lock?
+
+**Evidence**
+
+- `InterceptorSubjectContext.cs:226-237` (`GetWriteInterceptorFunction`) holds **no lock at all**. It
+  reads `_writeInterceptorFunction` (`:228`), calls `GetServices<IWriteInterceptor>()` (`:233`),
+  builds the chain (`:234`) and then `TryAdd`s it (`:235`).
+- The only lock in the resolve path is inside `GetServices<T>` (`:55-61`): the
+  `ConcurrentDictionary.GetOrAdd` factory takes `_lock` and computes
+  `GetServicesWithoutCache<T>()` under it. That lock is held across the recursion into fallback
+  contexts (`:280`, `:290-327`), so one `GetServices<T>` call is internally consistent.
+- Two `GetServices<T>` calls are two separate `_lock` acquisitions with a gap between them. Nothing
+  in the current code closes that gap.
+- A combined fetch is mechanically possible: `GetServicesWithoutCache<T>()` (`:262-288`) is a private
+  instance method with no per-call state beyond the `[ThreadStatic] _serviceQueryVisited` set, which
+  it clears in a `finally` (`:284-287`), so two sequential calls under one `lock (_lock)` are safe.
+  Nesting them would not be (they share that set), but the terminal only needs them sequentially.
+
+**Conclusion: NO as written today, YES if changed.** The two fetches are not in one critical
+section, and `_lock` on this context is anyway only atomic against local mutations. A change
+originating in a *fallback* context clears this context's caches from `OnContextChanged` (`:350-353`)
+without holding this context's `_lock`, so no lock on this context can serialize against it.
+
+**Recommended modification (removes the question rather than answering it).** Do not query the
+registry as a second service at all. Have `PropertyChangeInterceptor` **own** its registry and expose
+it through a core-owned interface, then have `WriteInterceptorFactory<TProperty>.Create` derive the
+registry array from the `interceptors` array it already receives
+(`Cache/WriteInterceptorFactory.cs:9`):
+
+```csharp
+// core: internal interface IOrderedSubscriptionSource { OrderedSubscriptionRegistry OrderedRegistry { get; } }
+// factory: registries = interceptors.OfType<IOrderedSubscriptionSource>().Select(s => s.OrderedRegistry)
+```
+
+This makes the pair atomic by construction (one query, one snapshot), makes the dangerous state
+"`PropertyChangeInterceptor` in the chain but its registry missing from the closure" unrepresentable,
+and removes `InterceptorSubjectContext.cs` from Task 6's file list entirely. It also answers Q4 for
+free: one registry per aggregated interceptor instance, in chain order.
+
+---
+
+## Q2. Does a `Subscribe` on the parent's registry reach every delegating subject?
+
+**Evidence**
+
+- `ExecuteInterceptedWrite` (`:183-195`) forwards to `_noServicesSingleFallbackContext` (`:185-190`)
+  before touching `EnsureInitialized`/`GetWriteInterceptorFunction`, so a delegating executor never
+  builds or caches a chain. The forward is recursive, so a chain of delegating contexts collapses to
+  the first non-delegating one.
+- `GetServices<T>` delegates the same way (`:46-50`), so a delegating context resolves the identical
+  service instances the delegation target does.
+- `ContextInheritanceHandler.cs:21` attaches a child subject's executor to the **parent subject's
+  executor**, not to the configured root, so real graphs are executor chains that terminate at the
+  configured context.
+- Observed on a `WithFullPropertyTracking` root with `parent.Child = child`:
+  - parent executor delegates to root: `True`
+  - child executor delegates to parent executor: `True`
+  - compiled write chains: root `2`, parent executor never initialized, child executor never
+    initialized
+  - `child.Context.GetServices<PropertyChangeInterceptor>()[0]` is reference-equal to the root's
+    instance: `True`
+- A context that does have its own services builds its own chain, but `GetServicesWithoutCache`
+  (`:290-327`) walks into the fallbacks and returns the fallback's **instances**, so the closure
+  captures the same registry object either way.
+
+**Conclusion: YES.** The chain and its closure live on the shared delegation target, and every
+delegating subject executes that one chain. A `Subscribe` that mutates the array inside the
+registry object is visible to all of them with no chain rebuild and no per-subject install. This is
+exactly how `PropertyChangeInterceptor` already works today: its `volatile DispatchState?
+_dispatchState` (`Change/PropertyChangeInterceptor.cs:29,52-57`) is swapped on subscribe while the
+interceptor instance stays baked into the chain. The registry is the same pattern, so it is
+precedented rather than novel.
+
+Caveat carried into Q5: this only holds while the delegation target's chain is current.
+
+---
+
+## Q3. Is the registry registered at configuration time, so a chain built before any subscribe still carries it? (the load-bearing question)
+
+**Evidence**
+
+- `Tracking/InterceptorSubjectContextExtensions.cs:86-90`: `WithPropertyChangeSubscriptions()` calls
+  `context.TryAddService(() => new PropertyChangeInterceptor(), _ => true)` **eagerly**. There is no
+  lazy path, no first-subscribe creation, and no lifecycle hook involved.
+- `InterceptorSubjectContext.cs:133-146` (`TryAddService`) and `:148-155` (`AddService`) construct
+  and store the instance immediately under `_lock`. The sibling `WithService` helpers
+  (`InterceptorSubjectContextExtensions.cs:16-20,31-36`) funnel into the same call, so every `With*`
+  extension in the tracking file registers eagerly.
+- Observed: on a bare `InterceptorSubjectContext.Create().WithPropertyChangeSubscriptions()` with
+  zero subjects and zero subscribers, `GetServices<PropertyChangeInterceptor>().Length == 1`
+  immediately. Same for a plain marker service through `WithService`.
+- The `AddFallbackContext` fast path (`:96-99`) does skip `OnContextChanged`, but its guard requires
+  `_serviceCache is null`, and `_serviceCache` and `_writeInterceptorFunction` are created together
+  in `EnsureInitialized` (`:67-83`). A context that has never initialized has no cached chain, so
+  there is nothing stale to invalidate on **that** context.
+
+**Conclusion: YES, and it is not a blocker.** A registry created by
+`WithPropertyChangeSubscriptions()` exists from the moment the context is configured, long before
+any chain is built, so a chain built before the first `Subscribe` still closes over the registry
+object and a later `Subscribe` is a pure array swap inside it. The design's expected answer holds.
+
+Two conditions that must be preserved when Task 5 writes the registry:
+
+1. The registry must be created by the `With*` extension, not by `OrderedSubscription`'s
+   constructor or by a lazy property on the interceptor. Lazily creating it on first subscribe would
+   reintroduce exactly the failure this question was asked about.
+2. If the registry is registered as a separate service rather than owned by the interceptor
+   (see Q1), the two `TryAddService` calls are two separate lock acquisitions. Register the
+   **registry first** so that any torn snapshot is "registry without interceptor" (a harmless miss)
+   rather than "interceptor without registry" (a permanent silent loss of ordered delivery).
+
+---
+
+## Q4. Under aggregation, one registry instance per subscribing context, or a deduplicated set?
+
+**Evidence**
+
+- `GetServicesWithoutCache(type, visited)` (`:321-324`) concatenates local services with the
+  fallbacks' results and applies `Distinct()`. `Distinct()` on `object` uses the default comparer,
+  which for a class without an `Equals` override is reference equality. It deduplicates *the same
+  instance reached twice*, not *different instances of the same type*.
+- `TryAddService(factory, _ => true)` (`:133-146`, via `WithPropertyChangeSubscriptions`) checks the
+  **aggregated** set, so configuring a context that already has a configured fallback adds nothing.
+  Independently configured contexts joined afterwards each keep their instance.
+- Observed:
+  - two contexts each configured with `WithPropertyChangeSubscriptions()`, then joined:
+    `2` instances
+  - a context configured **after** its fallback was attached: `1` instance
+  - diamond (`g -> h -> j`, `g -> i -> j`, service on `j` only): `1` instance, so the same instance
+    reached by two paths is deduplicated
+  - two contexts each with their own plain marker object, joined: `2` instances
+
+**Conclusion: one instance per registering context, NOT deduplicated by type.** The terminal must
+loop over an array of registries. A nested loop is correct without any dedup pass, because a given
+`OrderedSubscription` is added to exactly one registry, so no subscription can be reserved twice by
+one write. That is why `ArePropertyObserversResolved` (`Interceptors/IWriteInterceptor.cs:46`,
+`Change/PropertyChangeInterceptor.cs:264-280`) is needed for the *per-property* index (one shared
+subject-side structure that every aggregated instance would otherwise resolve) but is **not** needed
+for the registries.
+
+Worth knowing for test design: the multi-registry case is currently unreachable through the public
+subscription API. `TryGetService<T>` throws when more than one instance exists (`:157-166`), and both
+`GetPropertyChangeObservable` and `CreatePropertyChangeQueueSubscription` go through
+`GetService<PropertyChangeInterceptor>()` (`Tracking/InterceptorSubjectContextExtensions.cs:115,137`).
+Observed on the two-instance context: both throw
+`InvalidOperationException: There must be exactly one service of type ... PropertyChangeInterceptor`.
+So in practice the loop runs over 0 or 1 registries today, and the spec's test item "two aggregated
+contexts each with their own ordered registry: reservations land in both" cannot be written against
+the public API without first relaxing that constraint.
+
+---
+
+## Q5. Counter-examples to the closure-capture approach
+
+Two were found. Both are pre-existing defects in the current code rather than things ordered delivery
+introduces, but both bear directly on the design.
+
+### 5a. The `AddFallbackContext` fast path can leave a chain permanently stale (confirmed)
+
+The spec says registry visibility "rides chain-cache invalidation" and that a write "racing an
+attach" may miss. The word *racing* overstates the guarantee: the miss can be **permanent**, not
+transient.
+
+`AddFallbackContext` (`:85-109`) takes the fast path at `:96-99` when the context being extended has
+no caches, no services and this is its first fallback, and in that case does not call
+`OnContextChanged` at all. `OnContextChanged` (`:343-388`) is also the only thing that propagates
+invalidation upward to `_usedByContexts` (`:377-387`). So if some other context is already using this
+one as a fallback and has already cached a chain, that chain is never invalidated.
+
+Observed, using only public API:
+
+```
+A = Create().WithService(() => new CountingInterceptor("own"));
+B = Create();                       // fresh, never used
+A.AddFallbackContext(B);            // A has services -> no fast path for A; registers A in B._usedByContexts
+person = new Person(A); person.FirstName = "x";   // builds and caches A's chain
+C = Create().WithService(() => new CountingInterceptor("late"));
+B.AddFallbackContext(C);            // B is fresh -> FAST PATH -> OnContextChanged skipped
+```
+
+- `A` chain entries after the attach: `1` (unchanged, not invalidated)
+- `A` cached `IWriteInterceptor` array after the attach: `1`, should be `2`
+- the late interceptor invoked by a post-attach write: `False`
+- `A.GetServices<CountingInterceptor>()`: `2` (a service type never queried before recomputes
+  correctly, which is what makes this so easy to miss)
+
+With a real tracking context in place of `C` the symptom is the intended one for this design:
+
+- `A.GetServices<PropertyChangeInterceptor>()`: `1` (resolvable)
+- change events delivered by a write after the attach and after `Subscribe`: **`0`**
+
+That is "delivery silently never happens", indefinitely, for a subject whose attach completed and
+whose `Subscribe` returned. It breaks the letter of the spec's attach carve-out.
+
+Reachability is narrow but real. It needs a plain `InterceptorSubjectContext` (not an executor) as
+the user, because `InterceptorExecutor.AddFallbackContext` (`Interceptors/InterceptorExecutor.cs:84-98`)
+calls `context.GetServices<ILifecycleInterceptor>()` on the fallback at `:89`, which runs
+`EnsureInitialized` on it and therefore disarms the fast path. Observed: a fresh context's
+`_serviceCache` goes from uninitialized to initialized across an executor attach. Context-to-context
+composition is a supported public pattern and is used in the test suite
+(`Tracking.Tests/Change/WritePipelineOrderTests.cs:64`,
+`Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs:115,169,455`).
+
+**Impact on the design:** the ordered failure mode here is a permanent **miss**, not a stall. The
+chain that is stale lacks `PropertyChangeInterceptor` entirely, so `PublisherPresent` is never set,
+so the terminal reserves nothing and no drain can be left waiting on a pending head. That is the
+correct degradation, and it is the same outcome immediate delivery already has today. It does not
+invalidate closure capture. It does mean the spec's carve-out wording must be widened, or the hole
+closed.
+
+**Options (human decision, no code changed here):**
+
+1. Widen the documented carve-out from "a write racing an attach" to "a context that gains its first
+   fallback after another context has already cached a chain over it". Zero code, honest, leaves a
+   silent-failure trap in place.
+2. Close it: also require `_usedByContexts.Count == 0` for the fast path at `:96-99`. Two lines, no
+   hot-path cost (the fast path is a construction-time branch), and it makes "invalidated on every
+   attach" true. This is the recommended option.
+3. Drop the fast path. Not recommended, it exists for construction throughput.
+
+### 5b. Lock-order inversion between a fallback service change and a concurrent chain build (confirmed deadlock)
+
+Not specific to ordered delivery, but it constrains what Task 6 may do and it is the reason the
+closure-capture design is right.
+
+- Writer direction: `GetServices<T>` takes **this** context's `_lock` in the `GetOrAdd` factory
+  (`:57`) and holds it across the recursion into fallbacks, where `GetServicesWithoutCache(type,
+  visited)` takes the **fallback's** `_lock` (`:301`). Order: user then fallback.
+- Invalidation direction: `AddService` takes the **fallback's** `_lock` (`:150`) and calls
+  `OnContextChanged()` inside it (`:153`); the propagation to `_usedByContexts` (`:377-387`) then
+  takes the **user's** `_lock` (`:357`). Order: fallback then user.
+
+The class comment at `:12` documents `_lock -> UsedByContextsLock` but says nothing about ordering
+between two contexts' `_lock`s, and these two paths take them in opposite orders.
+
+Reproduced from the public API (`fallback.AddService(x)` concurrent with property writes on a subject
+whose context uses that fallback), hanging on attempt 2 of 200. Managed stacks from the live process:
+
+```
+Thread A (writer)
+  InterceptorSubjectContext.GetServicesWithoutCache(Type, HashSet)   <- blocked on fallback._lock
+  ...
+  InterceptorSubjectContext.GetServices()
+  InterceptorSubjectContext.GetWriteInterceptorFunction()
+  InterceptorSubjectContext.ExecuteInterceptedWrite(...)
+  Person.set_FirstName(String)
+
+Thread B (registrar)
+  InterceptorSubjectContext.OnContextChanged(HashSet)                <- blocked on parent._lock
+  InterceptorSubjectContext.OnContextChanged(HashSet)
+  InterceptorSubjectContext.OnContextChanged()
+  InterceptorSubjectContext.AddService(...)
+```
+
+**Impact on the design:** it is a strong argument *for* closure capture. Any design where `Subscribe`
+mutates the service set (and therefore calls `AddService`/`OnContextChanged` to force a chain
+rebuild) would run this deadlock every time a subscription is created while another thread is
+writing. The chosen design has `Subscribe` touch only a volatile array inside an already-registered
+object, taking no context lock, so it never enters this cycle. Task 6 must preserve that: **do not
+add any path where `Subscribe` triggers a chain rebuild.**
+
+It also argues against Q1's "fetch the registry in the same critical section" if that is implemented
+by holding `_lock` longer, since it widens this window. The Q1 recommendation (derive registries from
+the already-fetched interceptor array) adds no lock time at all.
+
+Reporting this separately is worthwhile regardless of Phase 2, since it is a live deadlock on master.
+
+### 5c. Chain cache `TryAdd`-after-`Clear` (structural, not reproduced)
+
+`GetWriteInterceptorFunction` (`:226-237`) computes the chain outside any lock and then `TryAdd`s it
+(`:235`). `OnContextChanged` clears `_writeInterceptorFunction` (`:352`). A concurrent invalidation
+landing between the compute and the `TryAdd` leaves a stale chain cached permanently. The same shape
+exists in `GetServices`'s `GetOrAdd` (`:55-61`), whose factory result is inserted after `_lock` is
+released. Not reproduced in 400 attempts; the window is narrow, and reading the code shows it is
+real. Pre-existing, applies equally to interceptors and registries, and would only ever cause a miss
+(a chain without `PropertyChangeInterceptor` sets no marker), never a stall.
+
+### 5d. Non-counter-examples checked and cleared
+
+- `InternalsVisibleTo` from core to Tracking exists (`Namotion.Interceptor.csproj:17`), so
+  Tracking can construct the core-owned registry and buffer types. Not a blocker.
+- Both terminals in `Cache/WriteInterceptorFactory.cs` are currently `static` lambdas (`:13`, `:40`).
+  Capturing registries makes them closures. Cost is one display-class allocation per
+  `(context, TProperty)` chain build (rare) plus one field load per write on the armed path. Covered
+  by the plan's benchmark gate 1, but note that the change is not free even when unarmed.
+- The zero-interceptor terminal (`:11-35`) can never reserve: `PublisherPresent` is set by
+  `PropertyChangeInterceptor`, which is an `IWriteInterceptor`, so `interceptors.Length == 0` implies
+  the marker is never set. Task 6's step 5 says "in each of the two lock bodies"; the block in the
+  zero-interceptor terminal would be unreachable code. Task 6's first test
+  (`WhenMarkerAbsent_ThenNoSlotIsReserved`) uses a bare context and therefore passes trivially
+  against that terminal; it should use a context **with** an interceptor but without the marker to
+  actually exercise the gate.
+- `_serviceQueryVisited` (`:20,277-287`) is a `[ThreadStatic]` cleared in a `finally`. Two sequential
+  `GetServicesWithoutCache<T>()` calls under one lock are safe; nesting them would not be. Only
+  relevant if Q1's combined-fetch variant is chosen over the recommended one.
+
+---
+
+## Overall verdict
+
+**Viable with two stated modifications.** The load-bearing assumption (Q3) holds: the registry would
+exist from configuration time, so the closure-capture approach does not depend on chain invalidation
+to become armed, and `Subscribe` correctly needs no rebuild. Q2 confirms the delegation path makes
+one registry reach every delegating subject. Q4 confirms the terminal needs a plain nested loop with
+no dedup.
+
+Modifications required before Task 6 is written:
+
+1. **Derive the registries from the interceptor array, not from a second service query** (Q1). One
+   snapshot, no tearing, no lock held longer, no `InterceptorSubjectContext.cs` change. Without this,
+   "interceptor armed but registry missing from the closure" is a representable state whose symptom
+   is exactly the silent non-delivery this task was asked to rule out.
+2. **Decide the fast-path hole** (Q5a): widen the spec's attach carve-out, or add
+   `_usedByContexts.Count == 0` to the guard at `:96-99`. Recommended: close it.
+
+Constraint Task 6 must respect: `Subscribe` must never trigger a chain rebuild, because the rebuild
+path deadlocks against a concurrent service change in a fallback context (Q5b).
+
+Separately, Q5b is a live deadlock on master reachable from the public API and deserves its own
+issue independent of Phase 2.

--- a/docs/superpowers/plans/2026-07-30-ordered-delivery-phase2.md
+++ b/docs/superpowers/plans/2026-07-30-ordered-delivery-phase2.md
@@ -1,0 +1,1398 @@
+# Phase 2: Ordered exactly-once delivery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `PropertyChangeDelivery.Ordered` mode that delivers property changes exactly once, in commit order per subject, on all four subscription channels.
+
+**Architecture:** Order and content are split. Order is fixed inside the subject lock the commit already holds: the terminal reserves a slot (a header, not a payload) in each armed subscription's segmented buffer, so slot position *is* commit position. Content arrives later: `PropertyChangeInterceptor`'s `finally` builds the payload once, outside the lock, and releases the reserved slots, guaranteeing no slot is ever left pending. Delivery is a FIFO drain that waits on a pending head, delivers before advancing, and clears the slot after.
+
+**Tech Stack:** C# 13, .NET Standard 2.0 (core) / .NET 9 (extensions), xUnit, BenchmarkDotNet, PublicApiGenerator + Verify.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-ordered-change-delivery-design.md` (sections 2-8; Decided 1-11).
+
+**Branch:** `feature/ordered-delivery`, **stacked on `feature/revision-label`** (Phase 1). Do not rebase onto master until Phase 1 merges. If a benchmark here forces a Phase 1 change (counter home, context stamp, struct growth), amend Phase 1 rather than working around it.
+
+**Breaking changes in this PR:** `PropertyChangeDelivery` becomes a required parameter on `GetPropertyChangeObservable`, `CreatePropertyChangeQueueSubscription`, `Subscribe`, and `SubscribeToProperty`. Mechanical for callers (add one argument).
+
+---
+
+## File Structure
+
+**Core (`src/Namotion.Interceptor`), all internal:**
+- `Ordering/OrderedSlotBuffer.cs` (create): non-generic header segments (revision, state) plus a generic derived payload buffer. The terminal is generic over `TProperty`, not over the payload, so it must reserve through a non-generic surface.
+- `Ordering/OrderedSubscriptionRegistry.cs` (create): per-context volatile subscription array, captured in the chain closure.
+- `Ordering/OrderedReservationRecord.cs` (create): pooled `(subscription, slotIndex)` tracker with a progress count.
+- `Ordering/OrderedPropertyIndex.cs` (create): core-owned per-property index in `Subject.Data`, the parallel of #377's `Immediate` layout.
+- `Interceptors/InterceptorExecutor.cs` (modify): `OrderedPropertyListenerCount` (`Interlocked`-maintained).
+- `Interceptors/IWriteInterceptor.cs` (modify): `PublisherPresent`, `ReservationRecord`.
+- `Cache/WriteInterceptorFactory.cs` (modify): reservation before the store, in both terminals.
+- `InterceptorSubjectContext.cs` (modify): capture the ordered registries at chain build.
+
+**Generator:** `SubjectCodeGenerator.cs` (modify): race-free executor publication.
+
+**Tracking (`src/Namotion.Interceptor.Tracking`):**
+- `Change/PropertyChangeDelivery.cs` (create): the public enum.
+- `Change/OrderedSubscription.cs` (create): buffer owner, drain loop, cancellable pending-head wait, `IDisposable`.
+- `Change/ExclusiveDrainGate.cs` (create): the CAS-gated on-demand drain scheduler, shared later with #381's `PathDeliveryQueue`.
+- `Change/PropertyChangeInterceptor.cs` (modify): rent-once, marker, `try/finally` publish with consume-once and one shared payload.
+- `Change/PropertyChangeSubscriptionExtensions.cs`, `InterceptorSubjectContextExtensions.cs` (modify): the required enum parameter on all entry points.
+
+**Connectors:** `ChangeQueueProcessor.cs` (modify): `bufferTime = 0` subscribes `Ordered`, `bufferTime > 0` stays `Immediate`.
+
+---
+
+## Group A: Prerequisites (must complete before any reservation code)
+
+### Task 1: Race-free executor publication
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Generator/SubjectCodeGenerator.cs:142`
+- Modify: `src/Namotion.Interceptor.Dynamic/DynamicSubject.cs:30` (same shape)
+- Test: `src/Namotion.Interceptor.Tests/ExecutorPublicationTests.cs`
+
+The generated `_context ??= new InterceptorExecutor(this)` is a racy lazy initializer: two threads racing the first `Context` access each construct an executor and one store is discarded. Phase 2 puts the ordered-subscription count on the executor, so a discarded instance means a subscription that no write ever reserves into, permanently.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+namespace Namotion.Interceptor.Tests;
+
+public class ExecutorPublicationTests
+{
+    [Fact]
+    public void WhenContextIsAccessedConcurrently_ThenAllThreadsSeeTheSameExecutor()
+    {
+        // Arrange
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            var person = new Person();
+            var contexts = new IInterceptorSubjectContext[2];
+            using var start = new ManualResetEventSlim(false);
+
+            var first = new Thread(() => { start.Wait(); contexts[0] = ((IInterceptorSubject)person).Context; });
+            var second = new Thread(() => { start.Wait(); contexts[1] = ((IInterceptorSubject)person).Context; });
+            first.Start();
+            second.Start();
+
+            // Act
+            start.Set();
+            first.Join();
+            second.Join();
+
+            // Assert
+            Assert.Same(contexts[0], contexts[1]);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~ExecutorPublicationTests"`
+Expected: FAIL intermittently (`Assert.Same` failure on at least one attempt). If it passes 200 attempts, raise the attempt count and add `Thread.SpinWait` jitter before the read; the race is narrow but real.
+
+- [ ] **Step 3: Emit interlocked publication**
+
+In `SubjectCodeGenerator.cs`, replace the generated accessor:
+
+```csharp
+                    IInterceptorSubjectContext IInterceptorSubject.Context
+                    {
+                        get
+                        {
+                            var context = _context;
+                            if (context is not null)
+                            {
+                                return context;
+                            }
+
+                            // Race-free publication: a loser's instance is discarded before any
+                            // state (services, chain cache, ordered-subscription count) reaches it.
+                            var created = new InterceptorExecutor(this);
+                            return System.Threading.Interlocked.CompareExchange(ref _context, created, null) ?? created;
+                        }
+                    }
+```
+
+Apply the identical shape to `DynamicSubject.cs:30`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~ExecutorPublicationTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the generator snapshot and full unit suites**
+
+Run: `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
+Expected: PASS. Generator snapshot tests will show the new accessor shape; accept those snapshots after reading the diff.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Generator/SubjectCodeGenerator.cs \
+        src/Namotion.Interceptor.Dynamic/DynamicSubject.cs \
+        src/Namotion.Interceptor.Tests/ExecutorPublicationTests.cs
+git commit -m "fix: publish the subject executor race-free instead of via a lazy ??="
+```
+
+---
+
+### Task 2: Verify chain-build snapshot consistency (investigation, no production code)
+
+**Files:**
+- Read: `src/Namotion.Interceptor/InterceptorSubjectContext.cs:96-99,183-195,226-237,343-388`
+- Create: `docs/superpowers/plans/2026-07-30-ordered-delivery-phase2-findings.md`
+
+The registry must be captured from the *same* service snapshot as the interceptors, and the spec's "invalidated on every attach" claim is known to be literally false on the `_noServicesSingleFallbackContext` delegation path.
+
+- [ ] **Step 1: Answer these questions in writing, with file:line evidence**
+
+1. `GetWriteInterceptorFunction` (`:226-237`) fetches only `IWriteInterceptor`. Can the registry be fetched in the same critical section, and under which lock?
+2. `_noServicesSingleFallbackContext` (`:183-195`): when a subject's executor has no services, the chain and its closure live on the shared parent context. Does a `Subscribe` on the parent's registry therefore reach every delegating subject with no extra work? Confirm by reading, not by assumption.
+3. `AddFallbackContext` fast path (`:96-99`) skips `OnContextChanged` when no caches exist. Can a chain built *before* a registry existed survive a later `Subscribe`? (Expected answer: yes and that is fine, because `WithPropertyChangeSubscriptions()` registers the registry object up front and `Subscribe` only mutates the array inside it. **Verify that the registry is in fact registered at configuration time, not at first subscribe.** If it is not, make it so.)
+4. Under aggregation, does `GetServices` return one registry instance per subscribing context (so the terminal must loop), or a deduplicated set?
+
+- [ ] **Step 2: Record the answers**
+
+Write the findings file with one section per question, each with file:line evidence and a yes/no conclusion. If question 3's expected answer is wrong, stop and raise it: the registry must move to configuration time before any other task proceeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-07-30-ordered-delivery-phase2-findings.md
+git commit -m "docs: record the chain-build snapshot findings for ordered delivery"
+```
+
+---
+
+## Group B: Core reservation machinery
+
+### Task 3: The slot buffer
+
+**Files:**
+- Create: `src/Namotion.Interceptor/Ordering/OrderedSlotBuffer.cs`
+- Test: `src/Namotion.Interceptor.Tests/Ordering/OrderedSlotBufferTests.cs`
+
+Slots are structs in segmented arrays: reservation must not allocate per write, and the terminal (generic over `TProperty`, not the payload) reserves through a non-generic surface.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Namotion.Interceptor.Ordering;
+
+namespace Namotion.Interceptor.Tests.Ordering;
+
+public class OrderedSlotBufferTests
+{
+    [Fact]
+    public void WhenSlotsAreReserved_ThenIndicesAreSequentialAndStatesArePending()
+    {
+        // Arrange
+        var buffer = new OrderedSlotBuffer<int>(initialCapacity: 4);
+
+        // Act
+        var first = buffer.ReserveSlot(revision: 7);
+        var second = buffer.ReserveSlot(revision: 8);
+
+        // Assert
+        Assert.Equal(0, first);
+        Assert.Equal(1, second);
+        Assert.Equal(OrderedSlotState.Pending, buffer.GetState(first));
+        Assert.Equal(7, buffer.GetRevision(first));
+    }
+
+    [Fact]
+    public void WhenSlotIsReleasedAndDrained_ThenPayloadIsDeliveredThenCleared()
+    {
+        // Arrange
+        var buffer = new OrderedSlotBuffer<int>(initialCapacity: 4);
+        var index = buffer.ReserveSlot(revision: 1);
+
+        // Act
+        buffer.Release(index, 42);
+        var hasHead = buffer.TryPeekHead(out var headIndex);
+        var state = buffer.GetState(headIndex);
+        var payload = buffer.GetPayload(headIndex);
+        buffer.AdvanceHead();
+
+        // Assert
+        Assert.True(hasHead);
+        Assert.Equal(index, headIndex);
+        Assert.Equal(OrderedSlotState.Released, state);
+        Assert.Equal(42, payload);
+        Assert.False(buffer.TryPeekHead(out _));
+        Assert.Equal(0, buffer.GetPayload(index)); // cleared on advance, no retained references
+    }
+
+    [Fact]
+    public void WhenCapacityIsExceeded_ThenBufferGrowsAndPreservesOrder()
+    {
+        // Arrange
+        var buffer = new OrderedSlotBuffer<int>(initialCapacity: 2);
+
+        // Act
+        for (var i = 0; i < 10; i++)
+        {
+            buffer.Release(buffer.ReserveSlot(i + 1), i);
+        }
+
+        // Assert
+        for (var i = 0; i < 10; i++)
+        {
+            Assert.True(buffer.TryPeekHead(out var index));
+            Assert.Equal(i, buffer.GetPayload(index));
+            buffer.AdvanceHead();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~OrderedSlotBufferTests"`
+Expected: FAIL, `OrderedSlotBuffer` does not exist.
+
+- [ ] **Step 3: Implement the buffer**
+
+Create `src/Namotion.Interceptor/Ordering/OrderedSlotBuffer.cs`:
+
+```csharp
+using System.Threading;
+
+namespace Namotion.Interceptor.Ordering;
+
+internal enum OrderedSlotState
+{
+    Pending = 0,
+    Released = 1,
+    Cancelled = 2,
+}
+
+/// <summary>
+/// Non-generic reservation surface. The terminal write is generic over the property type, not over
+/// the payload type, so it reserves through this base and the derived buffer owns the payload.
+/// </summary>
+internal abstract class OrderedSlotBufferBase
+{
+    /// <summary>
+    /// Reserves the next slot and returns its index. Called with the subject's SyncRoot held, which
+    /// is what makes slot order equal commit order for that subject. Allocation-free except for
+    /// amortized segment growth.
+    /// </summary>
+    internal abstract int ReserveSlot(long revision);
+
+    /// <summary>Marks a reserved slot as carrying no delivery (an uncommitted or failed write).</summary>
+    internal abstract void Cancel(int index);
+}
+
+internal sealed class OrderedSlotBuffer<TPayload>(int initialCapacity = 8) : OrderedSlotBufferBase
+{
+    private struct Slot
+    {
+        internal long Revision;
+        internal int State;
+        internal TPayload Payload;
+    }
+
+    private readonly object _growLock = new();
+    private Slot[] _slots = new Slot[initialCapacity];
+    private int _tail;      // next index to reserve
+    private int _head;      // next index to deliver
+
+    internal override int ReserveSlot(long revision)
+    {
+        lock (_growLock)
+        {
+            if (_tail == _slots.Length)
+            {
+                Compact();
+            }
+
+            var index = _tail++;
+            _slots[index].Revision = revision;
+            _slots[index].State = (int)OrderedSlotState.Pending;
+            return index;
+        }
+    }
+
+    // Called under _growLock. Drops already-delivered slots, growing only when the live window fills
+    // the array, so steady-state delivery never allocates.
+    private void Compact()
+    {
+        var live = _tail - _head;
+        if (live == 0)
+        {
+            Array.Clear(_slots, 0, _slots.Length);
+            _head = 0;
+            _tail = 0;
+            return;
+        }
+
+        if (live < _slots.Length / 2)
+        {
+            Array.Copy(_slots, _head, _slots, 0, live);
+            Array.Clear(_slots, live, _slots.Length - live);
+        }
+        else
+        {
+            var grown = new Slot[_slots.Length * 2];
+            Array.Copy(_slots, _head, grown, 0, live);
+            _slots = grown;
+        }
+
+        _head = 0;
+        _tail = live;
+    }
+
+    internal void Release(int index, TPayload payload)
+    {
+        _slots[index].Payload = payload;
+        Volatile.Write(ref _slots[index].State, (int)OrderedSlotState.Released);
+    }
+
+    internal override void Cancel(int index)
+        => Volatile.Write(ref _slots[index].State, (int)OrderedSlotState.Cancelled);
+
+    internal OrderedSlotState GetState(int index) => (OrderedSlotState)Volatile.Read(ref _slots[index].State);
+
+    internal long GetRevision(int index) => _slots[index].Revision;
+
+    internal TPayload GetPayload(int index) => _slots[index].Payload;
+
+    internal bool TryPeekHead(out int index)
+    {
+        lock (_growLock)
+        {
+            if (_head == _tail)
+            {
+                index = -1;
+                return false;
+            }
+
+            index = _head;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Retires the head slot. Must be called only AFTER the payload has been delivered: clearing and
+    /// making the slot reclaimable while a consumer still reads it by reference would tear the read.
+    /// </summary>
+    internal void AdvanceHead()
+    {
+        lock (_growLock)
+        {
+            _slots[_head].Payload = default!;   // do not pin subjects or boxed values
+            _slots[_head].Revision = 0;
+            _head++;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~OrderedSlotBufferTests"`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Namotion.Interceptor/Ordering/OrderedSlotBuffer.cs \
+        src/Namotion.Interceptor.Tests/Ordering/OrderedSlotBufferTests.cs
+git commit -m "feat: add the ordered slot buffer with non-generic reservation"
+```
+
+---
+
+### Task 4: The pooled reservation record
+
+**Files:**
+- Create: `src/Namotion.Interceptor/Ordering/OrderedReservationRecord.cs`
+- Test: `src/Namotion.Interceptor.Tests/Ordering/OrderedReservationRecordTests.cs`
+
+The record cannot hold a `ref` to a struct slot, so it stores `(buffer, slotIndex)` pairs. Its progress count is what makes reservation failure-atomic: it is incremented only *after* a successful reserve, so a throw mid-loop leaves exactly the tracked prefix for the `finally` to cancel.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Namotion.Interceptor.Ordering;
+
+namespace Namotion.Interceptor.Tests.Ordering;
+
+public class OrderedReservationRecordTests
+{
+    [Fact]
+    public void WhenTrackingThrowsMidLoop_ThenOnlyTheTrackedPrefixIsCancelled()
+    {
+        // Arrange
+        var record = new OrderedReservationRecord();
+        var first = new OrderedSlotBuffer<int>();
+        var second = new OrderedSlotBuffer<int>();
+        record.Track(first, first.ReserveSlot(1));
+        var untrackedIndex = second.ReserveSlot(2); // reserved but NOT tracked (simulates a throw)
+
+        // Act
+        record.CancelAll();
+
+        // Assert
+        Assert.Equal(OrderedSlotState.Cancelled, first.GetState(0));
+        Assert.Equal(OrderedSlotState.Pending, second.GetState(untrackedIndex));
+        Assert.Equal(0, record.Count);
+    }
+
+    [Fact]
+    public void WhenReset_ThenNoBufferReferencesAreRetained()
+    {
+        // Arrange
+        var record = new OrderedReservationRecord();
+        var buffer = new OrderedSlotBuffer<int>();
+        record.Track(buffer, buffer.ReserveSlot(1));
+
+        // Act
+        record.CancelAll();
+
+        // Assert
+        Assert.Equal(0, record.Count);
+        Assert.False(record.HoldsAnyBuffer, "a pooled record must not pin buffers between writes");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~OrderedReservationRecordTests"`
+Expected: FAIL, type does not exist.
+
+- [ ] **Step 3: Implement the record**
+
+Create `src/Namotion.Interceptor/Ordering/OrderedReservationRecord.cs`:
+
+```csharp
+namespace Namotion.Interceptor.Ordering;
+
+/// <summary>
+/// Tracks the slots one write reserved, so the publishing finally can release or cancel exactly
+/// those. Pooled and rented outside the subject lock. Not thread-safe: it belongs to one write on
+/// one thread, reachable only through that write's by-ref context.
+/// </summary>
+internal sealed class OrderedReservationRecord
+{
+    private (OrderedSlotBufferBase Buffer, int Index)[] _entries = new (OrderedSlotBufferBase, int)[4];
+
+    internal int Count { get; private set; }
+
+    internal bool HoldsAnyBuffer
+    {
+        get
+        {
+            for (var i = 0; i < _entries.Length; i++)
+            {
+                if (_entries[i].Buffer is not null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Records a successful reservation. Count is incremented last, so a throw between reserving and
+    /// tracking leaves the untracked slot out of the cancel set (that write never commits, and the
+    /// slot's own subscription is torn down with its buffer).
+    /// </summary>
+    internal void Track(OrderedSlotBufferBase buffer, int index)
+    {
+        if (Count == _entries.Length)
+        {
+            Array.Resize(ref _entries, _entries.Length * 2);
+        }
+
+        _entries[Count] = (buffer, index);
+        Count++;
+    }
+
+    internal (OrderedSlotBufferBase Buffer, int Index) this[int i] => _entries[i];
+
+    internal void CancelAll()
+    {
+        for (var i = 0; i < Count; i++)
+        {
+            _entries[i].Buffer.Cancel(_entries[i].Index);
+        }
+
+        Reset();
+    }
+
+    internal void Reset()
+    {
+        Array.Clear(_entries, 0, _entries.Length);
+        Count = 0;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~OrderedReservationRecordTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Namotion.Interceptor/Ordering/OrderedReservationRecord.cs \
+        src/Namotion.Interceptor.Tests/Ordering/OrderedReservationRecordTests.cs
+git commit -m "feat: add the pooled ordered reservation record"
+```
+
+---
+
+### Task 5: The registry, the per-property index, and the interlocked gate
+
+**Files:**
+- Create: `src/Namotion.Interceptor/Ordering/OrderedSubscriptionRegistry.cs`
+- Create: `src/Namotion.Interceptor/Ordering/OrderedPropertyIndex.cs`
+- Modify: `src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs`
+- Test: `src/Namotion.Interceptor.Tests/Ordering/OrderedPropertyIndexTests.cs`
+
+The gate must follow #377's discipline exactly (`PropertyChangeSubscriptions.cs:12-22`, `PropertyChangeSubscription.cs:33,60,67`): `Interlocked` increment **before** install, decrement **after** removal, and `Interlocked.MemoryBarrier()` after the install, because a `ConcurrentDictionary` bucket-lock release is not a full fence. A plain field loses updates under concurrent subscribes to two properties of one subject, and a lost increment closes the gate permanently on a live subscription.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Namotion.Interceptor.Ordering;
+
+namespace Namotion.Interceptor.Tests.Ordering;
+
+public class OrderedPropertyIndexTests
+{
+    [Fact]
+    public void WhenConcurrentInstallsRace_ThenTheGateCountsEveryLiveSubscription()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var executor = (Interceptors.InterceptorExecutor)((IInterceptorSubject)person).Context;
+        var buffers = new OrderedSlotBufferBase[64];
+        for (var i = 0; i < buffers.Length; i++)
+        {
+            buffers[i] = new OrderedSlotBuffer<int>();
+        }
+
+        // Act: install 64 listeners across two properties from many threads
+        Parallel.For(0, buffers.Length, i =>
+            OrderedPropertyIndex.Install(
+                new PropertyReference(person, i % 2 == 0 ? nameof(Person.FirstName) : nameof(Person.LastName)),
+                buffers[i]));
+
+        // Assert
+        Assert.Equal(buffers.Length, Volatile.Read(ref executor.OrderedPropertyListenerCount));
+        Assert.True(OrderedPropertyIndex.TryGet(new PropertyReference(person, nameof(Person.FirstName)), out var installed));
+        Assert.Equal(buffers.Length / 2, installed!.Length);
+    }
+
+    [Fact]
+    public void WhenAllRemoved_ThenGateReturnsToZero()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var executor = (Interceptors.InterceptorExecutor)((IInterceptorSubject)person).Context;
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+        var buffer = new OrderedSlotBuffer<int>();
+
+        // Act
+        OrderedPropertyIndex.Install(property, buffer);
+        OrderedPropertyIndex.Remove(property, buffer);
+
+        // Assert
+        Assert.Equal(0, Volatile.Read(ref executor.OrderedPropertyListenerCount));
+        Assert.False(OrderedPropertyIndex.TryGet(property, out _));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~OrderedPropertyIndexTests"`
+Expected: FAIL, types do not exist.
+
+- [ ] **Step 3: Add the gate field**
+
+In `InterceptorExecutor.cs`, next to `Revision`:
+
+```csharp
+    /// <summary>
+    /// Number of ordered per-property subscriptions installed on this subject. Maintained with
+    /// Interlocked (increment before install, decrement after removal) and read under the subject's
+    /// SyncRoot by the terminal, so a nonzero value always precedes a visible install. A plain field
+    /// would lose updates and permanently close the gate on a live subscription.
+    /// </summary>
+    internal int OrderedPropertyListenerCount;
+```
+
+- [ ] **Step 4: Implement the registry and the index**
+
+Create `src/Namotion.Interceptor/Ordering/OrderedSubscriptionRegistry.cs`:
+
+```csharp
+using System.Threading;
+
+namespace Namotion.Interceptor.Ordering;
+
+/// <summary>
+/// Per-context set of context-wide ordered subscriptions. Registered at configuration time (not at
+/// first subscribe) so the compiled write chain can capture it in its closure and a later Subscribe
+/// is just an array swap, needing no chain rebuild.
+/// </summary>
+internal sealed class OrderedSubscriptionRegistry
+{
+    private readonly object _lock = new();
+
+    private volatile OrderedSlotBufferBase[] _subscriptions = [];
+
+    internal OrderedSlotBufferBase[] Subscriptions => _subscriptions;
+
+    internal void Add(OrderedSlotBufferBase buffer)
+    {
+        lock (_lock)
+        {
+            var current = _subscriptions;
+            var updated = new OrderedSlotBufferBase[current.Length + 1];
+            Array.Copy(current, updated, current.Length);
+            updated[current.Length] = buffer;
+            _subscriptions = updated;
+        }
+
+        // The volatile publish orders the install against a terminal's in-lock read; the explicit
+        // barrier mirrors PropertyChangeSubscription.Create, since a lock release is not a full fence.
+        Interlocked.MemoryBarrier();
+    }
+
+    internal void Remove(OrderedSlotBufferBase buffer)
+    {
+        lock (_lock)
+        {
+            var current = _subscriptions;
+            var index = Array.IndexOf(current, buffer);
+            if (index < 0)
+            {
+                return;
+            }
+
+            var updated = new OrderedSlotBufferBase[current.Length - 1];
+            Array.Copy(current, updated, index);
+            Array.Copy(current, index + 1, updated, index, current.Length - index - 1);
+            _subscriptions = updated;
+        }
+    }
+}
+```
+
+Create `src/Namotion.Interceptor/Ordering/OrderedPropertyIndex.cs`:
+
+```csharp
+using System.Threading;
+using Namotion.Interceptor.Interceptors;
+
+namespace Namotion.Interceptor.Ordering;
+
+/// <summary>
+/// Core-owned per-property index of ordered subscriptions, stored in subject data. Deliberately a
+/// parallel structure to the Tracking-owned Immediate listener index: core cannot reference Tracking
+/// types, and the terminal must read this inside the subject lock.
+/// </summary>
+internal static class OrderedPropertyIndex
+{
+    private const string IndexKey = "ni.opl";
+
+    internal static void Install(PropertyReference property, OrderedSlotBufferBase buffer)
+    {
+        // Increment BEFORE the install: a write that sees the gate open may find nothing (harmless),
+        // but a write that finds the gate closed must be certain nothing is installed.
+        if (property.Subject.Context is InterceptorExecutor executor)
+        {
+            Interlocked.Increment(ref executor.OrderedPropertyListenerCount);
+        }
+
+        var key = (property.Name, IndexKey);
+        var data = property.Subject.Data;
+        while (true)
+        {
+            if (data.TryGetValue(key, out var existing))
+            {
+                var current = (OrderedSlotBufferBase[])existing!;
+                var updated = new OrderedSlotBufferBase[current.Length + 1];
+                Array.Copy(current, updated, current.Length);
+                updated[current.Length] = buffer;
+                if (data.TryUpdate(key, updated, current))
+                {
+                    break;
+                }
+            }
+            else if (data.TryAdd(key, new[] { buffer }))
+            {
+                break;
+            }
+        }
+
+        Interlocked.MemoryBarrier(); // see OrderedSubscriptionRegistry.Add
+    }
+
+    internal static void Remove(PropertyReference property, OrderedSlotBufferBase buffer)
+    {
+        var key = (property.Name, IndexKey);
+        var data = property.Subject.Data;
+        while (true)
+        {
+            if (!data.TryGetValue(key, out var existing) || existing is not OrderedSlotBufferBase[] current)
+            {
+                break;
+            }
+
+            var index = Array.IndexOf(current, buffer);
+            if (index < 0)
+            {
+                break;
+            }
+
+            if (current.Length == 1)
+            {
+                if (new PropertyReference(property.Subject, property.Name).TryRemovePropertyData(IndexKey, current))
+                {
+                    break;
+                }
+            }
+            else
+            {
+                var updated = new OrderedSlotBufferBase[current.Length - 1];
+                Array.Copy(current, updated, index);
+                Array.Copy(current, index + 1, updated, index, current.Length - index - 1);
+                if (data.TryUpdate(key, updated, current))
+                {
+                    break;
+                }
+            }
+        }
+
+        // Decrement AFTER removal, so the gate never reads closed while a listener is still installed.
+        if (property.Subject.Context is InterceptorExecutor executor)
+        {
+            Interlocked.Decrement(ref executor.OrderedPropertyListenerCount);
+        }
+    }
+
+    internal static bool TryGet(PropertyReference property, out OrderedSlotBufferBase[]? buffers)
+    {
+        if (property.Subject.Data.TryGetValue((property.Name, IndexKey), out var value) &&
+            value is OrderedSlotBufferBase[] installed)
+        {
+            buffers = installed;
+            return true;
+        }
+
+        buffers = null;
+        return false;
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~OrderedPropertyIndexTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Namotion.Interceptor/Ordering/OrderedSubscriptionRegistry.cs \
+        src/Namotion.Interceptor/Ordering/OrderedPropertyIndex.cs \
+        src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs \
+        src/Namotion.Interceptor.Tests/Ordering/OrderedPropertyIndexTests.cs
+git commit -m "feat: add the ordered subscription registry, per-property index and interlocked gate"
+```
+
+---
+
+### Task 6: Reserve in both terminals
+
+**Files:**
+- Modify: `src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs`
+- Modify: `src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs` (both terminals)
+- Modify: `src/Namotion.Interceptor/InterceptorSubjectContext.cs` (capture registries at chain build)
+- Test: `src/Namotion.Interceptor.Tests/Ordering/TerminalReservationTests.cs`
+
+Two invariants this task must establish: reservation happens **before** the value store (so a throwing reservation aborts an uncommitted write, making committed-implies-reserved structural), and reservation is gated on **both** the publisher marker and a non-null executor (ordered delivery is unsupported for non-executor subjects, and the gate has no home there).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Namotion.Interceptor.Ordering;
+
+namespace Namotion.Interceptor.Tests.Ordering;
+
+public class TerminalReservationTests
+{
+    [Fact]
+    public void WhenMarkerAbsent_ThenNoSlotIsReserved()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var buffer = new OrderedSlotBuffer<int>();
+        OrderedPropertyIndex.Install(new PropertyReference(person, nameof(Person.FirstName)), buffer);
+
+        // Act: no PropertyChangeInterceptor in the chain, so no marker is ever set
+        person.FirstName = "a";
+
+        // Assert: a miss, never a pending slot that would stall a drain forever
+        Assert.False(buffer.TryPeekHead(out _));
+    }
+
+    [Fact]
+    public void WhenMarkerSet_ThenSlotsAreReservedInCommitOrder()
+    {
+        // Arrange
+        var buffer = new OrderedSlotBuffer<int>();
+        var context = InterceptorSubjectContext.Create().WithService(() => new MarkerInterceptor());
+        var person = new Person(context);
+        OrderedPropertyIndex.Install(new PropertyReference(person, nameof(Person.FirstName)), buffer);
+
+        // Act
+        person.FirstName = "a";
+        person.FirstName = "b";
+
+        // Assert
+        Assert.True(buffer.TryPeekHead(out var head));
+        Assert.Equal(OrderedSlotState.Pending, buffer.GetState(head));
+        Assert.True(buffer.GetRevision(head) > 0);
+    }
+
+    private sealed class MarkerInterceptor : Interceptors.IWriteInterceptor
+    {
+        public void WriteProperty<TProperty>(ref Interceptors.PropertyWriteContext<TProperty> context, Interceptors.WriteInterceptionDelegate<TProperty> next)
+        {
+            context.ReservationRecord = new OrderedReservationRecord();
+            context.PublisherPresent = true;
+            next(ref context);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~TerminalReservationTests"`
+Expected: FAIL, `PropertyWriteContext` has no `ReservationRecord` or `PublisherPresent`.
+
+- [ ] **Step 3: Add the context fields**
+
+In `PropertyWriteContext<TProperty>`:
+
+```csharp
+    /// <summary>
+    /// Set by <c>PropertyChangeInterceptor</c> before calling next(). The terminal reserves slots
+    /// only when this is set, so "a slot was reserved but nothing on this stack will resolve it"
+    /// is unrepresentable: a chain without the publisher misses the write rather than stalling a
+    /// drain forever.
+    /// </summary>
+    internal bool PublisherPresent;
+
+    /// <summary>Pooled tracker for the slots this write reserved; null when unarmed.</summary>
+    internal Ordering.OrderedReservationRecord? ReservationRecord;
+```
+
+- [ ] **Step 4: Capture registries at chain build**
+
+Following Task 2's findings, extend chain construction so the compiled terminal closes over the ordered registries visible in the aggregated context set (plural: one per subscribing context). Pass them into `WriteInterceptorFactory<TProperty>.Create` alongside the interceptors, fetched in the same service snapshot as `IWriteInterceptor`.
+
+- [ ] **Step 5: Reserve in both terminals**
+
+In each of the two lock bodies in `WriteInterceptorFactory.cs`, **before** `innerWriteValue(...)`:
+
+```csharp
+                    var revision = ++context.Executor.Revision;
+                    context.Revision = revision;
+
+                    // The executor is on the write context, so there is no lookup and no subject that
+                    // can miss out: every committed write gets the revision label above, and the marker
+                    // below only decides whether slots are also reserved.
+                    if (context.PublisherPresent &&
+                        context.ReservationRecord is { } record)
+                    {
+                        for (var r = 0; r < registries.Length; r++)
+                        {
+                            var subscriptions = registries[r].Subscriptions;
+                            for (var s = 0; s < subscriptions.Length; s++)
+                            {
+                                record.Track(subscriptions[s], subscriptions[s].ReserveSlot(revision));
+                            }
+                        }
+
+                        if (Volatile.Read(ref context.Executor.OrderedPropertyListenerCount) != 0 &&
+                            OrderedPropertyIndex.TryGet(property, out var listeners))
+                        {
+                            for (var l = 0; l < listeners!.Length; l++)
+                            {
+                                record.Track(listeners[l], listeners[l].ReserveSlot(revision));
+                            }
+                        }
+                    }
+
+                    innerWriteValue(subject, context.NewValue);
+                    context.IsWritten = true;
+```
+
+Both terminals already hoist `var property = context.Property;` and `var subject = property.Subject;` above the lock, so use those locals rather than re-reading `context.Property`, which is a struct copy the JIT cannot fold across the opaque `innerWriteValue` call.
+
+Remove the Phase 1 `context.Revision = ...` line and its `Debug.Assert` that sat after `IsWritten`, since the revision is now assigned above. Keep the assert, moved up next to the new increment: it is what pins the executor-owns-subject pairing the plain increment depends on.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~TerminalReservationTests"`
+Expected: PASS.
+
+- [ ] **Step 7: Run the Phase 1 revision tests to confirm no regression**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests src/Namotion.Interceptor.Tracking.Tests`
+Expected: PASS, including `CommitRevisionTests` and `PropertyChangeRevisionTests` from Phase 1.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs \
+        src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs \
+        src/Namotion.Interceptor/InterceptorSubjectContext.cs \
+        src/Namotion.Interceptor.Tests/Ordering/TerminalReservationTests.cs
+git commit -m "feat: reserve ordered slots in the terminal write, gated on the publisher marker"
+```
+
+---
+
+## Group C: Tracking publish and delivery
+
+### Task 7: Publish in the finally with rent-once and consume-once
+
+**Files:**
+- Create: `src/Namotion.Interceptor.Tracking/Change/PropertyChangeDelivery.cs`
+- Modify: `src/Namotion.Interceptor.Tracking/Change/PropertyChangeInterceptor.cs`
+- Test: `src/Namotion.Interceptor.Tracking.Tests/Change/OrderedPublishTests.cs`
+
+Three defects the review caught must be prevented by construction here: renting the record twice under aggregated contexts leaks one pooled object per write (rent only when the field is null); publishing twice under aggregation corrupts already-consumed slots (null the record when consuming); and building the payload twice can make the `Immediate` and `Ordered` channels disagree for the same write (build once, share).
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+public class OrderedPublishTests
+{
+    [Fact]
+    public void WhenLifecycleHandlerThrows_ThenTheCommittedChangeIsStillDelivered()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithService(() => new ThrowingLifecycleHandler());
+        var person = new Person(context);
+        var delivered = new List<long>();
+        using var subscription = person.SubscribeToProperty(
+            p => p.FirstName,
+            (in SubjectPropertyChange change) => delivered.Add(change.Revision),
+            PropertyChangeDelivery.Ordered);
+
+        // Act
+        Assert.ThrowsAny<Exception>(() => person.FirstName = "a");
+
+        // Assert: committed implies delivered; the exception still propagated above
+        Assert.Single(delivered);
+    }
+
+    [Fact]
+    public void WhenWriteIsVetoed_ThenNoDeliveryOccursAndNoSlotStaysPending()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithService(() => new VetoingInterceptor());
+        var person = new Person(context);
+        var delivered = 0;
+        using var subscription = person.SubscribeToProperty(
+            p => p.FirstName,
+            (in SubjectPropertyChange _) => delivered++,
+            PropertyChangeDelivery.Ordered);
+
+        // Act
+        person.FirstName = "a";
+
+        // Assert
+        Assert.Equal(0, delivered);
+    }
+}
+```
+
+(Define `ThrowingLifecycleHandler` as an `ILifecycleHandler` whose attach throws, and `VetoingInterceptor` as an `IWriteInterceptor` that returns without calling `next`, following the existing patterns in `PropertyChangeInterceptorTests`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~OrderedPublishTests"`
+Expected: FAIL, `PropertyChangeDelivery` does not exist.
+
+- [ ] **Step 3: Add the enum**
+
+Create `src/Namotion.Interceptor.Tracking/Change/PropertyChangeDelivery.cs` with the exact XML documentation from the spec's section 8 (including the per-subject-only order wording and the performance paragraphs).
+
+- [ ] **Step 4: Rewrite `WriteProperty`'s arming and publish**
+
+```csharp
+    public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
+    {
+        // Rent-once: under aggregated contexts several interceptor instances run this method for one
+        // write. An unconditional rent would overwrite the field and leak one pooled record per write.
+        if (IsOrderedArmed(ref context) && context.ReservationRecord is null)
+        {
+            context.ReservationRecord = ReservationRecordPool.Rent();
+            context.PublisherPresent = true;
+        }
+
+        try
+        {
+            // ... existing idle fast path and dispatch, unchanged, except the payload is built once
+            // and reused for both the Immediate channels and the slot publish
+            next(ref context);
+            DispatchImmediateChannels(ref context, out var payload, out var hasPayload);
+            PublishOrdered(ref context, payload, hasPayload);
+        }
+        finally
+        {
+            // Consume-once: the innermost instance resolves and clears; outer instances no-op.
+            if (context.ReservationRecord is { } record)
+            {
+                context.ReservationRecord = null;
+                if (!context.IsWritten)
+                {
+                    record.CancelAll();
+                }
+
+                ReservationRecordPool.Return(record);
+            }
+        }
+    }
+```
+
+`PublishOrdered` releases each tracked slot with the shared payload (or cancels it when the payload could not be built, the derived-with-setter getter-throw case), then resets the record so the `finally` sees nothing left to cancel.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~OrderedPublishTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Tracking/Change/PropertyChangeDelivery.cs \
+        src/Namotion.Interceptor.Tracking/Change/PropertyChangeInterceptor.cs \
+        src/Namotion.Interceptor.Tracking.Tests/Change/OrderedPublishTests.cs
+git commit -m "feat: publish ordered slots in the interceptor finally with rent-once and consume-once"
+```
+
+---
+
+### Task 8: The drain with deliver-before-advance and cancellable waits
+
+**Files:**
+- Create: `src/Namotion.Interceptor.Tracking/Change/ExclusiveDrainGate.cs`
+- Create: `src/Namotion.Interceptor.Tracking/Change/OrderedSubscription.cs`
+- Test: `src/Namotion.Interceptor.Tracking.Tests/Change/OrderedDrainTests.cs`
+
+The wait must be event-based and cancellable, mirroring `PropertyChangeQueueSubscription.cs:20,52-102,104-120` (`ManualResetEventSlim`, token-aware wait with the reset-then-recheck dance for lost wakeups, and `Dispose` setting the signal). Otherwise a consumer blocked on a slot whose producer is stuck in a user lifecycle handler can never be shut down, and `ChangeQueueProcessor.Dispose` hangs.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+public class OrderedDrainTests
+{
+    [Fact]
+    public async Task WhenHeadIsPending_ThenDisposeUnblocksTheWaiter()
+    {
+        // Arrange
+        var subscription = new OrderedSubscription<int>();
+        subscription.Buffer.ReserveSlot(1); // pending forever: no producer will release it
+
+        // Act
+        var pump = Task.Run(() => subscription.TryDequeue(out _, CancellationToken.None));
+        subscription.Dispose();
+
+        // Assert
+        var completed = await Task.WhenAny(pump, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(pump, completed);
+        Assert.False(await pump);
+    }
+
+    [Fact]
+    public async Task WhenHeadIsPending_ThenCancellationUnblocksTheWaiter()
+    {
+        // Arrange
+        using var subscription = new OrderedSubscription<int>();
+        subscription.Buffer.ReserveSlot(1);
+        using var cancellation = new CancellationTokenSource();
+
+        // Act
+        var pump = Task.Run(() => subscription.TryDequeue(out _, cancellation.Token));
+        await cancellation.CancelAsync();
+
+        // Assert
+        var completed = await Task.WhenAny(pump, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(pump, completed);
+        Assert.False(await pump);
+    }
+
+    [Fact]
+    public void WhenSlotsAreReleasedOutOfOrder_ThenDeliveryStillFollowsReservationOrder()
+    {
+        // Arrange
+        using var subscription = new OrderedSubscription<int>();
+        var first = subscription.Buffer.ReserveSlot(1);
+        var second = subscription.Buffer.ReserveSlot(2);
+
+        // Act: release the SECOND slot first
+        subscription.Buffer.Release(second, 200);
+        Assert.False(subscription.TryDequeueImmediately(out _)); // head still pending: must not skip
+        subscription.Buffer.Release(first, 100);
+
+        // Assert
+        Assert.True(subscription.TryDequeueImmediately(out var firstValue));
+        Assert.Equal(100, firstValue);
+        Assert.True(subscription.TryDequeueImmediately(out var secondValue));
+        Assert.Equal(200, secondValue);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~OrderedDrainTests"`
+Expected: FAIL, `OrderedSubscription<T>` does not exist.
+
+- [ ] **Step 3: Implement the gate and the subscription**
+
+`ExclusiveDrainGate`: a CAS flag plus a `ThreadPool.UnsafeQueueUserWorkItem` scheduled only when the buffer turns non-empty and no drain is in flight, following `ChangeQueueProcessor._flushGate` (`ChangeQueueProcessor.cs:29,209,304`). Zero cost while idle, one work item per burst.
+
+`OrderedSubscription<TPayload>`: owns an `OrderedSlotBuffer<TPayload>`, a `ManualResetEventSlim`, and a one-shot disposed flag. The drain loop is exactly:
+
+```csharp
+        while (Buffer.TryPeekHead(out var index))
+        {
+            if (!WaitForResolution(index, cancellationToken))
+            {
+                return false;   // cancelled or disposed
+            }
+
+            var state = Buffer.GetState(index);
+            if (state == OrderedSlotState.Released)
+            {
+                // Deliver BEFORE advancing: advancing makes the slot reclaimable, and a concurrent
+                // producer could overwrite it while the consumer still reads the payload.
+                Deliver(Buffer.GetPayload(index));
+            }
+
+            Buffer.AdvanceHead();   // clears the payload: no retained subject or boxed references
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~OrderedDrainTests"`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Tracking/Change/ExclusiveDrainGate.cs \
+        src/Namotion.Interceptor.Tracking/Change/OrderedSubscription.cs \
+        src/Namotion.Interceptor.Tracking.Tests/Change/OrderedDrainTests.cs
+git commit -m "feat: add the ordered drain with deliver-before-advance and cancellable waits"
+```
+
+---
+
+### Task 9: Required delivery parameter on all four channels
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Tracking/Change/PropertyChangeSubscriptionExtensions.cs`
+- Modify: `src/Namotion.Interceptor.Tracking/InterceptorSubjectContextExtensions.cs`
+- Modify: `src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt`
+- Test: `src/Namotion.Interceptor.Tracking.Tests/Change/OrderedSubscribeValidationTests.cs`
+
+- [ ] **Step 1: Write the failing validation tests**
+
+```csharp
+    [Fact]
+    public void WhenSubscribingOrderedOnAttachedContextWithoutTracking_ThenThrows()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();   // no PropertyChangeInterceptor
+        var person = new Person(context);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => person.SubscribeToProperty(
+            p => p.FirstName, (in SubjectPropertyChange _) => { }, PropertyChangeDelivery.Ordered));
+    }
+
+    [Fact]
+    public void WhenSubscribingOrderedBeforeAttach_ThenAllowedAndDormantUntilAttached()
+    {
+        // Arrange
+        var person = new Person();   // no context yet
+
+        // Act
+        using var subscription = person.SubscribeToProperty(
+            p => p.FirstName, (in SubjectPropertyChange _) => { }, PropertyChangeDelivery.Ordered);
+
+        // Assert: no throw, and no delivery while unattached
+        person.FirstName = "a";
+        Assert.NotNull(subscription);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~OrderedSubscribeValidationTests"`
+Expected: FAIL to compile (no delivery parameter yet).
+
+- [ ] **Step 3: Add the required parameter and validation**
+
+Every entry point gains a required `PropertyChangeDelivery delivery` parameter: `Subscribe(observer|callback)`, `SubscribeToProperty(selector, observer|callback)`, `GetPropertyChangeObservable()`, `CreatePropertyChangeQueueSubscription()`, plus the new `GetPropertyChangesAsync(delivery, cancellationToken)`. `Ordered` throws `InvalidOperationException` when the subject or context is attached and the aggregated context set has no `PropertyChangeInterceptor`, and when `subject.Context is not InterceptorExecutor`.
+
+- [ ] **Step 4: Update every in-repo call site**
+
+Run: `dotnet build src/Namotion.Interceptor.slnx 2>&1 | grep -c "error CS"` and fix each until zero. Every existing call site takes `PropertyChangeDelivery.Immediate` (today's behavior), so the migration is mechanical.
+
+- [ ] **Step 5: Accept the API snapshot**
+
+Run the `PublicApi` test, read the diff (it must contain only the enum, the new parameters, and `GetPropertyChangesAsync`), then copy `.received.txt` over `.verified.txt`.
+
+- [ ] **Step 6: Run the full unit suite**
+
+Run: `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A src/Namotion.Interceptor.Tracking src/Namotion.Interceptor.Tracking.Tests
+git commit -m "feat!: require an explicit PropertyChangeDelivery on every subscription entry point"
+```
+
+---
+
+### Task 10: `ChangeQueueProcessor` mode wiring
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Connectors/ChangeQueueProcessor.cs:88`
+- Test: `src/Namotion.Interceptor.Connectors.Tests/ChangeQueueProcessorTests.cs`
+
+`bufferTime = 0` subscribes `Ordered` (exactly-once, commit order); `bufferTime > 0` stays `Immediate` so connector contexts remain unarmed and keep the cheap queue path, relying on the Phase 1 revision dedup.
+
+- [ ] **Step 1: Write the failing test** asserting that a processor constructed with `bufferTime: TimeSpan.Zero` receives changes in commit order under concurrent writers, and that one with `bufferTime: 8ms` leaves the context unarmed (assert `executor.OrderedPropertyListenerCount == 0` and that the registry has no subscriptions).
+
+- [ ] **Step 2: Run it and confirm it fails.**
+
+- [ ] **Step 3: Wire the mode**
+
+```csharp
+            _subscription = context.CreatePropertyChangeQueueSubscription(
+                _bufferTime > TimeSpan.Zero
+                    ? PropertyChangeDelivery.Immediate   // dedup mode: revision-based convergence
+                    : PropertyChangeDelivery.Ordered);   // no buffering: exactly-once, commit order
+```
+
+- [ ] **Step 4: Run the connector suite.** Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Connectors/ChangeQueueProcessor.cs \
+        src/Namotion.Interceptor.Connectors.Tests/ChangeQueueProcessorTests.cs
+git commit -m "feat: back the unbuffered ChangeQueueProcessor with ordered delivery"
+```
+
+---
+
+### Task 11: Concurrency and lifetime test suite
+
+**Files:**
+- Create: `src/Namotion.Interceptor.Tracking.Tests/Change/OrderedDeliveryConcurrencyTests.cs`
+
+Each test below targets a specific failure mode the reviews identified. Use `AsyncTestHelpers.WaitUntilAsync` or `CountdownEvent`, never `Task.Delay`.
+
+- [ ] **Step 1: Write the suite**
+
+1. **Commit order under concurrent writers**: many threads write one subject; assert every committed write is delivered exactly once and revisions are strictly increasing in delivery order.
+2. **Boundary, no stall ever**: subscribe repeatedly during a write storm; assert every write committed after `Subscribe` returned is delivered, delivered prefixes have no observable gaps, and the drain never stalls.
+3. **Record-pool balance at aggregation depth 2+**: aggregate two contexts, run N writes, assert rents equal returns (expose counters behind `InternalsVisibleTo`). This is the test that catches the double-rent leak, which the reservation-count and publish-count assertions cannot see.
+4. **Two registries**: two aggregated subscribing contexts; assert a write reserves into both.
+5. **Aggregation publish-once**: assert exactly one reservation set and exactly one publish per write at depth 2+.
+6. **Torn-read stress**: concurrent producers recycling slots while a consumer delivers; assert payload integrity and, with `WeakReference` in the #390 style, that advanced slots retain nothing.
+7. **Veto and no-op**: neither reserves a slot.
+8. **Transactions**: capture reserves nothing; commit replay delivers in replay order; origin filtering still suppresses self-echoes.
+9. **Dispose and detach**: per-subscription state is evicted, no leak; `Dispose` unblocks a pending-head waiter.
+10. **Stuck producer**: a lifecycle handler blocks; assert the drain parks and releases on resolve, and that cancellation still works throughout.
+
+- [ ] **Step 2: Run the suite.** Expected: PASS. Any flake is a design bug, not a test bug: report it rather than adding a retry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Tracking.Tests/Change/OrderedDeliveryConcurrencyTests.cs
+git commit -m "test: add the ordered delivery concurrency and lifetime suite"
+```
+
+---
+
+### Task 12: Benchmark gates 2-7 and 10
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Benchmark/PropertyChangeSubscriptionsBenchmark.cs`
+- Create: `src/Namotion.Interceptor.Benchmark/OrderedDeliveryBenchmark.cs`
+
+- [ ] **Step 1: Add an `Ordered` counterpart** for each of the nine existing `Write*` variants.
+
+- [ ] **Step 2: Add the usage-profile benchmark** (gate 3): 100 ordered per-property subscriptions across a graph; measure writes to a subject with no ordered subs, to an observed subject's unobserved property, and to an observed property.
+
+- [ ] **Step 3: Add the contention matrix** (gate 5): {same subject, distinct subjects} x {unarmed, 1 ordered sub, 4 ordered subs}.
+
+- [ ] **Step 4: Add latency and throughput** (gate 6) including the held-head case, and drain scheduling under bursty versus sustained load (gate 7).
+
+- [ ] **Step 5: Run every gate on a pinned CPU**
+
+```bash
+pwsh scripts/benchmark.ps1 -Stash
+```
+
+Acceptance, from the spec: gate 1 (unarmed) shows no measurable regression; gate 2 shows 0 B steady state on primitive-valued writes, including pool traffic and slot clearing; gate 3 shows unobserved subjects paying only the count load. **A gate 1 regression means the design changes** (amend Phase 1's counter home or context stamp), not that the number is accepted.
+
+- [ ] **Step 6: Record raw output in both PR descriptions and update the cost column** in `docs/tracking.md` from measurements.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Benchmark docs/tracking.md
+git commit -m "benchmarks: add the ordered delivery gates and record measured costs"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** prerequisites (Tasks 1-2); slot buffer with non-generic reservation surface (3); pooled record with progress-count atomicity (4); registry, core-owned per-property index, interlocked gate with trailing fence (5); reservation before the store in both terminals, gated on marker and executor (6); rent-once, consume-once, single shared payload, cancel on veto and on getter-throw (7); drain with deliver-before-advance, clear-on-advance, cancellable event-based wait, on-demand gate (8); required enum on all four channels plus validation and the pre-attach dormancy rule (9); processor modes (10); the full test list from the spec (11); gates 2-7 and 10 (12).
+
+**Deliberately deferred:** the exclusive-drain extraction shared with #381's `PathDeliveryQueue` (Task 8 creates the primitive in a form that can absorb it, but the #381 migration is a separate PR), and the cross-flush convergence follow-up.
+
+**Type consistency:** `OrderedSlotBufferBase.ReserveSlot(long)`/`Cancel(int)` are the only members the terminal uses (Tasks 3, 6); `OrderedSlotBuffer<TPayload>` adds `Release/GetState/GetRevision/GetPayload/TryPeekHead/AdvanceHead` used in Tasks 3 and 8; `OrderedReservationRecord.Track/CancelAll/Reset/Count/this[int]` are consistent across Tasks 4, 6, and 7; `OrderedPropertyIndex.Install/Remove/TryGet` across Tasks 5 and 6; `PropertyWriteContext.PublisherPresent`/`ReservationRecord` written in Task 6 and read in Task 7.
+
+**Known blocker for Task 6, Step 4:** the registry capture depends on Task 2's findings, specifically whether `WithPropertyChangeSubscriptions()` registers the registry at configuration time. If it does not, Task 2 must fix that before Task 6 begins, or a chain compiled before the first subscribe will never see the registry.

--- a/docs/superpowers/plans/2026-07-30-revision-label-phase1.md
+++ b/docs/superpowers/plans/2026-07-30-revision-label-phase1.md
@@ -1,0 +1,1105 @@
+# Phase 1: Per-subject revision label Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stamp every committed property write with a monotonic per-subject `Revision`, expose it on `SubjectPropertyChange`, and use it to fix the `ChangeQueueProcessor` flush dedup, which currently picks the "newest" value by array position (arrival order) and can hand a connector a stale value.
+
+**Architecture:** The commit already happens under a per-subject lock (`WriteInterceptorFactory`'s terminal, `lock (subject.SyncRoot)`). A plain `long` field on the subject's `InterceptorExecutor` is incremented there, so no new lock, no atomic, and no shared cache line. The value is stamped into the write context, read by `PropertyChangeInterceptor` when it builds the change, and consumed by the flush dedup. Nothing here is load-bearing for ordering, so there is no contiguity invariant to preserve.
+
+**Tech Stack:** C# 13, .NET Standard 2.0 (core) / .NET 9 (extensions), xUnit, BenchmarkDotNet, PublicApiGenerator + Verify.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-ordered-change-delivery-design.md` (Phase 1 scope; sections 1, 5, 9 and the `Create` subsection).
+
+**Branch:** `feature/revision-label`. This PR stays open and is the base of the Phase 2 PR (stacked), because Phase 2's benchmarks are the first real test of this PR's always-on cost and may force changes here.
+
+---
+
+## File Structure
+
+**Core (`src/Namotion.Interceptor`):**
+- `Interceptors/InterceptorExecutor.cs` (modify): gains the `Revision` field.
+- `SubjectRevisionCounter.cs` (create): the increment helper, including the non-executor fallback. Isolated so the fallback path is testable and the terminal stays a one-liner.
+- `Cache/WriteInterceptorFactory.cs` (modify): both terminals call the helper.
+- `Interceptors/IWriteInterceptor.cs` (modify): `PropertyWriteContext<TProperty>` gains internal `Revision` and `FinalValueIsNewValue`; `GetFinalValue()` honours the flag.
+- `PropertyReferenceExtensions.cs` (modify): the internal cascade overload forwards the flag.
+
+**Tracking (`src/Namotion.Interceptor.Tracking`):**
+- `Change/SubjectPropertyChange.cs` (modify): public `Revision`, optional `revision` parameter on `Create`, propagation through the private ctor, `MergeWithNewer`, `WithOrigin`.
+- `Change/PropertyChangeInterceptor.cs` (modify): pass `context.Revision` at both `Create` call sites.
+- `Change/DerivedPropertyChangeHandler.cs` (modify): set the flag on the recalculation publish.
+
+**Connectors (`src/Namotion.Interceptor.Connectors`):**
+- `ChangeDeduplicator.cs` (create): the flush dedup extracted as an internal static class so it is unit-testable with hand-built revisions. `ChangeQueueProcessor` is already 337 lines and this is a self-contained algorithm with a non-obvious contract.
+- `ChangeQueueProcessor.cs` (modify): delegate the dedup pass.
+
+**Docs:** `docs/tracking.md` (modify): the guarantee matrix.
+
+---
+
+### Task 1: Per-subject revision counter in core
+
+**Files:**
+- Create: `src/Namotion.Interceptor/SubjectRevisionCounter.cs`
+- Modify: `src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs`
+- Test: `src/Namotion.Interceptor.Tests/SubjectRevisionCounterTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Namotion.Interceptor.Tests.Models; // Person, or the nearest existing generated test subject
+
+namespace Namotion.Interceptor.Tests;
+
+public class SubjectRevisionCounterTests
+{
+    [Fact]
+    public void WhenIncrementedRepeatedly_ThenRevisionIsMonotonicPerSubject()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var first = new Person(context);
+        var second = new Person(context);
+
+        // Act
+        var firstA = SubjectRevisionCounter.Next(first);
+        var firstB = SubjectRevisionCounter.Next(first);
+        var secondA = SubjectRevisionCounter.Next(second);
+
+        // Assert
+        Assert.Equal(1, firstA);
+        Assert.Equal(2, firstB);
+        Assert.Equal(1, secondA); // independent per subject
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~SubjectRevisionCounterTests"`
+Expected: FAIL, compile error `The name 'SubjectRevisionCounter' does not exist`.
+
+- [ ] **Step 3: Add the field to the executor**
+
+In `src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs`, after the `_subject` field:
+
+```csharp
+    /// <summary>
+    /// Monotonic per-subject commit counter. Incremented by the terminal write while the subject's
+    /// SyncRoot is held, so a plain increment is exclusive: no Interlocked needed. Dense over
+    /// committed writes (vetoed and no-op writes never reach the terminal) and never reset, so it
+    /// stays comparable across detach and reattach. A label only: ordering does not depend on it.
+    /// </summary>
+    internal long Revision;
+```
+
+- [ ] **Step 4: Create the helper**
+
+Create `src/Namotion.Interceptor/SubjectRevisionCounter.cs`:
+
+```csharp
+using System.Runtime.CompilerServices;
+using Namotion.Interceptor.Interceptors;
+
+namespace Namotion.Interceptor;
+
+/// <summary>
+/// Assigns the monotonic per-subject commit revision. Called by the terminal write with the
+/// subject's SyncRoot held, which is what makes the plain increment safe.
+/// </summary>
+internal static class SubjectRevisionCounter
+{
+    private const string RevisionKey = "Namotion.Interceptor.Revision";
+
+    /// <summary>
+    /// Returns the next revision for the subject. Callers must hold the subject's SyncRoot.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static long Next(IInterceptorSubject subject)
+    {
+        // Generated subjects own their executor, so the counter is a plain field on an object that
+        // is already hot in this write: no lookup, no atomic, no shared cache line.
+        if (subject.Context is InterceptorExecutor executor)
+        {
+            return ++executor.Revision;
+        }
+
+        return NextFallback(subject);
+    }
+
+    /// <summary>
+    /// Hand-written subjects whose context is not an <see cref="InterceptorExecutor"/> keep the
+    /// counter in subject data, mirroring the write-timestamp holder. Label only: ordered delivery
+    /// is not offered for such subjects.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long NextFallback(IInterceptorSubject subject)
+    {
+        var holder = (long[])subject.Data.GetOrAdd((string.Empty, RevisionKey), static _ => new long[1])!;
+        return ++holder[0];
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~SubjectRevisionCounterTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Namotion.Interceptor/SubjectRevisionCounter.cs \
+        src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs \
+        src/Namotion.Interceptor.Tests/SubjectRevisionCounterTests.cs
+git commit -m "feat: add per-subject commit revision counter"
+```
+
+---
+
+### Task 2: Stamp the revision in both terminals
+
+**Files:**
+- Modify: `src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs` (add the context field)
+- Modify: `src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs:12-22` and `:27-38`
+- Test: `src/Namotion.Interceptor.Tests/SubjectRevisionCounterTests.cs`
+
+There are **two** terminals in that file (the interceptor-less fast path and the chain terminal). Both must be instrumented or writes on contexts without interceptors silently carry revision 0.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `SubjectRevisionCounterTests`:
+
+```csharp
+    [Fact]
+    public void WhenPropertyWrittenThroughChain_ThenContextCarriesIncreasingRevision()
+    {
+        // Arrange
+        var revisions = new List<long>();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithService(() => new RevisionCapturingInterceptor(revisions));
+        var person = new Person(context);
+
+        // Act
+        person.FirstName = "a";
+        person.FirstName = "b";
+        person.LastName = "c";
+
+        // Assert: dense and increasing across all properties of the subject
+        Assert.Equal(new long[] { 1, 2, 3 }, revisions);
+    }
+
+    private sealed class RevisionCapturingInterceptor(List<long> revisions) : IWriteInterceptor
+    {
+        public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
+        {
+            next(ref context);
+            revisions.Add(context.Revision);
+        }
+    }
+```
+
+Add `using Namotion.Interceptor.Interceptors;` to the file's usings.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~WhenPropertyWrittenThroughChain"`
+Expected: FAIL, compile error `'PropertyWriteContext<TProperty>' has no member 'Revision'`.
+
+- [ ] **Step 3: Add the context field**
+
+In `src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs`, inside `PropertyWriteContext<TProperty>` next to the other internal fields:
+
+```csharp
+    /// <summary>
+    /// The subject's commit revision assigned by the terminal write, or 0 when the write did not
+    /// commit. Monotonic per subject, not comparable across subjects.
+    /// </summary>
+    internal long Revision;
+```
+
+- [ ] **Step 4: Stamp it in both terminals**
+
+In `src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs`, in **both** lock bodies, immediately after `context.IsWritten = true;`:
+
+```csharp
+                    context.Revision = SubjectRevisionCounter.Next(context.Property.Subject);
+```
+
+For clarity, the interceptor-less terminal becomes:
+
+```csharp
+            return static (ref context, innerWriteValue) =>
+            {
+                lock (context.Property.Subject.SyncRoot)
+                {
+                    innerWriteValue(context.Property.Subject, context.NewValue);
+                    context.IsWritten = true;
+                    context.Revision = SubjectRevisionCounter.Next(context.Property.Subject);
+                    context.FinalizeOrigin();
+                    var raw = context.WriteTimestampRaw;
+                    context.Property.SetWriteTimestamp(raw > 0 ? raw : 0);
+                }
+            };
+```
+
+and the chain terminal gains the same line in the same position (before `FinalizeOrigin()`, keeping `return context.NewValue;` last).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests --filter "FullyQualifiedName~SubjectRevisionCounterTests"`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Run the full core and tracking suites**
+
+Run: `dotnet test src/Namotion.Interceptor.Tests src/Namotion.Interceptor.Tracking.Tests`
+Expected: PASS, no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs \
+        src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs \
+        src/Namotion.Interceptor.Tests/SubjectRevisionCounterTests.cs
+git commit -m "feat: stamp the commit revision in both write terminals"
+```
+
+---
+
+### Task 3: Expose `Revision` on `SubjectPropertyChange`
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs`
+- Test: `src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs`
+
+`Create` has ~100 call sites and is the only overload. It gains an **optional** `long revision = 0`: one method, no call-site churn, and 0 means "constructed outside a terminal write". This is source-compatible but binary breaking; accepted, because the source generator means consumers recompile against every version anyway, and a single clean method beats a permanently doubled API. Call it out in the PR description.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `SubjectPropertyChangeTests`:
+
+```csharp
+    [Fact]
+    public void WhenCreatedWithRevision_ThenRevisionIsExposedAndSurvivesMergeAndOrigin()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+
+        // Act
+        var earlier = SubjectPropertyChange.Create(property, ChangeOrigin.Local, DateTimeOffset.UtcNow, null, "a", "b", 5L);
+        var later = SubjectPropertyChange.Create(property, ChangeOrigin.Local, DateTimeOffset.UtcNow, null, "b", "c", 6L);
+        var merged = earlier.MergeWithNewer(later);
+        var reoriginated = later.WithOrigin(ChangeOrigin.Local);
+        var legacy = SubjectPropertyChange.Create(property, ChangeOrigin.Local, DateTimeOffset.UtcNow, null, "a", "b");
+
+        // Assert
+        Assert.Equal(5L, earlier.Revision);
+        Assert.Equal(6L, later.Revision);
+        Assert.Equal(6L, merged.Revision);          // merge takes the newer revision
+        Assert.Equal("a", merged.GetOldValue<string>());
+        Assert.Equal("c", merged.GetNewValue<string>());
+        Assert.Equal(6L, reoriginated.Revision);    // WithOrigin preserves it
+        Assert.Equal(0L, legacy.Revision);          // six-parameter overload defaults to 0
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~WhenCreatedWithRevision"`
+Expected: FAIL, compile error: no `Revision` member and no seven-argument `Create`.
+
+- [ ] **Step 3: Thread the field through the private constructor**
+
+In `SubjectPropertyChange.cs`, add `long revision` as the last parameter of the private constructor and assign it, then add the property after `ReceivedTimestamp`:
+
+```csharp
+    private SubjectPropertyChange(
+        PropertyReference property,
+        ChangeOrigin origin,
+        DateTimeOffset changedTimestamp,
+        DateTimeOffset? receivedTimestamp,
+        InlineValueStorage oldValueStorage,
+        InlineValueStorage newValueStorage,
+        object? oldBoxedHolder,
+        object? newBoxedHolder,
+        long revision)
+    {
+        Property = property;
+        Origin = origin;
+        ChangedTimestamp = changedTimestamp;
+        ReceivedTimestamp = receivedTimestamp;
+        _oldValueStorage = oldValueStorage;
+        _newValueStorage = newValueStorage;
+        _oldBoxedHolder = oldBoxedHolder;
+        _newBoxedHolder = newBoxedHolder;
+        Revision = revision;
+    }
+```
+
+```csharp
+    /// <summary>
+    /// The writing subject's commit revision: monotonic per subject over committed writes, so two
+    /// changes to the same subject are ordered by comparing it. Revisions of different subjects are
+    /// NOT comparable. 0 means the change was constructed outside a terminal write.
+    /// </summary>
+    public long Revision { get; }
+```
+
+- [ ] **Step 4: Add the optional parameter**
+
+Add a trailing optional parameter to the existing `Create` and pass it to all three `new SubjectPropertyChange(...)` returns. No second overload: one method, and `0` is the meaningful default for changes built outside a terminal write.
+
+```csharp
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SubjectPropertyChange Create<TValue>(
+        PropertyReference property,
+        ChangeOrigin origin,
+        DateTimeOffset changedTimestamp,
+        DateTimeOffset? receivedTimestamp,
+        TValue oldValue,
+        TValue newValue,
+        long revision = 0)
+    {
+        // ... existing body unchanged, with `revision` passed as the last constructor argument
+        // in all three returns (inline, string, and boxed-holder paths)
+    }
+```
+
+This is a binary break (source-compatible). Accepted: the source generator means consumers recompile against every version anyway. Note it in the PR description.
+
+- [ ] **Step 5: Propagate through `MergeWithNewer` and `WithOrigin`**
+
+`MergeWithNewer` takes the newer change's revision (it already takes the newer origin and timestamps):
+
+```csharp
+        return new SubjectPropertyChange(
+            Property,
+            newerChange.Origin,
+            newerChange.ChangedTimestamp,
+            newerChange.ReceivedTimestamp,
+            _oldValueStorage,
+            newerChange._newValueStorage,
+            _oldBoxedHolder,
+            newerChange._newBoxedHolder,
+            newerChange.Revision);
+```
+
+`WithOrigin` preserves `Revision` (append `Revision` as the last constructor argument).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~WhenCreatedWithRevision"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs \
+        src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
+git commit -m "feat: expose the commit revision on SubjectPropertyChange"
+```
+
+---
+
+### Task 4: Publish the revision on the change channels
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Tracking/Change/PropertyChangeInterceptor.cs:185` and `:229`
+- Test: `src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeRevisionTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeRevisionTests.cs`:
+
+```csharp
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+public class PropertyChangeRevisionTests
+{
+    [Fact]
+    public void WhenPropertiesWritten_ThenPublishedChangesCarryIncreasingRevisions()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        var person = new Person(context);
+        var revisions = new List<long>();
+        using var subscription = context.GetPropertyChangeObservable()
+            .Subscribe(change => revisions.Add(change.Revision));
+
+        // Act
+        person.FirstName = "a";
+        person.LastName = "b";
+
+        // Assert
+        Assert.All(revisions, revision => Assert.True(revision > 0, "published changes must carry a revision"));
+        Assert.Equal(revisions.OrderBy(revision => revision), revisions);
+        Assert.Equal(revisions.Distinct().Count(), revisions.Count);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~PropertyChangeRevisionTests"`
+Expected: FAIL, `revision > 0` assertion fails (changes still carry 0).
+
+- [ ] **Step 3: Pass the revision at both call sites**
+
+In `PropertyChangeInterceptor.cs`, both `SubjectPropertyChange.Create(...)` calls (in `WriteProperty` around line 185 and `DispatchLateConsumers` around line 229) gain `context.Revision` as the final argument:
+
+```csharp
+        var change = SubjectPropertyChange.Create(
+            context.Property,
+            context.Origin,
+            context.WriteTimestampForPublishing,
+            SubjectChangeContext.Current.ReceivedTimestamp,
+            context.CurrentValue,
+            context.GetFinalValue(),
+            context.Revision);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~PropertyChangeRevisionTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Tracking/Change/PropertyChangeInterceptor.cs \
+        src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeRevisionTests.cs
+git commit -m "feat: publish the commit revision on the change channels"
+```
+
+---
+
+### Task 5: `FinalValueIsNewValue` for derived recalculation publishes
+
+**Files:**
+- Modify: `src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs` (field + `GetFinalValue`)
+- Modify: `src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs:39-49` (internal cascade overload)
+- Modify: `src/Namotion.Interceptor/PropertyReferenceExtensions.cs:25-30`
+- Modify: `src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs:365`
+- Test: `src/Namotion.Interceptor.Tracking.Tests/Change/DerivedFinalValueTests.cs`
+
+This stops the recalculation publish from re-invoking the derived getter. It is an observable behavior change on the `Immediate` channels (the published value is now the stabilized recalculation result, not a possibly-newer re-read) and must be called out in the PR description.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/Namotion.Interceptor.Tracking.Tests/Change/DerivedFinalValueTests.cs`:
+
+```csharp
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+public class DerivedFinalValueTests
+{
+    [InterceptorSubject]
+    public partial class CountingDerived
+    {
+        public static int GetterCalls;
+
+        public partial int Value { get; set; }
+
+        [Derived]
+        public int Doubled
+        {
+            get
+            {
+                GetterCalls++;
+                return Value * 2;
+            }
+        }
+    }
+
+    [Fact]
+    public void WhenDerivedRecalculationPublishes_ThenGetterIsNotReinvokedAtPublishTime()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        var subject = new CountingDerived(context);
+        using var subscription = context.GetPropertyChangeObservable().Subscribe(_ => { });
+        CountingDerived.GetterCalls = 0;
+
+        // Act
+        subject.Value = 21;
+
+        // Assert: the recalculation evaluates the getter (possibly twice for stabilization), but the
+        // publish must not add another invocation on top of the recalculated value.
+        Assert.Equal(42, subject.Doubled - 0 + 0 - subject.Doubled + 42); // value is correct
+        Assert.True(CountingDerived.GetterCalls <= 2,
+            $"expected no publish-time re-invocation, saw {CountingDerived.GetterCalls} getter calls");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~DerivedFinalValueTests"`
+Expected: FAIL, getter call count exceeds 2 (the publish re-invokes it).
+
+- [ ] **Step 3: Add the flag and honour it**
+
+In `PropertyWriteContext<TProperty>` (`IWriteInterceptor.cs`), next to `Revision`:
+
+```csharp
+    /// <summary>
+    /// Set by the derived recalculation entry point, where <see cref="NewValue"/> is already the
+    /// stabilized getter output. Stops <see cref="GetFinalValue"/> from re-invoking the getter,
+    /// which would run user code at publish time and could return a value that never paired
+    /// atomically with the change's old value.
+    /// </summary>
+    internal bool FinalValueIsNewValue;
+```
+
+and in `GetFinalValue()`:
+
+```csharp
+    public TProperty GetFinalValue()
+    {
+        if (FinalValueIsNewValue)
+        {
+            return NewValue;
+        }
+
+        var property = Property;
+        var metadata = property.Metadata;
+        return metadata.IsDerived
+            ? (TProperty)metadata.GetValue?.Invoke(property.Subject)!
+            : NewValue;
+    }
+```
+
+- [ ] **Step 4: Thread the flag from the recalculation entry point**
+
+In `InterceptorExecutor.cs`, the internal cascade overload gains a parameter and sets the field:
+
+```csharp
+    internal bool SetPropertyValue<TProperty>(string propertyName, TProperty newValue, TProperty currentValue, Action<IInterceptorSubject, TProperty> writeValue, long rawTimestamp, bool finalValueIsNewValue)
+    {
+        var context = new PropertyWriteContext<TProperty>(
+            new PropertyReference(_subject, propertyName),
+            currentValue,
+            newValue,
+            rawTimestamp)
+        {
+            FinalValueIsNewValue = finalValueIsNewValue
+        };
+
+        ExecuteInterceptedWrite(ref context, writeValue);
+        return context.IsWritten;
+    }
+```
+
+In `PropertyReferenceExtensions.cs:25-30`, forward `finalValueIsNewValue: true` from the internal overload used by the cascade (that overload exists only for the derived recalculation path, so a literal `true` at the single forwarding site is correct; do not change the public overload).
+
+In `DerivedPropertyChangeHandler.cs:365` no signature change is needed if the internal extension overload passes `true`; verify by reading the call chain and adjust the extension's parameter list if it forwards positionally.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~DerivedFinalValueTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the derived and tracking suites**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests`
+Expected: PASS. If a derived test asserts the old publish value, treat it as the documented behavior change: update it and note the change in the PR description.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs \
+        src/Namotion.Interceptor/Interceptors/InterceptorExecutor.cs \
+        src/Namotion.Interceptor/PropertyReferenceExtensions.cs \
+        src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs \
+        src/Namotion.Interceptor.Tracking.Tests/Change/DerivedFinalValueTests.cs
+git commit -m "fix: stop re-invoking the derived getter when publishing a recalculation"
+```
+
+---
+
+### Task 6: Extract the flush deduplicator
+
+**Files:**
+- Create: `src/Namotion.Interceptor.Connectors/ChangeDeduplicator.cs`
+- Modify: `src/Namotion.Interceptor.Connectors/ChangeQueueProcessor.cs:39-44,228-262`
+- Test: `src/Namotion.Interceptor.Connectors.Tests/ChangeDeduplicatorTests.cs`
+
+`InternalsVisibleTo("Namotion.Interceptor.Connectors.Tests")` already exists (`Namotion.Interceptor.Connectors.csproj:10`), so the internal class is directly testable.
+
+This task is a pure extraction: behavior must not change yet.
+
+- [ ] **Step 1: Write the characterization test (positional behavior, revision 0)**
+
+Create `src/Namotion.Interceptor.Connectors.Tests/ChangeDeduplicatorTests.cs`:
+
+```csharp
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Connectors.Tests;
+
+public class ChangeDeduplicatorTests
+{
+    private static SubjectPropertyChange Change(PropertyReference property, string oldValue, string newValue, long revision)
+        => SubjectPropertyChange.Create(property, ChangeOrigin.Local, DateTimeOffset.UtcNow, null, oldValue, newValue, revision);
+
+    [Fact]
+    public void WhenRevisionsAreZero_ThenDeduplicationFallsBackToPositionalOrder()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+        var input = new List<SubjectPropertyChange>
+        {
+            Change(property, "a", "b", 0),
+            Change(property, "b", "c", 0),
+        };
+        var deduplicator = new ChangeDeduplicator();
+
+        // Act
+        var count = deduplicator.Deduplicate(input, out var buffer);
+
+        // Assert: one survivor, oldest old value, newest new value
+        Assert.Equal(1, count);
+        Assert.Equal("a", buffer[0].GetOldValue<string>());
+        Assert.Equal("c", buffer[0].GetNewValue<string>());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test src/Namotion.Interceptor.Connectors.Tests --filter "FullyQualifiedName~ChangeDeduplicatorTests"`
+Expected: FAIL, compile error `The name 'ChangeDeduplicator' does not exist`.
+
+- [ ] **Step 3: Create the deduplicator with today's positional logic moved verbatim**
+
+Create `src/Namotion.Interceptor.Connectors/ChangeDeduplicator.cs`:
+
+```csharp
+using System.Buffers;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Connectors;
+
+/// <summary>
+/// Collapses a flush batch to one change per property. Owns the pooled scratch buffers so
+/// <see cref="ChangeQueueProcessor"/> keeps only queueing and dispatch. Not thread-safe: the caller
+/// holds the flush gate, so every method runs single-threaded.
+/// </summary>
+internal sealed class ChangeDeduplicator : IDisposable
+{
+    private const int MinSize = 256;
+    private const int MaxSize = 1024;
+
+    // Value carries the survivor's buffer index plus the revision bounds seen for the property, so
+    // the newest new value and the oldest old value are chosen by revision rather than by position.
+    private readonly Dictionary<PropertyReference, (int Index, long Highest, long Lowest)> _indices = new(PropertyReference.Comparer);
+
+    private SubjectPropertyChange[] _buffer = ArrayPool<SubjectPropertyChange>.Shared.Rent(MinSize);
+
+    /// <summary>
+    /// Deduplicates <paramref name="changes"/> into an internal pooled buffer and returns the count.
+    /// The buffer is valid until the next call.
+    /// </summary>
+    internal int Deduplicate(List<SubjectPropertyChange> changes, out SubjectPropertyChange[] buffer)
+    {
+        _indices.Clear();
+        _indices.EnsureCapacity(changes.Count);
+
+        if (_buffer.Length < changes.Count)
+        {
+            ArrayPool<SubjectPropertyChange>.Shared.Return(_buffer, clearArray: true);
+            _buffer = ArrayPool<SubjectPropertyChange>.Shared.Rent(changes.Count);
+        }
+
+        var count = 0;
+
+        // Backward iteration keeps last-occurrence emit order (restored by the reverse below).
+        for (var i = changes.Count - 1; i >= 0; i--)
+        {
+            var change = changes[i];
+            if (!_indices.TryGetValue(change.Property, out var entry))
+            {
+                _indices[change.Property] = (count, change.Revision, change.Revision);
+                _buffer[count++] = change;
+                continue;
+            }
+
+            // 'change' is EARLIER by arrival than the survivor already stored at entry.Index.
+            _buffer[entry.Index] = change.MergeWithNewer(_buffer[entry.Index]);
+            _indices[change.Property] = entry;
+        }
+
+        if (count > 1)
+        {
+            Array.Reverse(_buffer, 0, count);
+        }
+
+        buffer = _buffer;
+        return count;
+    }
+
+    /// <summary>Clears retained references after the batch has been handed to the write handler.</summary>
+    internal void Reset()
+    {
+        _indices.Clear();
+        Array.Clear(_buffer, 0, _buffer.Length);
+
+        if (_buffer.Length >= MaxSize)
+        {
+            ArrayPool<SubjectPropertyChange>.Shared.Return(_buffer);
+            _buffer = ArrayPool<SubjectPropertyChange>.Shared.Rent(MinSize);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_buffer is null)
+        {
+            return;
+        }
+
+        Array.Clear(_buffer, 0, _buffer.Length);
+        ArrayPool<SubjectPropertyChange>.Shared.Return(_buffer);
+        _buffer = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test src/Namotion.Interceptor.Connectors.Tests --filter "FullyQualifiedName~ChangeDeduplicatorTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `ChangeQueueProcessor` to it**
+
+In `ChangeQueueProcessor.cs`, delete the `_flushPropertyIndices`, `_flushDedupedBuffer`, and `_flushDedupedCount` fields (lines 40-44) and replace the dedup block inside `TryFlushAsync` with:
+
+```csharp
+            var count = _deduplicator.Deduplicate(_flushChanges, out var deduped);
+            if (count > 0)
+            {
+                try
+                {
+                    await _writeHandler(new ReadOnlyMemory<SubjectPropertyChange>(deduped, 0, count), cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to write changes.");
+                }
+            }
+```
+
+Add the field `private readonly ChangeDeduplicator _deduplicator = new();`, call `_deduplicator.Reset()` in the `finally` alongside `_flushChanges.Clear()`, and `_deduplicator.Dispose()` in `Dispose()` in place of the old buffer return.
+
+- [ ] **Step 6: Run the connector suite**
+
+Run: `dotnet test src/Namotion.Interceptor.Connectors.Tests`
+Expected: PASS, no behavior change (this task is an extraction only).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Connectors/ChangeDeduplicator.cs \
+        src/Namotion.Interceptor.Connectors/ChangeQueueProcessor.cs \
+        src/Namotion.Interceptor.Connectors.Tests/ChangeDeduplicatorTests.cs
+git commit -m "refactor: extract the flush deduplicator from ChangeQueueProcessor"
+```
+
+---
+
+### Task 7: Revision-oriented deduplication
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Connectors/ChangeDeduplicator.cs`
+- Test: `src/Namotion.Interceptor.Connectors.Tests/ChangeDeduplicatorTests.cs`
+
+This is the actual bug fix: today's survivor is chosen by array position (arrival order), which is post-commit race order.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ChangeDeduplicatorTests`:
+
+```csharp
+    [Fact]
+    public void WhenArrivalOrderInvertsCommitOrder_ThenHighestRevisionWinsAndLowestSuppliesOldValue()
+    {
+        // Arrange: revision 6 arrived FIRST, revision 5 second (a post-commit race inversion)
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+        var input = new List<SubjectPropertyChange>
+        {
+            Change(property, "b", "newest", 6),
+            Change(property, "oldest", "b", 5),
+        };
+        var deduplicator = new ChangeDeduplicator();
+
+        // Act
+        var count = deduplicator.Deduplicate(input, out var buffer);
+
+        // Assert
+        Assert.Equal(1, count);
+        Assert.Equal("newest", buffer[0].GetNewValue<string>());  // fails today: positional picks "b"
+        Assert.Equal("oldest", buffer[0].GetOldValue<string>());
+        Assert.Equal(6L, buffer[0].Revision);
+    }
+
+    [Fact]
+    public void WhenThreeOccurrencesOutOfOrder_ThenBoundsAreTrackedAcrossAllOfThem()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        var person = new Person(context);
+        var property = new PropertyReference(person, nameof(Person.FirstName));
+        var input = new List<SubjectPropertyChange>
+        {
+            Change(property, "v2", "v3", 8),
+            Change(property, "v1", "v2", 7),
+            Change(property, "v0", "v1", 6),
+        };
+        var deduplicator = new ChangeDeduplicator();
+
+        // Act
+        var count = deduplicator.Deduplicate(input, out var buffer);
+
+        // Assert
+        Assert.Equal(1, count);
+        Assert.Equal("v0", buffer[0].GetOldValue<string>());
+        Assert.Equal("v3", buffer[0].GetNewValue<string>());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test src/Namotion.Interceptor.Connectors.Tests --filter "FullyQualifiedName~WhenArrivalOrderInvertsCommitOrder"`
+Expected: FAIL, `Assert.Equal("newest", ...)` gets `"b"`.
+
+- [ ] **Step 3: Choose survivor and baseline by revision**
+
+Replace the merge branch in `Deduplicate` with:
+
+```csharp
+            // 'change' is EARLIER by arrival than the survivor stored at entry.Index. Revisions,
+            // not positions, decide which end each value comes from: arrival order is post-commit
+            // race order. Changes built outside a terminal write carry 0 and keep the old
+            // positional behavior.
+            var kept = _buffer[entry.Index];
+            if (change.Revision == 0 || entry.Highest == 0)
+            {
+                kept = change.MergeWithNewer(kept);
+            }
+            else if (change.Revision > entry.Highest)
+            {
+                // This earlier-arriving change actually committed later: it supplies the new value.
+                kept = kept.MergeWithNewer(change);
+                entry.Highest = change.Revision;
+            }
+            else if (change.Revision < entry.Lowest)
+            {
+                kept = change.MergeWithNewer(kept);
+                entry.Lowest = change.Revision;
+            }
+
+            _buffer[entry.Index] = kept;
+            _indices[change.Property] = entry;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test src/Namotion.Interceptor.Connectors.Tests --filter "FullyQualifiedName~ChangeDeduplicatorTests"`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Run the full connector suite**
+
+Run: `dotnet test src/Namotion.Interceptor.Connectors.Tests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Connectors/ChangeDeduplicator.cs \
+        src/Namotion.Interceptor.Connectors.Tests/ChangeDeduplicatorTests.cs
+git commit -m "fix: deduplicate flush batches by commit revision instead of arrival position"
+```
+
+---
+
+### Task 8: Documentation and public API snapshot
+
+**Files:**
+- Modify: `docs/tracking.md`
+- Modify: `src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt`
+
+- [ ] **Step 1: Run the API snapshot test to see the diff**
+
+Run: `dotnet test src/Namotion.Interceptor.Tracking.Tests --filter "FullyQualifiedName~PublicApi"`
+Expected: FAIL, the received file adds `public long Revision { get; }` and the `long revision = 0` parameter on `Create`.
+
+- [ ] **Step 2: Accept the snapshot**
+
+```bash
+cp src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.received.txt \
+   src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+```
+
+Read the diff before accepting: it must contain **only** the `Revision` property and the new `Create` overload. Anything else means an unintended public change.
+
+- [ ] **Step 3: Add the guarantee section to `docs/tracking.md`**
+
+Add, in the property-change section:
+
+```markdown
+### Delivery guarantees
+
+Every committed write carries a `SubjectPropertyChange.Revision`: monotonic per subject over
+committed writes, so two changes to the *same subject* are ordered by comparing it. Revisions of
+different subjects are **not** comparable. A change built outside a terminal write carries 0.
+
+| Channel | Exactly-once | Order | Consumer runs on |
+|---|---|---|---|
+| Per-property callback | conditional (a) | arrival | writer thread |
+| Observable | conditional (a) | arrival | writer thread |
+| Pull queue | conditional (a) | arrival | consumer thread |
+| `ChangeQueueProcessor`, buffer > 0 | no, latest-state-wins | arrival of survivors; per-property newest within a flush (b) | processor thread |
+
+(a) A throwing lifecycle handler or a throwing earlier observer suppresses delivery for the rest of
+that write's consumers, so delivery is exactly-once only while those no-throw contracts hold.
+(b) Deduplication is scoped to one flush batch, so an inversion straddling a flush tick can still
+emit the older value last. Compare `Revision` in the write handler if that matters.
+
+Arrival order can differ from commit order under concurrent writers: dispatch happens after the
+commit and outside the subject lock. Compare `Revision` to converge, or re-read the property.
+```
+
+- [ ] **Step 4: Verify the whole solution builds and the unit suites pass**
+
+Run: `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/tracking.md src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+git commit -m "docs: document the commit revision and per-channel delivery guarantees"
+```
+
+---
+
+### Task 9: Benchmark gates 1, 8 and 9
+
+**Files:**
+- Modify: `src/Namotion.Interceptor.Benchmark/RegistryBenchmark.cs` (no code change expected; used as-is)
+- Create: `src/Namotion.Interceptor.Benchmark/ChangeDeduplicatorBenchmark.cs`
+
+Gate 1 is the make-or-break number: this PR adds always-on cost to every committed write.
+
+- [ ] **Step 1: Add the dedup benchmark**
+
+Create `src/Namotion.Interceptor.Benchmark/ChangeDeduplicatorBenchmark.cs`:
+
+```csharp
+using BenchmarkDotNet.Attributes;
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Benchmark;
+
+[MemoryDiagnoser]
+public class ChangeDeduplicatorBenchmark
+{
+    private readonly ChangeDeduplicator _deduplicator = new();
+    private List<SubjectPropertyChange> _batch = null!;
+
+    [Params(64, 512)]
+    public int BatchSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var context = InterceptorSubjectContext.Create();
+        var car = new Car(context);
+        _batch = new List<SubjectPropertyChange>(BatchSize);
+        for (var i = 0; i < BatchSize; i++)
+        {
+            // Half the batch repeats one property so the merge path is exercised.
+            var property = new PropertyReference(car, i % 2 == 0 ? "Name" : "Name");
+            _batch.Add(SubjectPropertyChange.Create(
+                property, ChangeOrigin.Local, DateTimeOffset.UtcNow, null, "old", "new", i + 1));
+        }
+    }
+
+    [Benchmark]
+    public int Deduplicate()
+    {
+        var count = _deduplicator.Deduplicate(_batch, out _);
+        _deduplicator.Reset();
+        return count;
+    }
+}
+```
+
+`Namotion.Interceptor.Benchmark` already has `InternalsVisibleTo` from core (`Namotion.Interceptor.csproj:16`); add the same entry to `Namotion.Interceptor.Connectors.csproj` if the internal `ChangeDeduplicator` is not visible:
+
+```xml
+		<InternalsVisibleTo Include="Namotion.Interceptor.Benchmark" />
+```
+
+- [ ] **Step 2: Verify the benchmark project builds**
+
+Run: `dotnet build src/Namotion.Interceptor.Benchmark -c Release`
+Expected: build succeeds.
+
+- [ ] **Step 3: Pin the CPU and run the gate**
+
+Pin to a fixed frequency first (see the recipe in the benchmark memory note; untrusted timings otherwise).
+
+Run:
+```bash
+pwsh scripts/benchmark.ps1 -Stash --filter "*RegistryBenchmark*"
+```
+Expected: `Write`, `WriteNoOp`, `WriteWithTimestampScope`, `Read` show **no measurable regression** and no allocation change. `WriteNoOp` in particular must be flat: the `[RunsFirst]` equality handler stops no-op writes before the terminal, so they must not pay anything.
+
+- [ ] **Step 4: Run the struct-size and dedup gates**
+
+Run:
+```bash
+pwsh scripts/benchmark.ps1 -Stash --filter "*SubjectUpdateBenchmark* *SubjectTransactionBenchmark* *ChangeDeduplicatorBenchmark*"
+```
+Expected: `SubjectPropertyChange`'s extra 8 bytes shows at most a small, explained delta on the copy-heavy update and transaction paths (the paths #389 measured). Record raw output.
+
+- [ ] **Step 5: Record the results in the PR description**
+
+Paste the raw BenchmarkDotNet tables. If gate 1 regresses measurably, **stop**: the spec requires changing the design (counter home or context stamp), not accepting the number.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Namotion.Interceptor.Benchmark/ChangeDeduplicatorBenchmark.cs \
+        src/Namotion.Interceptor.Connectors/Namotion.Interceptor.Connectors.csproj
+git commit -m "benchmarks: add the deduplicator benchmark and record the revision-label gates"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 scope):** revision on the executor and both terminals (Tasks 1-2); `SubjectPropertyChange.Revision` with the optional `revision` parameter and propagation through the private ctor, `MergeWithNewer`, `WithOrigin` (Task 3); publication on the channels (Task 4); `FinalValueIsNewValue` (Task 5); revision-oriented dedup with the `Revision` 0 positional fallback and both revision bounds (Tasks 6-7); `docs/tracking.md` matrix with the within-flush caveat (Task 8); gates 1, 8, 9 (Task 9). The non-executor fallback is covered in Task 1.
+
+**Deliberately out of scope, and why:** the `Interlocked.CompareExchange` executor publication and the `Interlocked` gate discipline belong to Phase 2 (nothing in Phase 1 reads a per-subject subscription count); cross-flush convergence is a recorded follow-up, and Task 8's documentation states the limit honestly rather than implying a full fix.
+
+**Type consistency:** `SubjectRevisionCounter.Next(IInterceptorSubject)` is used identically in both terminals; `context.Revision` is written in Task 2 and read in Task 4; `ChangeDeduplicator.Deduplicate(List<SubjectPropertyChange>, out SubjectPropertyChange[])` plus `Reset()`/`Dispose()` are the same members in Tasks 6, 7, and 9.
+
+**Known verification point for the executing engineer:** Task 5, Step 4 depends on the exact parameter list of the internal `SetPropertyValueWithInterception` overload (`PropertyReferenceExtensions.cs:25-30`). Read it before editing; if the cascade path is shared with any other caller, add an explicit `finalValueIsNewValue` parameter instead of hard-coding `true`.

--- a/docs/superpowers/specs/2026-07-29-ordered-change-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-29-ordered-change-delivery-design.md
@@ -1,0 +1,853 @@
+# Ordered and exactly-once property change delivery
+
+Date: 2026-07-29 (reworked 2026-07-30 after two independent adversarial review rounds)
+Status: Draft, awaiting user review (review round 2 verdict: mechanism core holds; its seven
+required text fixes are applied below)
+Fixes: #385 (both proposals: the commit sequence number ships as `Revision`, and the FIFO delivery
+investigation resolves into the slot mechanism). One #385 sub-claim is superseded: consumer-side
+completeness detection via contiguous sequences is unsound at the subscribe boundary (see
+Findings); completeness comes from in-lock reservation instead.
+
+## Problem
+
+The library exposes three property change delivery channels (per-property callbacks, an Rx
+observable, and a pull queue), and none of them guarantees delivery order. All dispatch happens
+after the commit and outside the subject lock, so under concurrent writers a change committed
+second can be delivered first. Consumers have no way to tell which of two deliveries reflects the
+newer stored value.
+
+This is not only a theoretical gap. `ChangeQueueProcessor.TryFlushAsync` deduplicates a flush batch
+by array position (backward iteration, last occurrence wins, `ChangeQueueProcessor.cs:243-256`).
+Array position is enqueue order, which is post-commit race order, not commit order. Under
+concurrent writers to one property the dedup can keep the earlier commit's value and hand a
+connector a stale final value. That is a live correctness bug on the state-mirroring path. This
+design fixes the within-flush case (the common burst) and documents the cross-flush case as a
+remaining limit with a recorded follow-up; see section 9.
+
+Delivery can also be lost entirely: a throwing lifecycle handler suppresses the write's
+notification (documented in #377, shipped in practice as #386), and a derived getter that throws
+during payload construction suppresses it too. The second case is not even a contract violation.
+
+Four consumer needs motivate the work:
+
+1. State-mirroring sources (OPC UA, MQTT, WebSocket) must converge to the newest committed value.
+2. Cross-channel consistency: a consumer reading two channels needs them to agree.
+3. Cross-property causal order: "the flag was set after the value".
+4. A principled, documented contract for the whole notification surface.
+
+Expected usage profile (a design input, not an afterthought): a typical application holds **many
+per-property subscriptions** (often ordered) as a high-performance alternative to context-wide
+observables, and sources sit on the **queue channel**, which must stay allocation-free and as fast
+as possible.
+
+## Goals
+
+- A delivery mode with a real guarantee: exactly-once, in commit order. Not a heuristic.
+- Preserve the existing fast path for consumers that do not opt in.
+- Per-property subscription cost must scale with what the written property has subscribed, not with
+  the total subscription count in the process.
+- The armed queue path stays allocation-free in steady state.
+- Make every consumer state which guarantee it wants, at the call site.
+- Document precisely what each channel and mode does and does not promise, with conditional
+  guarantees stated as conditional.
+
+## Non-goals
+
+- Global (cross-subject) ordered delivery and cross-subject labelling. See "Limits".
+- Turning the synchronous channels into ordered channels. Ordering requires buffering, and a
+  synchronous channel has no buffer: the writer thread is the delivery thread.
+- Ordered delivery for hand-written subjects whose `Context` is not an `InterceptorExecutor`.
+  Explicitly unsupported (today `SetPropertyValueWithInterception` already silently no-ops for
+  them, `PropertyReferenceExtensions.cs:15-16`).
+
+## Findings that constrain the design
+
+Verified in code; these drive the decisions.
+
+**The commit point is already under a per-subject lock.** `WriteInterceptorFactory.cs:14-21`
+(chain terminal) and `WriteInterceptorFactory.cs:12-22` (interceptor-less terminal; both terminals
+must be instrumented):
+
+```csharp
+lock (context.Property.Subject.SyncRoot)
+{
+    innerWriteValue(context.Property.Subject, context.NewValue);
+    context.IsWritten = true;
+    context.FinalizeOrigin();
+    context.Property.SetWriteTimestamp(raw > 0 ? raw : 0);
+}
+```
+
+`SyncRoot` is generated per subject instance (`SubjectCodeGenerator.cs:151`). This is the
+linearization point and it gives per-subject granularity for free.
+
+**Every subject owns a per-subject executor, and the write chain is compiled per aggregated
+context set and cached with invalidation.** `SubjectCodeGenerator.cs:142` emits
+`_context ??= new InterceptorExecutor(this)`; the executor caches the compiled write chain and
+rebuilds it on `OnContextChanged` (attach, detach, service changes). Chain compilation is therefore
+an existing, correctly-invalidated point at which per-context state can be bound to the write path.
+
+**Post-commit subscription resolution is unsound for ordered delivery.** This finding overturned an
+earlier revision of this design. If writers resolve the subscription list after the commit
+(outside the lock), resolution order is not commit order: two writes racing a `Subscribe` can
+resolve in inverted real-time order, so revision k's writer sees the new subscription while
+revision k+1's writer (which committed later but resolved earlier) misses it. The subscription then
+receives k, k+2, k+3 and any gap-waiting consumer stalls forever, while any non-waiting consumer
+breaks ordering. No baseline heuristic, timeout, or sorting fixes this: the information "k+1 is not
+coming" exists only in a writer that has published nothing. The subscription state must be read at
+a point serialized with installs, which means inside the subject lock. The only alternative family
+(pre-chain claims plus an install quiescence wait) was worked out in full and rejected: it requires
+two interlocked operations per write on a shared line even with zero subscribers, a `Subscribe`
+that blocks on in-flight lifecycle handlers, and a revision-sorting round-based pump.
+
+**A timeout-based reorder buffer cannot work.** The window between commit and any post-commit
+publication spans the entire unwind including lifecycle reconciliation, so it is bounded by the
+slowest handler, not a constant. A late arrival leaves only emit-out-of-order or drop.
+
+**`GetFinalValue()` invokes user code for derived properties** (`IWriteInterceptor.cs:210-217`):
+`metadata.GetValue?.Invoke(...)` when `metadata.IsDerived`. Running user getters under `SyncRoot`
+risks lock-order inversion (a getter such as `TotalPower => Devices.Sum(d => d.Power)` takes other
+subjects' locks), so payload construction must stay outside the lock.
+
+**Derived properties have two distinct write paths.**
+
+1. Recalculation: `DerivedPropertyChangeHandler.NotifyDerivedPropertyChanged:365` calls
+   `SetPropertyValueWithInterception(newValue, oldValue, NoOpWriteDelegate, rawTimestamp)` where
+   `newValue` is the stabilized getter output already committed to `data.LastKnownValue`. On this
+   path `NewValue` is the correct final value, and `GetFinalValue()`'s re-invocation of the getter
+   is what creates both a throw window and a torn pair (`OldValue` from recalculation N, `NewValue`
+   from a later state).
+2. Derived-with-setter (`DerivedPropertyChangeHandler.cs:156`): user code calls the setter of a
+   derived property that has one. `NewValue` is the setter input while the observable value is the
+   getter output, so re-invocation is load-bearing and must stay.
+
+**Aggregated contexts put multiple `PropertyChangeInterceptor` instances into one chain** (the
+existing `ArePropertyObserversResolved` flag exists for exactly this), but the **terminal runs
+exactly once per logical write**: one chain, one terminal; contexts contribute interceptor
+instances, not chains.
+
+**The generated null-context fast path bypasses interception entirely.**
+`SubjectCodeGenerator.cs:378-389`: when `_context is null` the setter stores the field directly
+(no lock, no revision, no reservation), and `_context` is published with a plain `??=`. All
+guarantees in this document are scoped to intercepted writes.
+
+**Transactions compose cleanly.** During capture, `SubjectTransactionInterceptor.WriteProperty`
+returns without calling `next` (`SubjectTransactionInterceptor.cs:85`), so the terminal never runs:
+no revision is assigned, no slot is reserved. During commit replay (`IsCommitting: true`) writes
+flow through the normal chain, so slots are reserved at replay, in replay order, under the same
+locks as ordinary writes. The echo suppression surviving from #344/#343/#366 is consumer-side
+origin filtering: commit applies carry the confirming source in their origin
+(`SubjectTransaction.cs:400`) and `ChangeQueueProcessor.ProcessAsync:145` skips changes whose
+`Origin.Source` equals its own source. Ordered subscriptions deliver commit applies as ordinary
+ordered changes; consumers filter echoes by origin exactly as today.
+
+## Design
+
+The mechanism is a claim/publish split mapped onto the existing lock: **reserve slots inside the
+subject lock (order), publish the payload in a `finally` outside it (content), deliver FIFO with a
+wait-on-pending head (guarantee)**.
+
+### 1. Per-subject `Revision` on the executor
+
+Every committed write increments an internal `long` field on the subject's `InterceptorExecutor`,
+inside `SyncRoot`: a plain increment on an object that is hot for the whole write. No dictionary
+lookup, no `Interlocked`, no shared cache line, no public API, no leak. Both terminal variants
+(chain and interceptor-less) are instrumented. For subjects whose `Context` is not an
+`InterceptorExecutor`, the label falls back to a per-subject `long[1]` holder in `Subject.Data`
+(one `GetOrAdd` per write, the same cost class as the existing `SetWriteTimestamp` storage); ordered
+delivery is not offered for such subjects (see Non-goals).
+
+The revision is stamped into an internal field on `PropertyWriteContext<TProperty>` (the pattern
+#383 established with `Terminal`). It is a **label**, not the ordering mechanism: ordering comes
+from slot positions. It exists for the `ChangeQueueProcessor` dedup fix, last-writer-wins
+convergence on the `Immediate` channels, and cross-channel agreement within a subject. Because it
+is not load-bearing for ordering, no contiguity invariant exists: vetoed writes, no-op writes, and
+transaction capture need no special care.
+
+The revision and the write timestamp cannot share a slot (timestamp is per property, revision per
+subject), and no merged operation is needed: consumers read both from the `SubjectPropertyChange`,
+stamped inside the same lock hold and therefore mutually consistent. Nobody polls the storage.
+
+### 2. Subscription topology: two kinds, two homes
+
+**Context-wide ordered subscriptions** (queue, observable, async stream: the source-facing
+channels; typically 1-2 per context) live in an **ordered registry captured in the chain closure**.
+The registry is a small core-owned object per context holding a volatile subscription array. It is
+resolved at chain-build time like any other service and baked into the terminal's closure.
+`Subscribe` mutates the array inside the registry; the terminal reads it in-lock.
+
+Why the chain closure and not per-subject state: the chain is already compiled from the aggregated
+context set and invalidated on every attach, detach, and service change (`OnContextChanged`). That
+machinery is exactly the install/evict protocol an executor-side field would need to reinvent, it
+already handles multi-context aggregation, and it works for every context regardless of which
+services are configured (a context with only the observable channel has no lifecycle interceptor,
+so lifecycle-based installation would silently never run). Because the registry and
+`PropertyChangeInterceptor` are registered together (`WithPropertyChangeSubscriptions()`), one
+chain-build snapshot contains both or neither.
+
+**Per-property ordered subscriptions** (the high-frequency kind per the usage profile) are
+**indexed subject-side**, mirroring the #377 `Immediate` listener layout but as a **parallel
+core-owned structure**: the terminal (core) cannot read Tracking-internal types
+(`InternalsVisibleTo` runs core to Tracking only), so the ordered index gets its own core-owned
+element type, `Subject.Data` key, and gate. The gate is a **per-subject count on the executor**, so
+subjects with no ordered per-property subscriptions pay a field load, and only subjects that have
+them pay the indexed dictionary lookup, which now runs inside `SyncRoot` (unlike today's
+post-commit lookup; benchmark gate 4 owns this). The terminal reserves **only into subscriptions
+matching the written property**: typically 0 or 1 reservations. Cost scales with what the written
+subject and property have subscribed, never with the process-wide count.
+
+**The gate is not a plain field.** It follows the discipline #377 established for its process-wide
+counterpart (`PropertyChangeSubscriptions.cs:12-22`, `PropertyChangeSubscription.cs:33,60,67`):
+`Interlocked` increment and decrement, **increment before install**, **decrement after removal**,
+and an `Interlocked.MemoryBarrier()` after the install, because a `ConcurrentDictionary` bucket-lock
+release is not a full fence. A plain field loses updates under concurrent subscribes to two
+properties of one subject, and a lost increment permanently closes the gate on a live subscription:
+every later write reads zero, reserves nothing, and the section 7 guarantee is silently violated
+forever. That trailing fence is also what makes the section 7 boundary argument airtight on weak
+memory: the in-lock reader's fence comes from `Monitor.Enter`, but the installer needs its own.
+
+Cost model per write, in-lock:
+
+| Write target | In-lock ordered-delivery cost |
+|---|---|
+| Subject without ordered per-property subs, no context-wide subs | marker check + per-subject count load |
+| Subject with ordered subs, write to an unobserved property | + one indexed lookup miss |
+| Property with one ordered per-property sub | + one lookup + one reservation |
+| Context-wide subs armed | + one reservation per context-wide sub |
+
+### 3. Slot reservation inside the lock (core)
+
+The terminal gains, inside the existing `lock (SyncRoot)`:
+
+```csharp
+var executor = subject.Context as InterceptorExecutor;
+var revision = executor is not null
+    ? ++executor.Revision
+    : IncrementRevisionFallback(subject);          // Data long[1] holder: label only;
+                                                   // ordered delivery unsupported here
+
+// Reservation is gated on the publisher marker: PropertyChangeInterceptor sets an internal
+// flag on the write context BEFORE calling next(). Reservation therefore cannot happen unless
+// the resolver is provably above the terminal on this call stack. A chain without the
+// interceptor (misconfiguration, teardown race) skips reservation: a miss, never a stall.
+if (context.PublisherPresent && executor is not null)   // ordered delivery requires an executor
+{                                                      // (Non-goals); the null branch above keeps
+    var record = context.ReservationRecord;             // the label working for other subjects
+                                                   // pooled, rented by the interceptor
+                                                   // OUTSIDE the lock (see below)
+    // Context-wide subscriptions, from the chain-closure registries. The chain build
+    // captures ALL ordered registries visible in the aggregated context set (an executor
+    // aggregating two subscribing contexts has two; instances are captured, not types).
+    // The in-lock read is serialized per subject by SyncRoot: once one write to a subject
+    // observes a subscription, every later write observes it too. The owed set is a clean
+    // per-subject suffix by construction; this is the boundary-correctness argument.
+    foreach (var registry in registries)           // captured at chain build
+    {
+        var subs = registry.Subscriptions;         // volatile read
+        for (var i = 0; i < subs.Length; i++)
+        {
+            var slot = subs[i].Buffer.ReserveSlot();  // interlocked cursor bump into a
+            slot.Revision = revision;                 // segmented array of structs
+            slot.State = Pending;
+            record.Track(subs[i], slot);           // progress count incremented AFTER a
+        }                                          // successful reserve: failure-atomic
+    }
+
+    // Per-property ordered subscriptions: per-subject count gate (interlocked executor field,
+    // read here under the lock), then the core-owned indexed lookup.
+    if (Volatile.Read(ref executor.OrderedPropertyListenerCount) != 0 &&
+        TryGetOrderedListeners(context.Property, out var listeners))
+    {
+        // same reserve-and-track loop
+    }
+}
+
+innerWriteValue(subject, context.NewValue);        // reservation BEFORE the store: the store
+context.IsWritten = true;                          // is a field write on the generated path;
+context.FinalizeOrigin();                          // if reservation throws, nothing was
+context.Property.SetWriteTimestamp(...);           // committed and the finally cancels the
+                                                   // tracked prefix. Committed implies reserved.
+```
+
+Properties of this step:
+
+- **Unarmed cost**: the publisher-marker check (a bool on the by-ref context) plus, when the marker
+  is set, a registry array read and a count-gate load. Fully accounted: `subject.Context` interface
+  dispatch, `isinst InterceptorExecutor`, the revision increment, and the context stamp are part of
+  the always-on cost and are what benchmark gate 1 measures.
+- **Armed cost**: interlocked cursor bump and two field writes per matching subscription. **No
+  per-write allocator inside the lock**: the reservation record is pooled and rented by the
+  interceptor before `next()`; slot buffers are segmented arrays whose growth allocates only
+  amortized, occasionally inside the lock (the `ConcurrentQueue` model that already measures 0 B;
+  benchmark gate 4's tail latencies own the occasional in-lock segment allocation).
+- **Failure atomicity**: the record's progress count is incremented only after a successful
+  reserve, so a throw anywhere in the loop leaves exactly the tracked prefix, which the `finally`
+  cancels. The value store happens after all reservations; an aborted reservation aborts the write
+  before commit.
+- **Aggregation**: the terminal runs once per logical write, so reservation is deduplicated by
+  construction. Publish-side dedup is separate (section 4).
+- The cross-subject caveat, stated: the per-subject lock does not serialize different subjects
+  reserving into the same subscription's buffer, hence the interlocked cursor. Per-subject commit
+  order is preserved (same-subject reservations are under `SyncRoot`), which is exactly the
+  promised guarantee. Cursor contention across subjects is inherent to any shared totally-ordered
+  queue.
+
+Layering: the slot buffer, slot state, registry, and reservation record are small **core-owned
+internals**; Tracking consumes them via `InternalsVisibleTo` (the #383 pattern). No interface, no
+virtual call, no delegate. No public API is added to core.
+
+### 4. Publish in the `finally` (Tracking)
+
+`PropertyChangeInterceptor.WriteProperty`:
+
+```csharp
+// Rent the pooled reservation record and set the publisher marker BEFORE next(), but only
+// when ordered delivery is armed anywhere (registry subs or ordered property-subscription
+// count nonzero): the idle fast path stays free of both the rental and the try/finally.
+var armed = /* registry subs present || subject's ordered per-property count != 0 */;
+if (armed && context.ReservationRecord is null)     // idempotent under aggregation: only the
+{                                                   // outermost armed instance rents; an
+    context.ReservationRecord = RecordPool.Rent();  // unconditional rent would overwrite the
+    context.PublisherPresent = true;                // field and leak one pooled record per
+}                                                   // write at aggregation depth >= 2
+
+try
+{
+    next(ref context);                              // commit + lifecycle reconciliation
+    DispatchImmediateChannels(ref context);         // unchanged post-unwind dispatch
+}
+finally
+{
+    if (context.ReservationRecord is { } record)    // consume-once: the innermost aggregated
+    {                                               // instance resolves and nulls the record;
+        context.ReservationRecord = null;           // outer instances see null and no-op
+        if (context.IsWritten)
+            PublishSlots(record, ref context);      // payload built outside the lock, struct
+        else                                        // copied into each tracked slot, then
+            CancelSlots(record);                    // State = Released (volatile), drains
+        RecordPool.Return(record);                  // signaled. Cancel covers vetoes and
+    }                                               // partial reservations.
+}
+```
+
+- The `finally` guarantees every tracked slot resolves to Released or Cancelled, so a drain waiting
+  on a Pending head always makes progress. A throwing lifecycle handler no longer suppresses
+  delivery to ordered subscribers: the value was committed, so it is delivered, and the exception
+  still propagates unchanged. This is a deliberate, documented semantic change.
+- The innermost aggregated instance's `finally` runs first on the unwind and is still outside
+  `LifecycleInterceptor` (`[RunsBefore(LifecycleInterceptor)]`), so publication happens after
+  attach/detach reconciliation, at the earliest safe point. Consume-once makes outer instances
+  no-ops (F3).
+- **Publish-time getter failure (derived-with-setter only): cancel the slot.** After section 5, the
+  only publish path that runs user code is the derived-with-setter getter re-invocation. If it
+  throws, the slot is cancelled: the consumer skips that delivery and converges on the next write.
+  Never publish a value that was not observable (the setter input is not; a fabricated pair is
+  not). This mirrors the codebase's actual precedent of keeping the last known value on getter
+  failure (`DerivedPropertyChangeHandler.cs:76-79`, `254-258`) rather than fabricating one. The
+  resulting footnote on the guarantee is removed entirely by the recorded follow-up (suppressing
+  the setter-write publication).
+- The `Immediate` channels keep today's dispatch path and semantics exactly. The idle fast path
+  (`PropertyChangeInterceptor.cs:156-161`) is entered only when ordered delivery is also unarmed,
+  so an armed write always has the publisher above the terminal.
+- **The payload is built once per write and shared** between the `Immediate` dispatch and the slot
+  publish. Building it twice would run the derived-with-setter getter twice, and the two channels
+  could then disagree on the delivered value for the same write, violating the cross-channel
+  consistency goal.
+
+### 5. Close the dominant derived publish window: `FinalValueIsNewValue`
+
+An internal flag on `PropertyWriteContext<TProperty>`, set only by the recalculation entry point
+(`DerivedPropertyChangeHandler.cs:365` through `PropertyReferenceExtensions.cs:25-30` and
+`InterceptorExecutor.cs:39-49`, all internal and already reachable). `GetFinalValue()` returns
+`NewValue` when set and re-invokes the getter otherwise (derived-with-setter). Effects: the dominant
+derived path stops running user code at publish time, removing its throw window and the torn old/new
+pair. Cost: one internal bool and one branch.
+
+Note for the "zero breaking changes" framing of Phase 1: this **is** an observable behavior change on
+the `Immediate` channels (a derived recalculation now publishes the stabilized value rather than a
+re-invoked getter's possibly-newer one). It is a bug fix, not a regression, but per the
+no-untested-regressions policy it must be called out in the PR description rather than folded in
+silently.
+
+### 6. Delivery: FIFO with wait-on-pending, deliver-before-advance
+
+The drain walks slots in reservation order. Slot order **is** commit order per subject, so there is
+no reordering, no sorting, no gap detection, no baseline logic:
+
+```csharp
+while (buffer.TryPeekHead(out var slot))
+{
+    AwaitReleasedOrCancelled(slot);                 // bounded: the finally always resolves
+    if (slot.State == Released)
+        Deliver(in slot.Payload);                   // deliver BEFORE advancing: the slot
+                                                    // cannot be reclaimed while the head
+                                                    // has not passed it (no torn reads)
+    slot.Payload = default;                         // clear on advance: a delivered slot
+    buffer.AdvanceHead();                           // must not pin subjects or boxed values
+}                                                   // (the #390 lesson; ChangeQueueProcessor
+                                                    // clears its buffers for the same reason)
+```
+
+- Push faces (callback, observable): a **per-subscription on-demand drain**, not a dedicated task:
+  a CAS gate plus a ThreadPool work item scheduled when the buffer turns non-empty and no drain is
+  in flight (the `ChangeQueueProcessor._flushGate` pattern). Zero cost while idle; a slow consumer
+  delays only itself.
+- Pull and async-enumerable faces: no pump at all; the consumer's own thread runs the same loop
+  inside `TryDequeue`/`MoveNextAsync` (the `out` copy makes deliver-before-advance automatic).
+- The `in`-reference cannot escape the callback (C# ref-safety), so delivering from the live slot
+  is safe; per-subscription buffers die with the subscription.
+- A head slot held Pending by a write stuck in lifecycle handlers delays that subscription's later
+  entries. That is what in-order delivery means; the entries are later commits.
+- **The pending-head wait is event-based and cancellable** (the `PropertyChangeQueueSubscription`
+  signal pattern): it honors the caller's `CancellationToken` and is released by subscription
+  disposal, so `TryDequeue`, `MoveNextAsync`, and drains never hang on a producer stuck in user
+  code once cancelled or disposed.
+- **Consumer contract**: a callback that blocks waiting for a *later* change of its own ordered
+  subscription deadlocks; dispatch is sequential by design. (A callback that writes properties,
+  including of the same subject, is fine: no lock is held during delivery and reservation does not
+  depend on the drain.)
+- Rx is a face, not the engine: `AsObservable` adapts the ordered subscription. `ObserveOn` would
+  add a second queue, and Rx has no resequencing operator, so the wait-on-pending loop is custom
+  either way.
+
+### 7. Boundary and contract scope
+
+**Subscribe versus write**: sound by lock serialization. `Subscribe` publishes into the registry
+(or the subject-side index) and returns immediately; the terminal's in-lock read is serialized per
+subject, so once one write observes the subscription, all later writes to that subject do: the owed
+set is a per-subject suffix. A write that commits after `Subscribe` returned performs its in-lock
+read after the install is visible and is delivered.
+
+**Attach carve-out**: registry visibility rides chain-cache invalidation, and a write racing an
+attach may still execute the old chain (no registry). Contract: delivery is guaranteed for writes
+committing after *both* `Subscribe` returned *and* the subject's attach completed. Writes racing an
+attach or a subject-side install may be **missed, never stalled, never disordered** (FIFO waits
+only on reserved slots; a missed write reserved nothing). This is the same shape as the
+already-documented dormancy limit: an unattached subject delivers nothing on any channel.
+
+**Contract scope**: all guarantees apply to **intercepted writes on generated subjects**. The
+generated null-context fast path bypasses interception entirely and `_context` is published without
+fences; writes racing the very first context attach may be unintercepted. Hand-written subjects
+whose `Context` is not an `InterceptorExecutor` are excluded from ordered delivery (Non-goals).
+
+**Validation**: `Subscribe(..., PropertyChangeDelivery.Ordered)` throws upfront when the subject or
+context is attached and its aggregated context set has no `PropertyChangeInterceptor`, making the
+misconfiguration loud at the right moment. It also throws when `subject.Context is not
+InterceptorExecutor`: ordered delivery is unsupported there (Non-goals), and the per-subject gate has
+no home, so allowing it would mean silent never-delivery instead of a loud failure. A per-property
+`Ordered` subscribe on a subject **not yet attached to any context is allowed and dormant**
+(consistent with `Immediate` subscriptions, which are context-free at install); delivery begins per
+the attach carve-out above. The publisher marker (section 3) keeps every later misconfiguration safe
+(teardown races, reattachment to a tracking-less context): a miss, never a stall.
+
+**Prerequisite: the executor must be published race-free.** The generated
+`IInterceptorSubject.Context => _context ??= new InterceptorExecutor(this)`
+(`SubjectCodeGenerator.cs:142`, same shape in `DynamicSubject.cs:30`) is a racy lazy initializer:
+two threads racing the first `Context` access each construct an executor and one store is discarded.
+That is a pre-existing latent defect (any state on the discarded instance is lost), and this design
+makes it a correctness hole: a pre-attach `Subscribe(Ordered)` can increment the gate on the
+discarded executor while a concurrent first attach installs the surviving one, leaving an installed
+listener that no write ever reserves into, **permanently**, in direct violation of the guarantee
+above. The generator must therefore publish the executor with
+`Interlocked.CompareExchange(ref _context, new InterceptorExecutor(this), null)` and return the
+winner (the loser's instance is discarded before any state reaches it). This is a Phase 2
+prerequisite and a standalone bug fix; the existing `??=` carve-out in Contract scope covers only
+unintercepted writes racing the first attach, never the loss of a subscription.
+
+### 8. Public API: a required delivery mode
+
+```csharp
+public enum PropertyChangeDelivery
+{
+    /// <summary>
+    /// Synchronous, on the writing thread. Arrival order, which can differ from commit order under
+    /// concurrent writers (compare <see cref="SubjectPropertyChange.Revision"/> to converge).
+    /// Exactly-once provided lifecycle handlers and observers honor their no-throw contracts;
+    /// a violation loses delivery for the remaining consumers of that write (at-most-once).
+    /// <para>Performance: lowest per-write overhead, no per-change allocation. The consumer runs
+    /// inline on the writing thread, so its cost is added to every write. Prefer for short
+    /// non-blocking work such as setting a flag.</para>
+    /// </summary>
+    Immediate,
+
+    /// <summary>
+    /// Exactly-once, in commit order per subject. The order guarantee is strictly per subject:
+    /// all changes of one subject (across all its properties) arrive in commit order, while
+    /// changes of different subjects may interleave in any order, and their
+    /// <see cref="SubjectPropertyChange.Revision"/> values are not comparable. Delivery survives
+    /// throwing lifecycle handlers and throwing observers of other channels. One exception: a
+    /// derived property with a setter whose getter throws at publish time skips that delivery.
+    /// <para>Performance: adds a slot reservation inside the subject lock and a payload publish per
+    /// committed write, allocation-free in steady state; delivery runs off the writer thread, so
+    /// consumer cost leaves the write path. A change can be held briefly while a concurrent write
+    /// to the same subject completes its publish.</para>
+    /// </summary>
+    Ordered,
+}
+```
+
+Required on every entry point, so each call site states its guarantee:
+
+```csharp
+using var h1 = car.SubscribeToProperty(c => c.Speed, callback, PropertyChangeDelivery.Ordered);
+using var h2 = property.Subscribe(callback, PropertyChangeDelivery.Immediate);
+
+using var h3 = context.GetPropertyChangeObservable(PropertyChangeDelivery.Ordered)
+    .Subscribe(change => ...);
+
+using var queue = context.CreatePropertyChangeQueueSubscription(PropertyChangeDelivery.Ordered);
+while (queue.TryDequeue(out var change, cancellationToken)) { ... }
+
+await foreach (var change in context.GetPropertyChangesAsync(PropertyChangeDelivery.Ordered, ct)) { ... }
+```
+
+The callback type stays `void (in SubjectPropertyChange)` for both modes; a pumped delivery invokes
+the same synchronous callback on the drain thread. `SubjectPropertyChange` gains a public
+`long Revision`.
+
+One method name covers two threading models; this is inherent (ordered delivery can never be
+inline) and the enum plus documentation carry the signal. The synchronous channels' documentation
+states explicitly that observers and callbacks must not throw, matching the Rx grammar and the
+lifecycle-handler contract; this is what makes the conditional exactly-once claim for `Immediate`
+precise.
+
+### 9. `ChangeQueueProcessor`
+
+- `bufferTime > 0` (dedup mode): the processor's internal subscription is **`Immediate`**. The
+  queue channel must stay as cheap as possible for connector deployments (the usage profile), and
+  within-flush convergence needs only the revision label: the per-property survivor keeps the
+  **highest `Revision`** (the dedup dictionary is keyed by `PropertyReference`, so compared
+  revisions always belong to one subject and are comparable), and the merged old value is taken
+  from the **lowest** revision. The flush pass tracks both bounds alongside the survivor index (a
+  widened dictionary value); still O(n). Changes carrying `Revision` 0 (hand-constructed, outside
+  the terminal) fall back to positional merging. Batch emit order stays **last-occurrence arrival
+  order**: cross-property commit order is not restored in this mode (a cross-subject revision sort
+  would be meaningless).
+
+  **Scope of the fix, stated honestly: within-flush only.** Dedup is scoped to one `_flushChanges`
+  batch (`ChangeQueueProcessor.cs:243-256`), so a commit-order inversion that straddles a flush tick
+  survives it: writer A commits revision 5 and is preempted before its post-commit enqueue, writer B
+  commits revision 6 and enqueues, the tick emits 6, then A enqueues and the next tick emits 5,
+  leaving the external system stale until the next real write. This is strictly better than master
+  (which inverts within a batch too, the common burst case) but it is **not** full convergence. Full
+  convergence needs a persistent per-property last-emitted-revision filter, whose state must be
+  evicted when subjects detach (a `PropertyReference`-keyed map holds subjects alive), so it is
+  recorded as a follow-up rather than smuggled into this design. Deployments that need exactly-once
+  commit order today use `bufferTime = 0` with `Ordered`.
+- `bufferTime = 0`: the processor subscribes **`Ordered`** and becomes an exactly-once,
+  commit-order forwarder. This arms the context: every write in it pays the reservation path. The
+  trade is explicit and belongs to deployments that choose zero buffering.
+- No constructor signature change.
+
+## Core footprint
+
+Everything added to `Namotion.Interceptor` is internal; core's public API snapshot stays
+byte-identical. Core holds mechanism, never policy: the same division of labor as `SyncRoot`, the
+write-timestamp slot, `FinalizeOrigin`, and #383's `Terminal` threading.
+
+| Addition to core | What it is | Why core |
+|---|---|---|
+| `InterceptorExecutor.Revision` | one `long`, incremented in the terminal | must happen inside `SyncRoot` |
+| `InterceptorExecutor.OrderedPropertyListenerCount` | one `int` gate, `Interlocked`-maintained by Tracking (increment before install, decrement after removal, trailing fence) | read in-lock by the terminal |
+| Race-free executor publication | generator emits `Interlocked.CompareExchange` instead of `??=` | prerequisite for the gate's home to be stable; standalone bug fix |
+| `PropertyWriteContext` fields | revision stamp, publisher marker, record ref, `FinalValueIsNewValue` | the per-call vehicle between layers |
+| Ordered registry | volatile subscription array per context | read in-lock; captured at chain build |
+| Slot buffer + reservation record | generic `SlotBuffer<TPayload>` (Tracking instantiates with `SubjectPropertyChange`; core reserves headers only) and the pooled tracker | `ReserveSlot` runs in-lock |
+| Terminal + chain-build code | ~15-30 lines | this is the commit section |
+| `InternalsVisibleTo(Tracking)` | one attribute | Tracking arms and consumes the mechanism |
+
+Untouched core is not achievable: the design rests on capturing order inside the commit's critical
+section, which core owns, and the Tracking-only alternative (post-commit resolution) is proven
+unsound, not merely inconvenient (see Findings). The mechanism is inert without Tracking: marker
+unset, the terminal's addition collapses to the revision increment and a false branch, which is
+what benchmark gate 1 protects.
+
+## Guarantee matrix
+
+The deliverable for `docs/tracking.md`.
+
+| Channel | Delivery | Exactly-once | Order | Consumer runs on | Per-write cost |
+|---|---|---|---|---|---|
+| Per-property callback | `Immediate` | conditional (a) | arrival | writer thread | lowest, no allocation |
+| Per-property callback | `Ordered` | yes (b) | commit, per subject | drain thread | gated lookup + slot reserve + publish |
+| Observable | `Immediate` | conditional (a) | arrival | writer thread | lowest |
+| Observable | `Ordered` | yes (b) | commit, per subject | drain thread | slot reserve + publish |
+| Pull queue | `Immediate` | conditional (a) | arrival | consumer thread | post-commit enqueue |
+| Pull queue | `Ordered` | yes (b) | commit, per subject | consumer thread | slot reserve + publish |
+| `ChangeQueueProcessor`, buffer = 0 | `Ordered` | yes (b) | commit | processor thread | as pull queue |
+| `ChangeQueueProcessor`, buffer > 0 | dedup (`Immediate`-fed) | no, latest-state-wins | arrival, of survivors; per-property newest **within a flush** (c) | processor thread | plus dedup pass per flush |
+
+(a) Exactly-once provided lifecycle handlers and observers honor their no-throw contracts, and
+except (b).
+(b) A derived-with-setter property whose getter throws at publish time skips that delivery on all
+channels (the getter re-invocation is load-bearing there; a fabricated value is never published).
+Removed entirely by the recorded setter-write-suppression follow-up.
+(c) Dedup is per flush batch, so an inversion straddling a flush tick still emits stale-last. Better
+than master, not full convergence; see section 9 and the recorded follow-up.
+
+All guarantees scoped to intercepted writes on generated subjects (section 7). "Commit, per
+subject" is strict: one subject's changes arrive complete and in commit order, different subjects'
+changes may interleave arbitrarily, and their revisions are not comparable. Every entry in the
+last column stays qualitative until measured (see benchmark plan).
+
+## Limits, stated explicitly
+
+**Ordered delivery and the label are per subject, not global.** Different subjects hold different
+`SyncRoot` locks, so their slot reservations into one subscription can interleave in either order,
+and revisions of different subjects are not comparable. Within one subject, ordering holds across
+all its properties, and per-property order follows as a subsequence. Cross-subject causal order is
+not provided; it would require a process-wide serialization point on every write. If ever needed, a
+`WithGlobalChangeOrdering()` opt-in can add a cross-subject label without disturbing this design.
+
+**`Immediate` guarantees are conditional on consumer contracts** (matrix note a). The library does
+not add per-observer `try/catch` to the hot path: even with it, the guarantee would remain
+conditional on user code in new ways.
+
+**Ordered mode trades memory for liveness.** Unbounded slot buffers by default, matching today's
+raw queue. A slow consumer grows the buffer rather than dropping (incompatible with exactly-once)
+or blocking the writer. A blocking bound is a later knob.
+
+**A producer preempted between reservation and publish briefly holds back that subscription's
+head.** Latency, not corruption; bounded by the producer's unwind (including its lifecycle
+handlers).
+
+**A stuck producer parks the drain thread.** A push-face drain blocked on a Pending head holds its
+ThreadPool thread for the producer's entire unwind; a hanging lifecycle handler holds it
+unboundedly, and many ordered subscriptions make this a ThreadPool starvation vector. The pull
+faces block only their own consumer thread, and every wait is cancellable (section 6).
+
+## Decided
+
+1. **Ordering core: in-lock slot reservation + `finally` publish.** The alternative family
+   (pre-chain claims plus install quiescence) was fully designed and rejected; an earlier no-hook
+   revision (post-commit resolution + contiguous-prefix pump) was found unsound (see Findings).
+2. **Context-wide subscription state lives in chain-closure registries** (plural: all registries
+   in the aggregated context set are captured; rides existing chain-cache invalidation, no
+   executor-side install/evict protocol, no lifecycle dependency); **per-property ordered
+   subscriptions are indexed subject-side** in a core-owned parallel of the #377 layout, gated by
+   a per-subject count on the executor, so cost scales with the written subject's and property's
+   subscribers (usage-profile requirement).
+3. **Publisher marker**: reservation is gated on `PropertyChangeInterceptor` having set a per-write
+   context flag before `next()`, making "reserved but no resolver on the stack" unrepresentable;
+   plus a `Subscribe`-time validation throw for contexts without the interceptor.
+4. **Pooled reservation record** rented outside the lock, progress-count tracked, consume-once in
+   the `finally` (also the aggregation publish dedup), returned to the pool.
+5. **Deliver-before-advance and clear-on-advance** in the drain (no torn reads on recycled slots,
+   no pinned references).
+6. **Publish-time getter failure cancels the slot** (never publish a fabricated value); footnote
+   (b) until the setter-write-suppression follow-up lands.
+7. **Pump model: per-subscription on-demand drain** (CAS gate + ThreadPool work item), pull faces
+   pumpless.
+8. **Release timing: 0.9.0 publishes on its own schedule; this work does not gate it.** The
+   required-enum change breaks the 0.8.0-era APIs and the #377 subscription API one release after
+   it ships; accepted, the fix is mechanical.
+9. **Transactions: resolved by code reading** (see Findings).
+10. **Fallback values**: recalculation-path derived publishes use `NewValue` via
+    `FinalValueIsNewValue` (it is the stabilized value); no `Faulted` flag anywhere.
+11. **`ChangeQueueProcessor` modes**: `bufferTime > 0` rides an `Immediate` subscription plus
+    revision-oriented dedup (arrival-order survivors, per-property latest-state; keeps connector
+    contexts unarmed and the queue channel cheap); `bufferTime = 0` rides `Ordered` and arms the
+    context, an explicit trade for zero-buffer deployments.
+
+## Delivery structure: two stacked PRs
+
+Phase 1 (additive, zero breaking changes): per-subject `Revision` in both terminals,
+`SubjectPropertyChange.Revision`, the `ChangeQueueProcessor` dedup fix, `FinalValueIsNewValue`,
+the `docs/tracking.md` matrix, benchmark gates 1, 8, 9.
+
+Phase 2 (breaking): the ordered channel (marker, registries, per-property index, reservation
+record, slot buffers, publish, drain, required enum, `bufferTime = 0` riding `Ordered`), remaining
+gates.
+
+**PR 2 is stacked on PR 1, not merged sequentially.** Phase 2's benchmarks are the first real
+measurement of Phase 1's always-on cost under load (gate 1 measures it in isolation; gates 2-7
+measure it in context), and a regression there may require changing Phase 1 decisions: where the
+revision counter lives, whether the context stamp is needed at all, or the struct-size trade of
+`SubjectPropertyChange.Revision`. Keeping PR 1 open and stacked lets both be corrected together
+before either merges, instead of shipping a label whose storage the ordered channel then proves
+wrong.
+
+### `SubjectPropertyChange.Create` and revision propagation
+
+`Create` has roughly 100 call sites across production and tests, and is the only overload today
+(`SubjectPropertyChange.cs:43-49`). It gains an **optional** `long revision = 0`: one method, no
+call-site churn, and 0 means exactly "constructed outside a terminal write", which the dedup already
+falls back to positional merging for.
+
+This is source-compatible but **binary breaking** (a consumer compiled against the six-parameter
+method would get `MissingMethodException`). Accepted deliberately: the library ships a source
+generator, so consumers recompile against every new version regardless, which makes binary
+compatibility far less load-bearing here than a clean single-method surface. The alternative
+considered and rejected was a seven-parameter overload with the six-parameter one forwarding: binary
+safe, but it permanently doubles a public API for a constraint this project does not operate under.
+`PublicApiGenerator` captures optional-parameter defaults, so the snapshot test surfaces the change
+either way. Phase 1 is therefore "additive plus one declared binary break", not literally
+break-free; the PR description must say so.
+
+Revision must also propagate through every derived-instance path, none of which the private
+constructor knows about today:
+
+- the private constructor (`SubjectPropertyChange.cs:14-32`) gains the field;
+- `MergeWithNewer` (`:193-204`) carries the **newer** change's revision, since it is called inside
+  the dedup being fixed (`ChangeQueueProcessor.cs:254`); a merged survivor defaulting to 0 would
+  degrade every three-occurrence property to positional comparison mid-batch;
+- `WithOrigin` (`:211-219`) preserves it, or every confirmed transaction snapshot
+  (`SourceTransactionWriter.cs:306,325,394`) loses its revision.
+
+## Plan-level verification items
+
+- Chain-build snapshot consistency: registry and `PropertyChangeInterceptor` must come from one
+  consistent service snapshot under concurrent context mutation (the existing interceptor chain has
+  the same exposure; verify the locking covers the registry).
+- `OnContextChanged`/chain-rebuild fires on every attach flow, including the
+  `new Subject(context)` constructor path.
+- #344 history: confirm no suppression mechanism exists in the enqueue path beyond consumer-side
+  origin filtering.
+- Subject-side ordered-listener install visibility (`ConcurrentDictionary` add versus in-lock
+  read): confirm monotone visibility, mirroring the #377 Dekker analysis.
+- Shared-payload optimization: with N matching subscriptions the payload struct is copied into N
+  slots; a shared payload table may win for large N. Measure.
+- Slot buffer segment size, growth policy, and disposal; drain state eviction verified by test.
+  Per-property subscriptions are the many-instances case (usage profile: 100+ per app), so their
+  initial segment must be small (4-8 slots, grow on demand) to keep idle memory per subscription
+  in the low hundreds of bytes rather than kilobytes.
+- Document the drain concurrency contract: callbacks are serial within one subscription and may
+  run in parallel across subscriptions.
+- Pending-head wait mechanism: event-based, cancellable, released on disposal, allocation profile.
+- Chain-build capture of ordered registries: `GetWriteInterceptorFunction` today fetches only
+  `IWriteInterceptor` (`InterceptorSubjectContext.cs:226-237`); the registry fetch must come from the
+  same consistent snapshot. Also cover the `_noServicesSingleFallbackContext` delegation path
+  (`InterceptorSubjectContext.cs:183-195`), where the chain and its closure live on the shared parent
+  context and the first-attach fast path skips `OnContextChanged` entirely (`:96-99`): the "invalidated
+  on every attach" claim is literally false there, and it happens to work only because the parent's
+  chain already carries the registry. Verify, do not assume.
+- `record.Track(subscription, slot)` cannot store a `ref` to a struct slot: it stores
+  `(subscription, slotIndex)` and publish/cancel re-address the slot. The pseudo-code shape is
+  illustrative, not literal.
+- The generic slot buffer needs a **non-generic header surface**: the terminal is generic over
+  `TProperty`, not over the payload, so core reserves header segments (revision, state) through a
+  non-generic base and Tracking's derived type owns the `SubjectPropertyChange` payload segments.
+- Home for the once-built shared payload (`Immediate` dispatch plus slot publish): the pooled
+  reservation record is the natural armed-only home; a field on `PropertyWriteContext<TProperty>`
+  would grow the struct on the unarmed path, which gate 9 must then cover. Today's per-instance build
+  under aggregation (`PropertyChangeInterceptor.cs:185`) is the retained unarmed baseline.
+- The reservation record's tracking list can grow inside the lock when one write matches many
+  subscriptions: same amortized class as slot segments, and covered by the same caveat.
+
+## Benchmark plan (gate, not garnish)
+
+Everything quantitative in this document is mechanism-derived reasoning and must be measured before
+merge. This codebase has been burned exactly here: #383's apparent "+3% write regression" was JIT
+code-placement luck, and #388 made `--memoryRandomization` the default for that reason. Method:
+`pwsh scripts/benchmark.ps1 -Stash`, CPU pinned at a fixed frequency, allocation columns treated as
+first-class results (priority order per AGENTS.md).
+
+1. **Unarmed regression gate** (the make-or-break number): `RegistryBenchmark` `Write`, `WriteNoOp`,
+   `WriteWithTimestampScope`, `Read` with zero ordered subscriptions. Measures the full always-on
+   set: `subject.Context` dispatch, `isinst`, revision increment, context stamp, marker check.
+   Acceptance: no measurable time or allocation regression; if it regresses, the design changes.
+2. **Armed steady-state allocation gate**: `Ordered` counterparts of every existing
+   `PropertyChangeSubscriptionsBenchmark` `Write*` variant. Acceptance: 0 B steady state on
+   primitive-valued writes (including record pool traffic and slot clearing), matching today's
+   queue channel; time within a stated envelope of the `Immediate` counterparts.
+3. **Many-per-property-subscriptions scenario** (usage-profile gate): e.g. 100 ordered per-property
+   subscriptions across a graph; measure writes to observed and unobserved properties. Acceptance:
+   writes to subjects without ordered subscriptions pay only the per-subject count load; writes to
+   an observed subject's unobserved properties pay one indexed lookup miss; observed properties pay
+   only their own subscribers.
+4. **In-lock cost isolation**: armed single-writer benchmark isolating lock-hold extension
+   (cursor bump + field writes) against the unarmed baseline.
+5. **Contention matrix**: multi-writer benchmarks over {same subject, distinct subjects} x
+   {unarmed, one ordered subscription, four ordered subscriptions}. Verifies no cross-subject
+   contention when unarmed and characterizes cursor contention when armed.
+6. **Delivery latency and throughput**: commit-to-consumer latency distribution and sustained
+   throughput for `Ordered` push and pull faces under single and concurrent writers, including the
+   held-head case.
+7. **Pump overhead**: on-demand drain scheduling cost under bursty writes versus sustained load.
+8. **`ChangeQueueProcessor` dedup**: flush-pass cost with revision comparison versus positional, at
+   realistic batch sizes.
+9. **Struct-size check**: `SubjectPropertyChange` +8 bytes (`Revision`) across the copy-heavy paths
+   #389 measured, plus `PropertyWriteContext` growth (record reference, marker, flags) on the
+   unarmed path.
+10. **Transactions**: `SubjectTransactionBenchmark` `CommitChanges` (Local / SingleSource /
+    MultiSource), unarmed and armed.
+
+Results are recorded in the PR with raw BenchmarkDotNet output, and the guarantee matrix's cost
+column is updated from measurements before `docs/tracking.md` ships.
+
+## Testing
+
+- Ordering under concurrent writers: many threads writing one subject, assert per-subject commit
+  order (by revision) and every committed write delivered exactly once on `Ordered`.
+- Boundary: subscriptions installed concurrently with write storms; assert no stall ever, every
+  write committed after `Subscribe` returned (and attach completed) is delivered, and delivered
+  prefixes are gap-free per subject.
+- Attach carve-out: subjects attached mid-storm; racing writes may miss but never stall or
+  disorder.
+- Publisher marker: a chain without `PropertyChangeInterceptor` and an armed subject-side
+  subscription; assert miss-not-stall; `Subscribe` validation throws on such contexts.
+- Publish guarantee: a throwing lifecycle handler; assert `Ordered` consumers receive the change,
+  the drain does not stall, and the exception propagates unchanged.
+- Publish-time getter throw (derived-with-setter): slot cancelled, consumer skips, next write
+  converges, no stall.
+- Atomicity: fault injection between reservations; assert the tracked prefix is cancelled and
+  nothing was committed.
+- Aggregation: exactly one reservation set AND exactly one publish per write at aggregation depth
+  >= 2 (consume-once).
+- Torn-read stress: concurrent producers recycling slots while a consumer delivers; assert payload
+  integrity (deliver-before-advance) and cleared slots after advance (no pinned references,
+  `WeakReference` assertions in the #390 style).
+- `FinalValueIsNewValue`: recalculation publishes the stabilized value without re-invoking the
+  getter (counting getter); derived-with-setter still re-invokes.
+- Veto and no-op writes: no slot reserved, no revision-related machinery invoked.
+- Transactions: capture reserves nothing; commit replay delivers in replay order; origin-based echo
+  filtering still suppresses self-echoes in `ChangeQueueProcessor`.
+- `ChangeQueueProcessor` dedup with deliberately inverted enqueue order: highest `Revision` wins
+  and the merged old value comes from the lowest revision. Fails on current code.
+- Subscribe and dispose races against in-flight writes, both modes; drain state eviction on
+  subscription disposal and subject detach (no leak).
+- Record-pool balance at aggregation depth >= 2 (rent idempotence: exactly one rent and one return
+  per write; catches the double-rent leak the reservation/publish counts alone cannot see).
+- Two aggregated contexts each with their own ordered registry: reservations land in both.
+- Cancellation and disposal during a pending-head wait unblock `TryDequeue`, `MoveNextAsync`, and
+  drains.
+- Cross-channel value agreement for derived-with-setter on one write (payload built once).
+- Drain behavior under a producer stuck in a lifecycle handler: thread parked, released on
+  resolve, cancellable throughout.
+- Pre-attach ordered per-property subscribe: dormant, delivers after attach to a tracking context,
+  validation throws when the attached context set lacks the interceptor.
+- Public API snapshot updated: enum, required parameters, `SubjectPropertyChange.Revision`.
+
+## Follow-ups, tracked separately
+
+- Derived-with-setter: suppress the setter-write publication and let the recalculation publish
+  alone. Removes footnote (b) everywhere and deletes the last publish-time user-code path; changes
+  observable notification count and needs an origin-semantics pass (the suppressed setter-write may
+  carry `FromSource`; the surviving recalc publishes `Local`, which matches what sources receive
+  today).
+- `WithGlobalChangeOrdering()` opt-in if a cross-subject label is ever needed.
+- Blocking-bound backpressure knob for `Ordered` subscriptions.
+- **Cross-flush convergence for `ChangeQueueProcessor` dedup mode**: a persistent per-property
+  last-emitted-revision filter, so an inversion straddling a flush tick cannot emit stale-last. Needs
+  an eviction story, since a `PropertyReference`-keyed map holds subjects alive; candidate homes are
+  the subject's own `Data` (dies with the subject) or lifecycle-driven eviction. Completes the
+  convergence contract that section 9 currently scopes to within-flush.
+- **Extract the exclusive-drain primitive.** #381's `PathDeliveryQueue` independently implements the
+  same pattern as section 6 (single-drainer flag, FIFO backlog, callbacks outside the lock,
+  zero-copy uncontended fast path, nested writes handed to the active drainer). The convergence
+  validates the design; the duplication should be lifted into one shared primitive used by both.
+- `SubscribeToPath` (#381) does **not** simplify by migrating to `Ordered`: its queue orders
+  composite events across multiple subjects, which is out of scope here, and per-hop `Ordered`
+  subscriptions would give it N independent drains to re-serialize. Delayed walks could also
+  coalesce transitions, weakening its one-event-per-transition contract. Matches the analysis in
+  #385. Available later as an opt-in mode purely to move the path walk off the writer thread.
+- Use #381's `PathBenchmarkModels` / `SubjectPathSubscriptionBenchmark` shape as the basis for
+  benchmark gate 3 (a path is N per-property subscriptions, so 100 paths is the many-subscriptions
+  profile with an existing baseline), and do one throwaway `Ordered` migration as a stress test of
+  drain-per-subscription at hundreds of subscriptions (empirical answer to the ThreadPool
+  starvation limit).
+- `ChangeQueueProcessor.bufferTime` is a hidden mode switch (interval, dedup on/off, and after this
+  design the delivery guarantee: 0 = exactly-once commit order, > 0 = latest-state-wins). Follow up
+  with an explicit mode in the API (for example `LatestState(interval)` / `EveryChange()`) instead
+  of a magic zero; a pure rename such as `deduplicationTime` would still hide the guarantee switch
+  and misname the batching half. Interacts with #353's proposed configuration object.

--- a/docs/superpowers/specs/2026-07-29-ordered-change-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-29-ordered-change-delivery-design.md
@@ -649,23 +649,44 @@ faces block only their own consumer thread, and every wait is cancellable (secti
     contexts unarmed and the queue channel cheap); `bufferTime = 0` rides `Ordered` and arms the
     context, an explicit trade for zero-buffer deployments.
 
-## Delivery structure: two stacked PRs
+## Delivery structure: three stacked PRs
 
-Phase 1 (additive, zero breaking changes): per-subject `Revision` in both terminals,
-`SubjectPropertyChange.Revision`, the `ChangeQueueProcessor` dedup fix, `FinalValueIsNewValue`,
-the `docs/tracking.md` matrix, benchmark gates 1, 8, 9.
+Superseded plan, kept for context: this section originally described two PRs and argued that the
+first must not merge before the second validated it. Both parts changed once the work was reviewed.
 
-Phase 2 (breaking): the ordered channel (marker, registries, per-property index, reservation
-record, slot buffers, publish, drain, required enum, `bufferTime = 0` riding `Ordered`), remaining
-gates.
+The label and its consumer were split apart, because six independent review dimensions found no
+correctness or thread-safety defect in the revision mechanism and every defect they did find in the
+connector layer consuming it. The consumer went through three retention designs and two write-back
+attempts; the label went through none. Holding the stable half hostage to the volatile one bought
+nothing.
 
-**PR 2 is stacked on PR 1, not merged sequentially.** Phase 2's benchmarks are the first real
-measurement of Phase 1's always-on cost under load (gate 1 measures it in isolation; gates 2-7
-measure it in context), and a regression there may require changing Phase 1 decisions: where the
-revision counter lives, whether the context stamp is needed at all, or the struct-size trade of
-`SubjectPropertyChange.Revision`. Keeping PR 1 open and stacked lets both be corrected together
-before either merges, instead of shipping a label whose storage the ordered channel then proves
-wrong.
+- **PR 1 (#399, additive plus one declared binary break):** per-subject `Revision` in both
+  terminals, `SubjectPropertyChange.Revision`, `FinalValueIsNewValue`, the compare-and-swap executor
+  publication, the `docs/tracking.md` matrix, benchmark gate 1.
+- **PR 2 (#420, additive):** the `ChangeQueueProcessor` merge fix, cross-flush convergence, the
+  transaction write-back, `docs/connectors.md`, the CI path filters.
+- **PR 3 (#422, breaking):** the ordered channel (marker, registries, per-property index,
+  reservation record, slot buffers, publish, drain, required enum, `bufferTime = 0` riding
+  `Ordered`), remaining gates.
+
+**PR 1 may merge before the later two.** The original argument was that Phase 2's benchmarks are the
+first measurement of Phase 1's always-on cost under load, so a regression could force Phase 1
+decisions to change: where the revision counter lives, whether the context stamp is needed, or the
+struct-size trade. That still holds, but all three of those live behind `internal` members
+(`InterceptorExecutor.Revision`, and `Revision`/`Executor`/`FinalValueIsNewValue` on
+`PropertyWriteContext`), so correcting them later is a follow-up rather than a public break. Gate 1
+measured clean in isolation, and this repository accepts justified breaking changes with approval,
+so even a public correction is a decision rather than a wall.
+
+The residual risk, named so it is not discovered later: the executor threaded through
+`PropertyWriteContext` is the load-bearing internal decision, it is what makes the increment a plain
+field increment under a lock the caller already holds, and it is already in tension with the
+`TODO: Get rid of the executor completely` on `IInterceptorExecutor`. If the in-context gates argue
+against it, that correction touches the always-on write path.
+
+`bufferTime = 0` riding `Ordered` makes PR 2's supersession gate on the immediate path dead code,
+since an ordered channel cannot deliver an older commit after a newer one. PR 3 deletes it
+deliberately rather than leaving it.
 
 ### `SubjectPropertyChange.Create` and revision propagation
 


### PR DESCRIPTION
Design for review ahead of implementation. The branch carries the spec and phase plans; the code follows once the shape is agreed.

Stacked on #420, which is stacked on #399. Phase 2 of the two-phase design those two began.

## Summary

Gives each of the three change channels an opt-in delivery mode with a real guarantee: **exactly-once, in commit order, per subject**. Consumers that do not opt in keep today's path unchanged.

None of the channels guarantees order today. Dispatch happens after the commit and outside the subject lock, so under concurrent writers a change committed second can be delivered first, and nothing in the payload lets a consumer tell which delivery reflects the newer stored value. #399 added the `Revision` label so a consumer can *detect* that; this makes the delivery itself ordered so it does not have to.

Fixes the rest of #385.

## How it works

**Claim and publish, split across the lock the write already takes.** Reserve a slot inside `SyncRoot` (which fixes the order), publish the payload into that slot in a `finally` outside the lock (which keeps user code off the lock), and drain FIFO with a wait on a pending head (which turns the two into a guarantee). Order comes from slot positions, not from the revision label, so no contiguity invariant is needed and vetoed writes, no-op writes and transaction capture need no special handling.

**Two subscription topologies, because they have different cost profiles.** Context-wide ordered subscriptions (queue, observable, async stream: the source-facing channels, typically one or two per context) live in an ordered registry captured in the interceptor chain closure. Per-property ordered subscriptions, which applications hold many of, live in a core-owned per-property index behind a per-subject count gate, so a write pays for what *that property* has subscribed rather than for the process-wide subscription count.

**The queue path stays allocation-free in steady state**, via a pooled reservation record with rent-once and progress-count atomicity, and a shared single payload build across subscriptions.

**`ChangeQueueProcessor` with `bufferTime = 0` rides the Ordered channel**, so the unbuffered connector path becomes ordered exactly-once rather than arrival-ordered. Buffered mode keeps the merge-and-converge behaviour #420 gives it.

## Guarantee matrix

| Channel | Delivery | Exactly-once | Order | Consumer runs on |
|---|---|---|---|---|
| Per-property callback | `Immediate` | conditional (a) | arrival | writer thread |
| Per-property callback | `Ordered` | yes (b) | commit, per subject | drain thread |
| Observable | `Immediate` | conditional (a) | arrival | writer thread |
| Observable | `Ordered` | yes (b) | commit, per subject | drain thread |
| Pull queue | `Immediate` | conditional (a) | arrival | consumer thread |
| Pull queue | `Ordered` | yes (b) | commit, per subject | consumer thread |
| `ChangeQueueProcessor`, buffer = 0 | `Ordered` | yes (b) | commit | processor thread |
| `ChangeQueueProcessor`, buffer > 0 | merged, latest-state-wins | no | per-property newest, converging across flushes (#420) | processor thread |

(a) Provided lifecycle handlers and observers honor their no-throw contracts.
(b) A derived-with-setter property whose getter throws at publish time skips that delivery on all channels; a fabricated value is never published.

"Commit, per subject" is strict: one subject's changes arrive complete and in commit order, different subjects' changes may interleave arbitrarily, and their revisions are not comparable.

## Breaking changes

**`PropertyChangeDelivery` becomes a required argument on all four subscription entry points.** Every consumer states which guarantee it wants at the call site, rather than inheriting a default that says nothing. This is the deliberate cost of the design: the existing surface cannot express the distinction, and a defaulted parameter would leave the majority of call sites silently on the weaker guarantee.

## Known limits

**Ordering is per subject, not global.** Different subjects hold different `SyncRoot` locks, so their reservations into one subscription can interleave either way. Within a subject, ordering holds across all its properties and per-property order follows as a subsequence. Cross-subject causal order would need a process-wide serialization point on every write.

**`Immediate` guarantees stay conditional on consumer contracts.** The library does not wrap the hot path in per-observer `try`/`catch`; even with it, the guarantee would just be conditional in different ways.

**Ordered mode trades memory for liveness.** Slot buffers are unbounded by default, matching today's raw queue. A slow consumer grows the buffer rather than dropping changes (incompatible with exactly-once) or blocking the writer. A bound is a later knob.

**A producer preempted between reservation and publish briefly holds back that subscription's head.** Latency, not corruption, bounded by the producer's unwind.

**A stuck producer parks the drain thread.** A push-face drain blocked on a pending head holds its thread-pool thread for the producer's entire unwind, so a hanging lifecycle handler holds it unboundedly; many ordered subscriptions make that a starvation vector. The pull faces block only their own consumer thread, and every wait is cancellable.

**Not offered for hand-written subjects** whose `Context` is not an `InterceptorExecutor`.

## Verification plan

Benchmarks are a gate rather than a garnish: the unarmed path must not regress, and the armed queue path must stay allocation-free in steady state. The spec on this branch records the full benchmark plan, the plan-level verification items, and the testing strategy.

Extraction of the exclusive-drain primitive shared with #381's `PathDeliveryQueue` is part of the work.