### PR TITLE
Capture outbound changes before a source signals readiness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,18 @@ jobs:
         id: filter
         with:
           filters: |
+            shared: &shared
+              - 'src/Namotion.Interceptor/**'
+              - 'src/Namotion.Interceptor.Generator/**'
+              - 'src/Namotion.Interceptor.Tracking/**'
+              - 'src/Namotion.Interceptor.Registry/**'
+              - 'src/Namotion.Interceptor.Connectors/**'
+              - 'src/Namotion.Interceptor.Dynamic/**'
+              # Test-only references: not used by the connectors, only by their test projects.
+              - 'src/Namotion.Interceptor.Testing/**'
+              - 'src/Namotion.Interceptor.Hosting/**'
+              - 'src/Namotion.Interceptor.Validation/**'
+              - 'src/Namotion.Interceptor.AspNetCore/**'
             homeblaze:
               - 'src/HomeBlaze/**'
             nugetplugins:
@@ -50,11 +62,14 @@ jobs:
               - 'src/HomeBlaze/HomeBlaze.Plugins/**'
               - 'src/HomeBlaze/HomeBlaze.Plugins.Tests/**'
             opcua:
+              - *shared
               - 'src/Namotion.Interceptor.OpcUa*/**'
               - 'src/HomeBlaze/*OpcUa*/**'
             websocket:
+              - *shared
               - 'src/Namotion.Interceptor.WebSocket*/**'
             mqtt:
+              - *shared
               - 'src/Namotion.Interceptor.Mqtt*/**'
 
   test:

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceBaseTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceBaseTests.cs
@@ -22,6 +22,12 @@ public class SubjectSourceBaseTests
             .Setup(s => s.TryGetService<ISubjectRegistry>())
             .Returns(new SubjectRegistry());
 
+        // The source creates its change-queue subscription before it starts listening, so the
+        // stub context has to provide the change interceptor the subscription is taken from.
+        subjectContextMock
+            .Setup(s => s.TryGetService<PropertyChangeInterceptor>())
+            .Returns(new PropertyChangeInterceptor());
+
         var subjectMock = new Mock<IInterceptorSubject>();
         subjectMock
             .Setup(s => s.Context)
@@ -428,7 +434,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context) { FirstName = "Original" };
 
         var (source, writtenChanges, writeTcs) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.FirstName = "Original"; }); // Server didn't change it
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.FirstName), "Original")); // Server didn't change it
 
         // Pre-fill retry queue: client changed "Original" -> "ClientChange"
         EnqueueRetryChange(source, subject, nameof(Person.FirstName), "Original", "ClientChange");
@@ -455,7 +461,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context) { FirstName = "Original" };
 
         var (source, writtenChanges, _) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.FirstName = "ServerChanged"; }); // Server DID change it
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.FirstName), "ServerChanged")); // Server DID change it
 
         // Pre-fill retry queue: client changed "Original" -> "ClientChange"
         EnqueueRetryChange(source, subject, nameof(Person.FirstName), "Original", "ClientChange");
@@ -483,7 +489,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context) { Father = personA };
 
         var (source, _, writeTcs) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.Father = personA; }); // Server didn't change it
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.Father), personA)); // Server didn't change it
 
         // Pre-fill retry queue: client changed Father from personA -> personB
         EnqueueRetryChange<Person?>(source, subject, nameof(Person.Father), personA, personB);
@@ -510,7 +516,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context) { Father = personA };
 
         var (source, _, _) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.Father = personC; }); // Server replaced with C
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.Father), personC)); // Server replaced with C
 
         // Pre-fill retry queue: client changed Father from personA -> personB
         EnqueueRetryChange<Person?>(source, subject, nameof(Person.Father), personA, personB);
@@ -537,7 +543,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context) { Children = listA };
 
         var (source, _, writeTcs) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.Children = listA; }); // Server didn't replace it
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.Children), listA)); // Server didn't replace it
 
         // Pre-fill retry queue: client replaced collection listA -> listB
         EnqueueRetryChange(source, subject, nameof(Person.Children), listA, listB);
@@ -564,7 +570,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context) { Children = listA };
 
         var (source, _, _) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.Children = listC; }); // Server replaced collection
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.Children), listC)); // Server replaced collection
 
         // Pre-fill retry queue: client replaced listA -> listB
         EnqueueRetryChange(source, subject, nameof(Person.Children), listA, listB);
@@ -591,8 +597,8 @@ public class SubjectSourceBaseTests
         var (source, writtenChanges, writeTcs) = CreateSourceWithRetryQueue(subject, context,
             initialStateAction: s =>
             {
-                subject.FirstName = "ServerFirst"; // Server changed this -> conflict
-                subject.LastName = "OrigLast";     // Server didn't change this -> no conflict
+                ApplyFromSource(s, subject, nameof(Person.FirstName), "ServerFirst"); // Server changed this -> conflict
+                ApplyFromSource(s, subject, nameof(Person.LastName), "OrigLast");     // Server didn't change this -> no conflict
             });
 
         EnqueueRetryChange(source, subject, nameof(Person.FirstName), "OrigFirst", "ClientFirst");
@@ -624,8 +630,8 @@ public class SubjectSourceBaseTests
         var (source, writtenChanges, _) = CreateSourceWithRetryQueue(subject, context,
             initialStateAction: s =>
             {
-                subject.FirstName = "ServerFirst";
-                subject.LastName = "ServerLast";
+                ApplyFromSource(s, subject, nameof(Person.FirstName), "ServerFirst");
+                ApplyFromSource(s, subject, nameof(Person.LastName), "ServerLast");
             });
 
         EnqueueRetryChange(source, subject, nameof(Person.FirstName), "OrigFirst", "ClientFirst");
@@ -680,7 +686,7 @@ public class SubjectSourceBaseTests
         var subject = new Person(context); // FirstName starts as null
 
         var (source, writtenChanges, _) = CreateSourceWithRetryQueue(subject, context,
-            initialStateAction: s => { subject.FirstName = "ServerValue"; }); // Server set it
+            initialStateAction: s => ApplyFromSource(s, subject, nameof(Person.FirstName), "ServerValue")); // Server set it
 
         // Pre-fill retry queue: client changed null -> "ClientValue"
         EnqueueRetryChange(source, subject, nameof(Person.FirstName), null, "ClientValue");
@@ -781,6 +787,78 @@ public class SubjectSourceBaseTests
         Assert.Contains(writtenChanges, c =>
             c.Property.Name == nameof(Person.LastName) &&
             c.GetNewValue<string?>() == "ClientLast");
+    }
+
+    [Fact]
+    public async Task WhenPropertyIsWrittenWhileSourceIsStillStarting_ThenChangeIsStillSentToSource()
+    {
+        // A source signals readiness to the outside world before its processing loop runs:
+        // it claims properties and (for OPC UA) creates monitored items inside StartListeningAsync,
+        // and applies initial state right after. A write landing in that window must survive,
+        // otherwise it is lost with no error, no retry and no log (issue #416).
+
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithRegistry();
+        var subject = new Person(context) { FirstName = "Initial" };
+
+        var writtenChanges = new ConcurrentBag<SubjectPropertyChange>();
+        var claimed = new TaskCompletionSource();
+        var writeMade = new TaskCompletionSource();
+
+        TestSubjectSource? source = null;
+        source = new TestSubjectSource(subject, context, NullLogger.Instance,
+            bufferTime: TimeSpan.FromMilliseconds(10))
+        {
+            StartListeningOverride = async (_, _) =>
+            {
+                new PropertyReference(subject, nameof(Person.FirstName)).SetSource(source!);
+                claimed.SetResult();
+
+                // Hold the source inside startup until the test has written, reproducing the
+                // scheduler starvation that widens this window on a loaded CI machine.
+                await writeMade.Task.ConfigureAwait(false);
+                return null;
+            },
+            WriteChangesOverride = (changes, _) =>
+            {
+                foreach (var change in changes.ToArray())
+                {
+                    writtenChanges.Add(change);
+                }
+                return new ValueTask<WriteResult>(WriteResult.Success);
+            },
+        };
+
+        // Act
+        await source.StartAsync(CancellationToken.None);
+        await claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        subject.FirstName = "WrittenDuringStartup";
+        writeMade.SetResult();
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => writtenChanges.Any(c => c.Property.Name == nameof(Person.FirstName)),
+            timeout: TimeSpan.FromSeconds(5),
+            message: "Expected the write made during source startup to reach the source");
+        await source.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Contains(writtenChanges, c =>
+            c.Property.Name == nameof(Person.FirstName) &&
+            c.GetNewValue<string?>() == "WrittenDuringStartup");
+    }
+
+    /// <summary>
+    /// Applies a value the way a real source applies loaded initial state: stamped with the source
+    /// origin, so the change queue recognizes it as an echo instead of writing it straight back.
+    /// A plain local write here would model the source incorrectly.
+    /// </summary>
+    private static void ApplyFromSource(
+        ISubjectSource source, IInterceptorSubject subject, string propertyName, object? value)
+    {
+        new PropertyReference(subject, propertyName).SetValueFromSource(source, null, null, value);
     }
 
     private static (TestSubjectSource source,
@@ -894,6 +972,12 @@ public class SubjectSourceBaseTests
         subjectContextMock
             .Setup(s => s.TryGetService<ISubjectRegistry>())
             .Returns(new SubjectRegistry());
+
+        // The source creates its change-queue subscription before it starts listening, so the
+        // stub context has to provide the change interceptor the subscription is taken from.
+        subjectContextMock
+            .Setup(s => s.TryGetService<PropertyChangeInterceptor>())
+            .Returns(new PropertyChangeInterceptor());
 
         var subjectMock = new Mock<IInterceptorSubject>();
         subjectMock

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -79,11 +79,11 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
         {
             try
             {
-                _propertyWriter.StartBuffering();
-                await using var listenLifetime = await StartListeningAsync(_propertyWriter, stoppingToken).ConfigureAwait(false);
-
-                await _propertyWriter.LoadInitialStateAndResumeAsync(stoppingToken).ConfigureAwait(false);
-
+                // The processor's change subscription must exist before the source signals readiness
+                // to the outside world. StartListeningAsync claims properties and creates monitored
+                // items, and LoadInitialStateAndResumeAsync applies the initial state; a local write
+                // between either of those and the subscription would have no subscriber and would be
+                // dropped silently (not queued, not retried, not logged).
                 using var processor = new ChangeQueueProcessor(
                     this,
                     _context,
@@ -93,8 +93,13 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
                     maxQueueDepth: null,
                     logger: _logger);
 
-                // Optimistic retry re-apply: after initial state load + ChangeQueueProcessor creation,
-                // re-apply queued changes locally if the source hasn't changed the property.
+                _propertyWriter.StartBuffering();
+                await using var listenLifetime = await StartListeningAsync(_propertyWriter, stoppingToken).ConfigureAwait(false);
+
+                await _propertyWriter.LoadInitialStateAndResumeAsync(stoppingToken).ConfigureAwait(false);
+
+                // Optimistic retry re-apply: after initial state load, re-apply queued changes locally
+                // if the source hasn't changed the property.
                 // ChangeQueueProcessor picks up re-applied changes and sends them to the source as fresh writes.
                 ReapplyRetryQueue();
 


### PR DESCRIPTION
Fixes the first of the two defects in #416, and adds the CI path filters that make connector integration suites actually run for this kind of change.

## The defect

`SubjectSourceBase` created its `ChangeQueueProcessor`, and with it the subscription that captures outgoing property changes, only after `StartListeningAsync` and `LoadInitialStateAndResumeAsync` had run. Both of those are what the outside world uses to conclude the source is ready: `StartListeningAsync` claims the properties and creates the OPC UA monitored items, and loading the initial state applies the server's values to the subject, including the `Connected` flag the tests wait on.

A local write landing between either of those and the processor's construction had no subscriber. It was not queued, not retried and not logged, and it never recovered, while the next write to the same property went through in milliseconds.

This is not test only. Any application that writes a property right after host start loses those writes silently.

## Why it correlates with load

The window is one continuation. Under thread pool starvation it widens past the 100 ms readiness poll in the tests, so the test writes into the hole. That is the load correlation recorded in the issue.

## Evidence

Injecting a 3 second stall into that window makes it deterministic. Same harness, same test, both ways:

| | result |
|---|---|
| before | fails every time, server value never changes |
| after | passes in 3.7 s |

Instrumented run at the moment of failure, on master's code:

```
[0.3s] Client connected in 270ms total          <- readiness gate passes
[  7ms] CLIENT ...0000 -> b70ff4d7 origin=Local  <- the write, change IS raised
[3.2s] creating change queue processor           <- capture starts, too late
[20.3s] server subject value : <null>            <- never arrived
        server NODE value    : 00000000-...      <- never reached the node either
        client prop claimed  : True by OpcUaSubjectClientSource
        client connected     : True, reconnecting=False
        client pending writes: 0                 <- not queued, not retried, not logged
[30.3s] dequeued NullableGuidValue ... -> QUEUED  <- a later write goes through instantly
```

## The fix

Create the processor first, then buffer, listen and load. Its property filter is evaluated when a change is dequeued, which is after the claims exist, so capturing earlier is safe. Initial state is applied through `SetValueFromSource`, so those applies carry the source origin and the processor skips them as echoes rather than writing them back (verified: all 55 initial applies show up as `origin=FromSource -> SKIPPED`).

### What it does not cover

The retry backoff window. If `StartListeningAsync` throws, the processor is disposed and rebuilt only after the retry delay. Keeping one processor across attempts would let a source that can never connect accumulate changes without bound, since the queue is unbounded. The normal reconnect path is unaffected either way: it runs inside the health loop with the processor alive, so writes are queued and retried through `WriteRetryQueue`.

## Tests

`WhenPropertyIsWrittenWhileSourceIsStillStarting_ThenChangeIsStillSentToSource` holds the source inside `StartListeningAsync` after it has claimed the property, writes during that window, then releases. Deterministic and protocol free. It fails on master (5 s timeout) and passes with the fix (137 ms).

Three existing `SubjectSourceBaseTests` needed correcting:

- Two stub contexts never provided the `PropertyChangeInterceptor` the subscription is taken from. As a side effect of fixing that, those two stopped burning 30 s each on timeouts and the project went from 1m01s to 0.7 s.
- One simulated "the server changed this value" with a plain local write, which the now live subscription correctly forwards. Real sources apply loaded state through `SetValueFromSource`, so the stubs now do the same, at all eight sites. One other site had the same latent problem and was only passing because it stopped the source before the buffer flushed.

Full unit suite passes, 0 failures.

## CI path filters

The filters matched only each connector's own project, so a pull request touching `Namotion.Interceptor`, `Tracking`, `Registry` or `Connectors` ran no connector integration suite at all. This pull request is an instance: it modifies `Connectors`, which every connector consumes, and without this would not run the OPC UA job that is supposed to verify it. Taken from the same change in #420, so it is reviewed there too. If #420 lands first this hunk becomes a no-op.

## Still open in #416

The second defect is unaffected by this and stays open. Under a loaded harness (2 visible cores, saturated CPU) the first server to client update after a client connects still sometimes never arrives, permanently and with no log:

- `WriteAndReadArraysOnServer_ShouldUpdateClient`
- `ArrayResize_GrowAndShrink_ServerToClient_ShouldSync`

In every observed case the failing test is the one that created its class's shared client. The server side processor is built before the server starts, so the ordering bug fixed here does not explain it. Being investigated separately.

Case 2 in the issue (the certificate mismatch on reconnect) did not reproduce at all in roughly 25 loaded runs and remains unexplained.
