### PR TITLE
fix: Stop the OPC UA server applying its own node state back to the subject

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,12 @@ The library uses a fluent configuration API:
 
 ## Key Dependencies
 
-- Microsoft.CodeAnalysis.CSharp 4.14.0 (source generator)
-- System.Reactive 6.0.1 (change tracking observables)
+Versions are pinned in the project files, not here, so read them from there.
+
+- Microsoft.CodeAnalysis.CSharp (source generator)
+- System.Reactive (change tracking observables)
 - Microsoft.Extensions.DependencyInjection.Abstractions (hosting)
-- OPCFoundation.NetStandard.Opc.Ua.* 1.5.376.244 (industrial integration)
+- OPCFoundation.NetStandard.Opc.Ua.* (industrial integration)
 
 ## Industrial Integration Focus
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
@@ -1,4 +1,5 @@
 using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.OpcUa.Attributes;
 using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
 using Namotion.Interceptor.Registry.Attributes;
 using Namotion.Interceptor.Testing;
@@ -7,14 +8,10 @@ using Xunit.Abstractions;
 namespace Namotion.Interceptor.OpcUa.Tests.Integration;
 
 /// <summary>
-/// The server pushes a local change onto its node and then calls <c>ClearChangeMasks</c>, which raises
-/// <c>StateChanged</c> synchronously on the same thread. That handler is how a client write reaches the
-/// subject, so without a guard the server also applies its own writes back to the subject as if a client
-/// had sent them.
-///
-/// Normally invisible, because the value it applies is the one just written and the equality check drops
-/// it. It stops being invisible when the subject moved on between the batch being assembled and the node
-/// write: the reflection then carries the older value and overwrites the newer commit.
+/// The server must never apply its own node state back to the subject. Two paths reach the
+/// <c>StateChanged</c> handler that carries client writes: the flush loop's own <c>ClearChangeMasks</c>,
+/// and node removal flushing the value mask set at creation. Both are masked by the equality check until
+/// the subject has moved on, at which point they overwrite the newer commit with an older value.
 /// </summary>
 [Trait("Category", "Integration")]
 public class OpcUaServerSelfWriteTests
@@ -55,10 +52,60 @@ public class OpcUaServerSelfWriteTests
         // IncomingChangesPerSecond is documented as "client writes to server", and no client exists.
         Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
     }
+
+    /// <summary>
+    /// The value mask set when a variable node is created is never cleared, so removing the node ORs in
+    /// Deleted and flushes both, which reaches the same handler carrying the node's creation value.
+    /// </summary>
+    [Fact]
+    public async Task WhenASubjectIsDetached_ThenNothingIsAppliedBackToTheSubject()
+    {
+        // Arrange
+        var logger = new TestLogger(_output);
+        using var port = await OpcUaTestPortPool.AcquireAsync();
+
+        await using var server = new OpcUaTestServer<SelfWriteTestParent>(logger);
+        await server.StartAsync(
+            createRoot: context => new SelfWriteTestParent(context),
+            initializeDefaults: (context, root) =>
+                root.Child = new SelfWriteTestChild(context) { Value = "initial" },
+            baseAddress: port.BaseAddress,
+            certificateStoreBasePath: port.CertificateStoreBasePath);
+
+        var serverService = server.Server!;
+        var property = new PropertyReference(server.Root!.Child!, nameof(SelfWriteTestChild.Value));
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => serverService.TryGetVariableNode(property, out _),
+            message: "the child's variable node should exist");
+
+        Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+
+        // Act: detaching runs the removal synchronously on this thread.
+        server.Root.Child = null;
+
+        // Assert
+        Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+    }
 }
 
 [InterceptorSubject]
 public partial class SelfWriteTestRoot
+{
+    [Path("opc", "Value")]
+    public partial string? Value { get; set; }
+}
+
+[InterceptorSubject]
+public partial class SelfWriteTestParent
+{
+    [Path("opc", "Child")]
+    [OpcUaReference("HasComponent")]
+    public partial SelfWriteTestChild? Child { get; set; }
+}
+
+[InterceptorSubject]
+public partial class SelfWriteTestChild
 {
     [Path("opc", "Value")]
     public partial string? Value { get; set; }

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
@@ -87,7 +87,6 @@ public class OpcUaServerSelfWriteTests
         // Assert
         Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
     }
-
 }
 
 [InterceptorSubject]

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
@@ -1,6 +1,5 @@
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.OpcUa.Attributes;
-using Namotion.Interceptor.OpcUa.Server;
 using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
 using Namotion.Interceptor.Registry.Attributes;
 using Namotion.Interceptor.Testing;
@@ -89,66 +88,6 @@ public class OpcUaServerSelfWriteTests
         Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
     }
 
-    /// <summary>
-    /// Node removal flushes whatever masks are pending and, unguarded, would do so from the detaching
-    /// thread. This reproduces the write loop's state between assigning a node value and flushing it
-    /// itself: the lock is held and a value mask is pending. A detach must not be able to flush that.
-    ///
-    /// The wait cannot make this flaky. While this thread holds the lock, correct code cannot reach the
-    /// flush at all, so the assertions hold however long the detach is given; a longer wait only makes
-    /// the failing case easier to catch. Verified in the other direction by removing the lock, which
-    /// fails the test.
-    /// </summary>
-    [Fact]
-    public async Task WhenASubjectIsDetachedWhileTheWriteLoopHoldsTheLock_ThenNothingIsAppliedBackToTheSubject()
-    {
-        // Arrange
-        var logger = new TestLogger(_output);
-        using var port = await OpcUaTestPortPool.AcquireAsync();
-
-        await using var server = new OpcUaTestServer<SelfWriteTestParent>(logger);
-        await server.StartAsync(
-            createRoot: context => new SelfWriteTestParent(context),
-            initializeDefaults: (context, root) =>
-                root.Child = new SelfWriteTestChild(context) { Value = "initial" },
-            baseAddress: port.BaseAddress,
-            certificateStoreBasePath: port.CertificateStoreBasePath);
-
-        var serverService = server.Server!;
-        var child = server.Root!.Child!;
-        var property = new PropertyReference(child, nameof(SelfWriteTestChild.Value));
-
-        await AsyncTestHelpers.WaitUntilAsync(
-            () => serverService.TryGetVariableNode(property, out _),
-            message: "the child's variable node should exist");
-
-        Assert.True(serverService.TryGetVariableNode(property, out var node));
-        var nodeManagerLock = ((OpcUaStandardServer)serverService.CurrentServer!).NodeManagerLock;
-        Assert.NotNull(nodeManagerLock);
-
-        Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
-
-        lock (nodeManagerLock)
-        {
-            // The write loop's mid-write state: value assigned, its own flush not yet reached.
-            node!.Value = "stale write loop value";
-
-            var detach = new Thread(() => server.Root.Child = null) { IsBackground = true };
-            detach.Start();
-
-            // A window for the damage to land, not a synchronisation point. The removal blocks inside
-            // DeleteNode either way, because it takes this lock itself before it finishes; what the fix
-            // changes is that it can no longer flush the mask on the way there.
-            detach.Join(TimeSpan.FromSeconds(5));
-
-            // Assert while still holding the lock: releasing it lets the removal flush the mask this
-            // test left pending, which is the one case the handler's comment calls out.
-            Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
-            Assert.Equal("initial", child.Value);
-        }
-
-        await AsyncTestHelpers.WaitUntilAsync(() => server.Root.Child is null);
-    }
 }
 
 [InterceptorSubject]

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
@@ -1,5 +1,6 @@
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.OpcUa.Attributes;
+using Namotion.Interceptor.OpcUa.Server;
 using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
 using Namotion.Interceptor.Registry.Attributes;
 using Namotion.Interceptor.Testing;
@@ -86,6 +87,67 @@ public class OpcUaServerSelfWriteTests
 
         // Assert
         Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+    }
+
+    /// <summary>
+    /// Node removal flushes whatever masks are pending and, unguarded, would do so from the detaching
+    /// thread. This reproduces the write loop's state between assigning a node value and flushing it
+    /// itself: the lock is held and a value mask is pending. A detach must not be able to flush that.
+    ///
+    /// The wait cannot make this flaky. While this thread holds the lock, correct code cannot reach the
+    /// flush at all, so the assertions hold however long the detach is given; a longer wait only makes
+    /// the failing case easier to catch. Verified in the other direction by removing the lock, which
+    /// fails the test.
+    /// </summary>
+    [Fact]
+    public async Task WhenASubjectIsDetachedWhileTheWriteLoopHoldsTheLock_ThenNothingIsAppliedBackToTheSubject()
+    {
+        // Arrange
+        var logger = new TestLogger(_output);
+        using var port = await OpcUaTestPortPool.AcquireAsync();
+
+        await using var server = new OpcUaTestServer<SelfWriteTestParent>(logger);
+        await server.StartAsync(
+            createRoot: context => new SelfWriteTestParent(context),
+            initializeDefaults: (context, root) =>
+                root.Child = new SelfWriteTestChild(context) { Value = "initial" },
+            baseAddress: port.BaseAddress,
+            certificateStoreBasePath: port.CertificateStoreBasePath);
+
+        var serverService = server.Server!;
+        var child = server.Root!.Child!;
+        var property = new PropertyReference(child, nameof(SelfWriteTestChild.Value));
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => serverService.TryGetVariableNode(property, out _),
+            message: "the child's variable node should exist");
+
+        Assert.True(serverService.TryGetVariableNode(property, out var node));
+        var nodeManagerLock = ((OpcUaStandardServer)serverService.CurrentServer!).NodeManagerLock;
+        Assert.NotNull(nodeManagerLock);
+
+        Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+
+        lock (nodeManagerLock)
+        {
+            // The write loop's mid-write state: value assigned, its own flush not yet reached.
+            node!.Value = "stale write loop value";
+
+            var detach = new Thread(() => server.Root.Child = null) { IsBackground = true };
+            detach.Start();
+
+            // A window for the damage to land, not a synchronisation point. The removal blocks inside
+            // DeleteNode either way, because it takes this lock itself before it finishes; what the fix
+            // changes is that it can no longer flush the mask on the way there.
+            detach.Join(TimeSpan.FromSeconds(5));
+
+            // Assert while still holding the lock: releasing it lets the removal flush the mask this
+            // test left pending, which is the one case the handler's comment calls out.
+            Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+            Assert.Equal("initial", child.Value);
+        }
+
+        await AsyncTestHelpers.WaitUntilAsync(() => server.Root.Child is null);
     }
 }
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerSelfWriteTests.cs
@@ -1,0 +1,65 @@
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
+using Namotion.Interceptor.Registry.Attributes;
+using Namotion.Interceptor.Testing;
+using Xunit.Abstractions;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Integration;
+
+/// <summary>
+/// The server pushes a local change onto its node and then calls <c>ClearChangeMasks</c>, which raises
+/// <c>StateChanged</c> synchronously on the same thread. That handler is how a client write reaches the
+/// subject, so without a guard the server also applies its own writes back to the subject as if a client
+/// had sent them.
+///
+/// Normally invisible, because the value it applies is the one just written and the equality check drops
+/// it. It stops being invisible when the subject moved on between the batch being assembled and the node
+/// write: the reflection then carries the older value and overwrites the newer commit.
+/// </summary>
+[Trait("Category", "Integration")]
+public class OpcUaServerSelfWriteTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public OpcUaServerSelfWriteTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task WhenTheServerWritesItsOwnNodes_ThenNothingIsAppliedBackToTheSubject()
+    {
+        // Arrange
+        var logger = new TestLogger(_output);
+        using var port = await OpcUaTestPortPool.AcquireAsync();
+
+        await using var server = new OpcUaTestServer<SelfWriteTestRoot>(logger);
+        await server.StartAsync(
+            createRoot: context => new SelfWriteTestRoot(context),
+            baseAddress: port.BaseAddress,
+            certificateStoreBasePath: port.CertificateStoreBasePath);
+
+        var serverService = server.Server!;
+        var property = new PropertyReference(server.Root!, nameof(SelfWriteTestRoot.Value));
+
+        // Act: a purely local write. No client ever connects, so every inbound apply the server
+        // records can only be its own write coming back.
+        server.Root!.Value = "written by the server";
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => serverService.TryGetVariableNode(property, out var node) &&
+                  Equals(node.Value, "written by the server"),
+            message: "the server should push the local write onto its node");
+
+        // Assert: the write reached the node without being counted as traffic from a client.
+        // IncomingChangesPerSecond is documented as "client writes to server", and no client exists.
+        Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+    }
+}
+
+[InterceptorSubject]
+public partial class SelfWriteTestRoot
+{
+    [Path("opc", "Value")]
+    public partial string? Value { get; set; }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/SelfEchoReproTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/SelfEchoReproTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Namotion.Interceptor.OpcUa.Server;
 using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
 using Namotion.Interceptor.Testing;
@@ -7,8 +6,8 @@ using Xunit.Abstractions;
 namespace Namotion.Interceptor.OpcUa.Tests.Integration;
 
 /// <summary>
-/// Throwaway review test: reproduces the previously demonstrated failure where a detach on
-/// another thread flushed the flush loop's mid-write node state back into the subject.
+/// Regression test for the detach against flush loop race: a detach on another thread must not
+/// flush node state the write loop has set but not yet flushed itself, back into the subject.
 /// </summary>
 [Trait("Category", "Integration")]
 public class SelfEchoReproTests
@@ -49,9 +48,6 @@ public class SelfEchoReproTests
         var nodeManagerLock = standardServer.NodeManagerLock!;
         var systemContext = standardServer.CurrentInstance.DefaultSystemContext;
 
-        var flagField = typeof(OpcUaSubjectServer).GetField(
-            "_isWritingOwnNodeValues", BindingFlags.NonPublic | BindingFlags.Static)!;
-
         using var valueAssigned = new ManualResetEventSlim();
         using var detachRequested = new ManualResetEventSlim();
         Exception? flushError = null;
@@ -75,7 +71,7 @@ public class SelfEchoReproTests
                     // code: the echo has already fired and DeleteNode blocks at RemoveRootNotifier)
                     // or has finished entirely. Both outcomes are terminal for the interleaving, so
                     // proceeding is deterministic in both directions. The only wait on the detach
-                    // thread after detachRequested.Set() is a lock, so WaitSleepJoin is unambiguous.
+                    // thread after detachRequested.Set() is a lock, so WaitSleepJoin is the expected signal.
                     var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
                     while (detachThread!.IsAlive &&
                            (detachThread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) == 0)
@@ -84,14 +80,14 @@ public class SelfEchoReproTests
                         Thread.SpinWait(1000);
                     }
 
-                    flagField.SetValue(null, true);
+                    OpcUaSubjectServer.IsWritingOwnNodeValues = true;
                     try
                     {
                         node.ClearChangeMasks(systemContext, false);
                     }
                     finally
                     {
-                        flagField.SetValue(null, false);
+                        OpcUaSubjectServer.IsWritingOwnNodeValues = false;
                     }
                 }
             }

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/SelfEchoReproTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/SelfEchoReproTests.cs
@@ -1,0 +1,131 @@
+using System.Reflection;
+using Namotion.Interceptor.OpcUa.Server;
+using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
+using Namotion.Interceptor.Testing;
+using Xunit.Abstractions;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Integration;
+
+/// <summary>
+/// Throwaway review test: reproduces the previously demonstrated failure where a detach on
+/// another thread flushed the flush loop's mid-write node state back into the subject.
+/// </summary>
+[Trait("Category", "Integration")]
+public class SelfEchoReproTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SelfEchoReproTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task WhenDetachRacesTheFlushLoopMidWrite_ThenTheStaleValueIsNotAppliedBack()
+    {
+        // Arrange
+        var logger = new TestLogger(_output);
+        using var port = await OpcUaTestPortPool.AcquireAsync();
+
+        await using var server = new OpcUaTestServer<SelfWriteTestParent>(logger);
+        await server.StartAsync(
+            createRoot: context => new SelfWriteTestParent(context),
+            initializeDefaults: (context, root) =>
+                root.Child = new SelfWriteTestChild(context) { Value = "initial" },
+            baseAddress: port.BaseAddress,
+            certificateStoreBasePath: port.CertificateStoreBasePath);
+
+        var serverService = (OpcUaSubjectServer)server.Server!;
+        var child = server.Root!.Child!;
+        var property = new PropertyReference(child, nameof(SelfWriteTestChild.Value));
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => serverService.TryGetVariableNode(property, out _),
+            message: "the child's variable node should exist");
+
+        Assert.True(serverService.TryGetVariableNode(property, out var node));
+
+        var standardServer = (OpcUaStandardServer)serverService.CurrentServer!;
+        var nodeManagerLock = standardServer.NodeManagerLock!;
+        var systemContext = standardServer.CurrentInstance.DefaultSystemContext;
+
+        var flagField = typeof(OpcUaSubjectServer).GetField(
+            "_isWritingOwnNodeValues", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        using var valueAssigned = new ManualResetEventSlim();
+        using var detachRequested = new ManualResetEventSlim();
+        Exception? flushError = null;
+        Exception? detachError = null;
+        Thread? detachThread = null;
+
+        // Simulates the flush loop's exact state between assigning a node value and its own
+        // ClearChangeMasks: NodeManagerLock held, node.Value set, Value change mask pending.
+        var flushThread = new Thread(() =>
+        {
+            try
+            {
+                lock (nodeManagerLock)
+                {
+                    node!.Value = "stale-echo";
+                    valueAssigned.Set();
+                    Assert.True(detachRequested.Wait(TimeSpan.FromSeconds(10)));
+
+                    // Wait (bounded, no fixed sleep) until the detach thread is either blocked on a
+                    // lock (correct code: RemoveSubjectNodes waits for NodeManagerLock; defective
+                    // code: the echo has already fired and DeleteNode blocks at RemoveRootNotifier)
+                    // or has finished entirely. Both outcomes are terminal for the interleaving, so
+                    // proceeding is deterministic in both directions. The only wait on the detach
+                    // thread after detachRequested.Set() is a lock, so WaitSleepJoin is unambiguous.
+                    var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+                    while (detachThread!.IsAlive &&
+                           (detachThread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) == 0)
+                    {
+                        Assert.True(DateTime.UtcNow < deadline, "detach thread should block or finish");
+                        Thread.SpinWait(1000);
+                    }
+
+                    flagField.SetValue(null, true);
+                    try
+                    {
+                        node.ClearChangeMasks(systemContext, false);
+                    }
+                    finally
+                    {
+                        flagField.SetValue(null, false);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                flushError = exception;
+            }
+        });
+
+        detachThread = new Thread(() =>
+        {
+            try
+            {
+                Assert.True(valueAssigned.Wait(TimeSpan.FromSeconds(10)));
+                detachRequested.Set();
+                server.Root.Child = null;
+            }
+            catch (Exception exception)
+            {
+                detachError = exception;
+            }
+        });
+
+        // Act
+        flushThread.Start();
+        detachThread.Start();
+
+        Assert.True(flushThread.Join(TimeSpan.FromSeconds(30)), "flush thread should finish (no deadlock)");
+        Assert.True(detachThread.Join(TimeSpan.FromSeconds(30)), "detach thread should finish (no deadlock)");
+        Assert.Null(flushError);
+        Assert.Null(detachError);
+
+        // Assert: the mid-write value must not have been applied back to the subject.
+        Assert.Equal("initial", child.Value);
+        Assert.Equal(0d, serverService.Diagnostics.IncomingChangesPerSecond);
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
@@ -137,30 +137,37 @@ internal class CustomNodeManager : CustomNodeManager2
         _structureLock.Wait();
         try
         {
-            var registeredSubject = subject.TryGetRegisteredSubject();
-
-            // Remove variable nodes for this subject's properties
-            if (registeredSubject != null)
+            // DeleteNode flushes whatever change masks are pending and takes no lock of its own, so
+            // without this it can flush a value the write loop has set but not yet flushed itself,
+            // from a thread the write loop's guard does not cover. DeleteNode already takes this lock
+            // internally, so the order is unchanged.
+            lock (Lock)
             {
-                foreach (var property in registeredSubject.Properties)
+                var registeredSubject = subject.TryGetRegisteredSubject();
+
+                // Remove variable nodes for this subject's properties
+                if (registeredSubject != null)
                 {
-                    if (property.Reference.TryGetPropertyData(_serverService.OpcUaVariableKey, out var node)
-                        && node is BaseDataVariableState variableNode)
+                    foreach (var property in registeredSubject.Properties)
                     {
-                        DeleteNode(SystemContext, variableNode.NodeId);
-                        property.Reference.RemovePropertyData(_serverService.OpcUaVariableKey);
+                        if (property.Reference.TryGetPropertyData(_serverService.OpcUaVariableKey, out var node)
+                            && node is BaseDataVariableState variableNode)
+                        {
+                            DeleteNode(SystemContext, variableNode.NodeId);
+                            property.Reference.RemovePropertyData(_serverService.OpcUaVariableKey);
+                        }
                     }
                 }
-            }
 
-            // Remove object nodes
-            var keysToRemove = _subjects.Where(kvp => kvp.Key.Subject == subject).Select(kvp => kvp.Key).ToList();
-            foreach (var key in keysToRemove)
-            {
-                if (_subjects.TryGetValue(key, out var nodeState))
+                // Remove object nodes
+                var keysToRemove = _subjects.Where(kvp => kvp.Key.Subject == subject).Select(kvp => kvp.Key).ToList();
+                foreach (var key in keysToRemove)
                 {
-                    DeleteNode(SystemContext, nodeState.NodeId);
-                    _subjects.Remove(key);
+                    if (_subjects.TryGetValue(key, out var nodeState))
+                    {
+                        DeleteNode(SystemContext, nodeState.NodeId);
+                        _subjects.Remove(key);
+                    }
                 }
             }
         }

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
@@ -393,14 +393,15 @@ internal class CustomNodeManager : CustomNodeManager2
             variableNode.Timestamp = writeTimestamp.Value.UtcDateTime;
         }
 
+        // Assigning the value above leaves a pending change mask that nothing else clears, so the next
+        // flush of this node reports the creation value as if a client had written it. Cleared here,
+        // during CreateAddressSpace and before the handler is attached, so nothing observes it.
+        variableNode.ClearChangeMasks(SystemContext, false);
+
         variableNode.StateChanged += (_, _, changes) =>
         {
-            // Node removal flushes the value mask set at creation, which is not a client write.
-            if (changes.HasFlag(NodeStateChangeMasks.Value) &&
-                !changes.HasFlag(NodeStateChangeMasks.Deleted))
+            if (changes.HasFlag(NodeStateChangeMasks.Value))
             {
-                // No lock needed: StateChanged fires from ClearChangeMasks which is always
-                // called under NodeManager.Lock (from WriteChangesAsync or SDK write handling).
                 _serverService.UpdateProperty(property.Reference, variableNode.Timestamp, variableNode.Value);
             }
         };

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
@@ -402,6 +402,8 @@ internal class CustomNodeManager : CustomNodeManager2
         {
             if (changes.HasFlag(NodeStateChangeMasks.Value))
             {
+                // Callers that reach here hold NodeManager.Lock;
+                // a value set without a matching ClearChangeMasks would break that
                 _serverService.UpdateProperty(property.Reference, variableNode.Timestamp, variableNode.Value);
             }
         };

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
@@ -409,8 +409,8 @@ internal class CustomNodeManager : CustomNodeManager2
         {
             if (changes.HasFlag(NodeStateChangeMasks.Value))
             {
-                // Callers that reach here hold NodeManager.Lock;
-                // a value set without a matching ClearChangeMasks would break that
+                // Callers that reach here hold NodeManager.Lock; every value set must be flushed by
+                // the same actor under that same hold, or a later flush misattributes it as a client write.
                 _serverService.UpdateProperty(property.Reference, variableNode.Timestamp, variableNode.Value);
             }
         };

--- a/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/CustomNodeManager.cs
@@ -395,7 +395,9 @@ internal class CustomNodeManager : CustomNodeManager2
 
         variableNode.StateChanged += (_, _, changes) =>
         {
-            if (changes.HasFlag(NodeStateChangeMasks.Value))
+            // Node removal flushes the value mask set at creation, which is not a client write.
+            if (changes.HasFlag(NodeStateChangeMasks.Value) &&
+                !changes.HasFlag(NodeStateChangeMasks.Deleted))
             {
                 // No lock needed: StateChanged fires from ClearChangeMasks which is always
                 // called under NodeManager.Lock (from WriteChangesAsync or SDK write handling).

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
@@ -35,7 +35,7 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
 
     // Thread-scoped, not an instance field: a client write on another thread must not be caught by it.
     [ThreadStatic]
-    private static bool _isWritingOwnNodeValues;
+    internal static bool IsWritingOwnNodeValues;
 
     /// <inheritdoc />
     public IInterceptorSubject RootSubject => _subject;
@@ -135,7 +135,7 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
         var span = changes.Span;
         lock (nodeManagerLock)
         {
-            _isWritingOwnNodeValues = true;
+            IsWritingOwnNodeValues = true;
             try
             {
                 for (var i = 0; i < span.Length; i++)
@@ -157,7 +157,7 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
             }
             finally
             {
-                _isWritingOwnNodeValues = false;
+                IsWritingOwnNodeValues = false;
             }
         }
 
@@ -369,7 +369,7 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
 
     internal void UpdateProperty(PropertyReference property, DateTimeOffset changedTimestamp, object? value)
     {
-        if (_isWritingOwnNodeValues)
+        if (IsWritingOwnNodeValues)
         {
             // Our own node write, reflected back synchronously by ClearChangeMasks.
             return;

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
@@ -33,12 +33,7 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
     internal ThroughputCounter IncomingThroughput { get; } = new();
     internal ThroughputCounter OutgoingThroughput { get; } = new();
 
-    // Set only while this thread is inside the node update loop of WriteChangesAsync.
-    // ClearChangeMasks raises StateChanged synchronously on the calling thread and that handler
-    // routes back into UpdateProperty, so without this the server would apply its own writes to
-    // the subject as if a client had sent them. Thread-scoped rather than an instance field, so a
-    // client write arriving on another thread can never be mistaken for one of ours, whichever
-    // lock either side happens to hold.
+    // Thread-scoped, not an instance field: a client write on another thread must not be caught by it.
     [ThreadStatic]
     private static bool _isWritingOwnNodeValues;
 
@@ -376,10 +371,7 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
     {
         if (_isWritingOwnNodeValues)
         {
-            // The server's own node write, reflected straight back by ClearChangeMasks. Applying it
-            // would write the value the flush batch carried over whatever the subject holds now,
-            // which a newer local commit may already have superseded, and it would count the
-            // server's outgoing traffic as inbound client writes.
+            // Our own node write, reflected back synchronously by ClearChangeMasks.
             return;
         }
 

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaSubjectServer.cs
@@ -33,6 +33,15 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
     internal ThroughputCounter IncomingThroughput { get; } = new();
     internal ThroughputCounter OutgoingThroughput { get; } = new();
 
+    // Set only while this thread is inside the node update loop of WriteChangesAsync.
+    // ClearChangeMasks raises StateChanged synchronously on the calling thread and that handler
+    // routes back into UpdateProperty, so without this the server would apply its own writes to
+    // the subject as if a client had sent them. Thread-scoped rather than an instance field, so a
+    // client write arriving on another thread can never be mistaken for one of ours, whichever
+    // lock either side happens to hold.
+    [ThreadStatic]
+    private static bool _isWritingOwnNodeValues;
+
     /// <inheritdoc />
     public IInterceptorSubject RootSubject => _subject;
 
@@ -131,21 +140,29 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
         var span = changes.Span;
         lock (nodeManagerLock)
         {
-            for (var i = 0; i < span.Length; i++)
+            _isWritingOwnNodeValues = true;
+            try
             {
-                var change = span[i];
-                if (change.Property.TryGetPropertyData(OpcUaVariableKey, out var data) &&
-                    data is BaseDataVariableState node &&
-                    change.Property.TryGetRegisteredProperty() is { } registeredProperty)
+                for (var i = 0; i < span.Length; i++)
                 {
-                    var value = change.GetNewValue<object?>();
-                    var convertedValue = _configuration.ValueConverter
-                        .ConvertToNodeValue(value, registeredProperty);
+                    var change = span[i];
+                    if (change.Property.TryGetPropertyData(OpcUaVariableKey, out var data) &&
+                        data is BaseDataVariableState node &&
+                        change.Property.TryGetRegisteredProperty() is { } registeredProperty)
+                    {
+                        var value = change.GetNewValue<object?>();
+                        var convertedValue = _configuration.ValueConverter
+                            .ConvertToNodeValue(value, registeredProperty);
 
-                    node.Value = convertedValue;
-                    node.Timestamp = change.ChangedTimestamp.UtcDateTime;
-                    node.ClearChangeMasks(currentInstance.DefaultSystemContext, false);
+                        node.Value = convertedValue;
+                        node.Timestamp = change.ChangedTimestamp.UtcDateTime;
+                        node.ClearChangeMasks(currentInstance.DefaultSystemContext, false);
+                    }
                 }
+            }
+            finally
+            {
+                _isWritingOwnNodeValues = false;
             }
         }
 
@@ -357,6 +374,15 @@ internal class OpcUaSubjectServer : BackgroundService, IOpcUaSubjectServer, ISub
 
     internal void UpdateProperty(PropertyReference property, DateTimeOffset changedTimestamp, object? value)
     {
+        if (_isWritingOwnNodeValues)
+        {
+            // The server's own node write, reflected straight back by ClearChangeMasks. Applying it
+            // would write the value the flush batch carried over whatever the subject holds now,
+            // which a newer local commit may already have superseded, and it would count the
+            // server's outgoing traffic as inbound client writes.
+            return;
+        }
+
         IncomingThroughput.Add(1);
         var receivedTimestamp = DateTimeOffset.UtcNow;
 


### PR DESCRIPTION
Three defects with one shape: the OPC UA server applies its own node state back to its own subject, as though a client had written it.

`CustomNodeManager` attaches a `StateChanged` handler to every variable node and routes it into `OpcUaSubjectServer.UpdateProperty`, which applies the value through `SetValueFromSource`. That handler is how a client write reaches the local model. But `StateChanged` fires on *any* value change, and three different things reach it that are not client writes.

Each is normally invisible, because the value applied is the one the subject already holds and the equality check drops it. Each stops being invisible the moment the subject has moved on, and then it overwrites a newer commit with an older value. Each also counts the server's own traffic as inbound, contradicting what `OpcUaServerDiagnostics.IncomingChangesPerSecond` documents.

## 1. The flush loop reflects its own writes

`WriteChangesAsync` assigns a node value and calls `ClearChangeMasks`, which raises `StateChanged` synchronously on the same thread, inside `NodeManagerLock`.

```
local write V1  ->  batch assembled with V1
local write V2  ->  subject now holds V2
flush           ->  node = V1, ClearChangeMasks fires
                ->  UpdateProperty applies V1, reverting V2
```

On its own this converges: `V2` was enqueued when it committed, so the next flush sends it. The damage is a transient revert of the local model and the notifications that ride with it, seen by every observer as `V2 -> V1 -> V2`, plus the derived recalculation and validation those trigger. It stops converging as soon as anything treats the reflection as authoritative.

**Fix:** a thread-scoped flag set while the flush loop writes node values, checked in `UpdateProperty`. Thread-scoped rather than an instance field so a client write arriving on another thread can never be mistaken for one of ours.

## 2. The mask left behind at node creation

Assigning a node's value when it is created marks the value change mask, and nothing clears it. Any later flush of that node therefore reports the creation value as a client write. Node removal is the reliable trigger: it ORs in `Deleted` and flushes both.

This one is not transient. It also had a wider reach than removal: attribute nodes are SDK children of their property node, and a client write flushes children through `ClearChangeMasks(includeChildren: true)`, so every client write was flushing attribute creation masks too.

**Fix:** clear the mask at creation, before the handler is attached. Nodes are built in `CreateAddressSpace`, before the endpoint opens, so no client or subscriber can observe it. Both property and attribute variables go through `ConfigureVariableNode`, so one clear covers them.

An earlier revision of this PR instead filtered notifications carrying `Deleted`. That was replaced: `DeleteNode` takes no lock, so a detach-thread flush can interleave with a client write and produce `Value | Deleted` where the `Value` is a genuine, `Good`-acknowledged client write, which the filter would have dropped.

## 3. A detach racing the flush loop mid-write

`CustomNodeManager2.DeleteNode` flushes whatever masks are pending and takes no lock of its own, so a detaching subject could flush a value the write loop had set but not yet flushed itself. The handler then ran on the detach thread, which the thread-scoped flag does not cover, and applied the server's own value.

**Fix:** take the node manager lock around the `DeleteNode` calls in `RemoveSubjectNodes`.

No new lock ordering: `DeleteNode` already acquires that lock internally through `RemoveReferences`, so `_structureLock -> Lock` existed before this change. The reverse order does not exist: `CreateAddressSpace`, the other `_structureLock` holder, is invoked from `MasterNodeManager.StartupAsync`, which holds a `SemaphoreSlim`. The suite was run repeatedly watching for hangs, since a lock-ordering mistake shows up as a hang rather than a failure.

## Verification

Every mechanism is covered by a test that fails when that mechanism alone is removed, each confirmed by defect injection with a rebuild on both sides:

| mechanism | test | without it |
|---|---|---|
| flush-loop flag | `WhenTheServerWritesItsOwnNodes...` | fails |
| creation-mask clear | `WhenASubjectIsDetached...` | fails |
| node manager lock | `WhenDetachRacesTheFlushLoopMidWrite...` | fails, `Expected: "initial" / Actual: "stale-echo"` |

The third reproduces the flush loop's exact mid-write state on one thread while another detaches, and uses no fixed sleep: the flush side waits until the detach thread is either blocked on a lock or finished, both terminal for the interleaving. Measured 0 failures in 10 isolated runs, and 5 consecutive full-suite runs at 290/290.

The first two assert on `IncomingChangesPerSecond` with no client ever connected, so any inbound apply the server records can only be its own.

## Also in this change

`AGENTS.md` no longer pins dependency versions. Two of the three listed had already drifted from the project files (System.Reactive 6.0.1 against 6.1.0, OPC UA 1.5.376.244 against 1.5.378.145), and the stale OPC UA number sent a review at the wrong SDK source.

## Known limits

**A value set without a matching flush under the same lock still misattributes.** That is the invariant the handler comment names, and it is what all three fixes rest on rather than something they enforce.

**One pre-existing lock-order cycle is untouched**: application code that synchronously assigns a subject-containing property in reaction to a client write can interleave with a detach. Identical on master, neither created nor fixed here, and it needs app-mediated subject mutation driven by a client write.

**Concurrent local suite runs are unreliable** for reasons unrelated to this change: the shared fixture binds a hardcoded port and the pool walks a fixed sequence, so two processes running the suite can connect to each other's servers.
