### PR TITLE
fix: Bound the StopAsync token on the participant startup unwind

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -159,6 +159,8 @@ ExecuteAsync (retry loop)
  └── ProcessAsync()                ← runs ChangeQueueProcessor, calls your WriteChangesAsync
 ```
 
+Stopping runs through `BackgroundService.StopAsync`, which waits for the pump task with no bound of its own, so pass it a bounded cancellation token (hosts supply one via `HostOptions.ShutdownTimeout`) because a hook blocked in a protocol call that ignores cancellation would otherwise hang the caller forever.
+
 #### ISubjectSource Interface
 
 `SubjectSourceBase` implements `ISubjectSource`; its abstract `WriteChangesAsync` and `LoadInitialStateAsync` satisfy the interface members directly.

--- a/src/Namotion.Interceptor.ConnectorTester/Hosting/ParticipantHostBundle.cs
+++ b/src/Namotion.Interceptor.ConnectorTester/Hosting/ParticipantHostBundle.cs
@@ -21,6 +21,15 @@ internal sealed class ParticipantHostBundle : IHostedService, IAsyncDisposable
     private readonly IReadOnlyList<IHostedService> _hostedServices;
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Budget for a single service's stop during the startup unwind. Long enough for a socket close
+    /// and a pump task to unwind, short enough that a connector stuck in a protocol call that ignores
+    /// cancellation does not turn a reported startup failure into a hang. Applied per service rather
+    /// than shared across the unwind, so one slow stop cannot starve the services after it of the
+    /// chance to release their sockets.
+    /// </summary>
+    private static readonly TimeSpan RollbackStopTimeout = TimeSpan.FromSeconds(5);
+
     public ParticipantHostBundle(string participantName, IServiceProvider participantServiceProvider)
     {
         _participantName = participantName;
@@ -55,7 +64,11 @@ internal sealed class ParticipantHostBundle : IHostedService, IAsyncDisposable
             {
                 try
                 {
-                    await _hostedServices[i].StopAsync(CancellationToken.None).ConfigureAwait(false);
+                    // Bounded rather than CancellationToken.None: BackgroundService.StopAsync waits
+                    // for the pump task with no bound of its own, so an unbounded token here would
+                    // trade the startup failure we are about to rethrow for an unrecoverable hang.
+                    using var stopTimeout = new CancellationTokenSource(RollbackStopTimeout);
+                    await _hostedServices[i].StopAsync(stopTimeout.Token).ConfigureAwait(false);
                 }
                 catch (Exception stopException)
                 {

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -12,6 +12,14 @@ namespace Namotion.Interceptor.Connectors;
 /// <see cref="StartListeningAsync"/> (protected), <see cref="LoadInitialStateAsync"/> (public),
 /// and <see cref="WriteChangesAsync"/> (public).
 /// </summary>
+/// <remarks>
+/// <see cref="BackgroundService.StopAsync"/> must be called with a bounded cancellation token.
+/// <see cref="StartListeningAsync"/> and <see cref="LoadInitialStateAsync"/> are protocol calls that
+/// can block without observing cancellation, and <see cref="BackgroundService.StopAsync"/> waits for
+/// the pump task with no bound of its own, so an unbounded token waits forever. Hosts already supply
+/// that bound through <c>HostOptions.ShutdownTimeout</c>; code that stops a source directly, outside
+/// the host lifecycle, has to supply its own.
+/// </remarks>
 public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
 {
     private readonly IInterceptorSubjectContext _context;


### PR DESCRIPTION
## Problem

`ParticipantHostBundle.StartAsync` rolls back the prefix of hosted services that already started when a later one fails, and it stopped them with `CancellationToken.None`.

`SubjectSourceBase` derives from `BackgroundService`, and `BackgroundService.StopAsync(token)` awaits `Task.WhenAny(_executeTask, Task.Delay(Timeout.Infinite, token))`. With `CancellationToken.None` there is no second leg to complete, so the wait is unbounded. A connector's `StartListeningAsync` or `LoadInitialStateAsync` can sit in a network call that never observes cancellation, and then the rollback hangs instead of rethrowing the startup failure it was unwinding for.

## Why the caller, not the framework

The pump itself is well behaved: `ExecuteAsync` threads `stoppingToken` through the retry delay, the initial state load and `ProcessAsync`, and returns on `OperationCanceledException`. Under a real host the wait is already bounded by `HostOptions.ShutdownTimeout`, which `IHost.StopAsync` links into the token it passes down. The only unbounded path was this one caller passing `None`.

## Changes

- `ParticipantHostBundle`: the startup unwind now stops each service under a `CancellationTokenSource` with a 5 second budget. Per service rather than one shared budget, so a slow first stop cannot starve the services after it of the chance to release their sockets. A timeout surfaces through the existing swallow-and-log path, so the original startup exception still propagates.
- `SubjectSourceBase`: XML doc note that `StopAsync` must be called with a bounded token, and why.
- `docs/connectors.md`: one sentence on the same point in the pump lifecycle section.

The bundle's own `StopAsync` was already correct: it forwards the caller's token, which the host bounds.

## Rejected alternative

Overriding `StopAsync` in `SubjectSourceBase` to impose a default bound was considered and rejected. It deviates from the documented `BackgroundService` contract, it would silently override a caller that deliberately passed a generous token, and returning early would leave a detached pump task running rather than actually stopping it. Bounding at the call site keeps the decision where the shutdown budget is actually known.

## Verification

- `dotnet build src/Namotion.Interceptor.slnx`: succeeded, 0 warnings.
- `dotnet test src/Namotion.Interceptor.Connectors.Tests`: 450 passed.
- `dotnet test src/Namotion.Interceptor.ConnectorTester.Tests`: 117 passed.
