### PR TITLE
Initialize subjects once instead of once per attach [Design]

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -167,6 +167,13 @@ public class UnitAttribute : Attribute, ISubjectPropertyInitializer
 
     public void InitializeProperty(RegisteredSubjectProperty property)
     {
+        // Initializers run again whenever a subject is re-attached, over properties that are
+        // still on the subject, so check before adding.
+        if (property.TryGetAttribute("Unit") is not null)
+        {
+            return;
+        }
+
         property.AddAttribute("Unit", typeof(string), _ => _unit, null);
     }
 }
@@ -187,7 +194,7 @@ public class DefaultValueInitializer : ISubjectPropertyInitializer
             .OfType<DefaultValueAttribute>()
             .FirstOrDefault();
 
-        if (attribute is not null)
+        if (attribute is not null && property.TryGetAttribute("DefaultValue") is null)
         {
             property.AddAttribute("DefaultValue", property.Type,
                 _ => attribute.Value, null);

--- a/docs/superpowers/specs/2026-08-07-registration-scoped-initializers-design.md
+++ b/docs/superpowers/specs/2026-08-07-registration-scoped-initializers-design.md
@@ -1,12 +1,13 @@
-# Registration-scoped subject initializers
+# Initialize subjects once, not once per attach
 
 Status: approved, not yet implemented
 Issue: #430
 Supersedes the approach in PR #429
+Targets `master`. PR #419 strengthens this design but is not a prerequisite.
 
 ## Problem
 
-Three separate extension points add properties to a subject while it attaches:
+Three extension points add properties to a subject while it attaches:
 
 | Extension point | Interface | Example |
 |---|---|---|
@@ -14,27 +15,26 @@ Three separate extension points add properties to a subject while it attaches:
 | property lifecycle handler | `IPropertyLifecycleHandler` | `PropertyAttributeInitializer` adds `State` and `Configuration` |
 | subject lifecycle handler | `ILifecycleHandler` | `MethodPropertyInitializer` adds a property per `[Operation]` method |
 
-All three re-run whenever a subject re-attaches, which an ordinary move between parents
-triggers as soon as the old reference is removed before the new one is added. Their effect
-does not re-run with them: the properties they added live on `subject.Properties` and
-survive detach. The second run therefore adds a property that is already there, and
-`RegisteredSubject.AddProperty` throws.
+All three re-run whenever a subject re-attaches, which an ordinary move between parents triggers
+as soon as the old reference is removed before the new one is added. Their effect does not re-run
+with them: the properties they added live on `subject.Properties` and survive detach. The second
+run therefore adds a property that is already there, and `RegisteredSubject.AddProperty` throws.
 
 ### The re-run is redundant, not merely unsafe
 
 `RegisteredSubject`'s constructor rebuilds its property set from `subject.Properties`
-(`RegisteredSubject.cs:143`), which still holds everything the previous run added. On
-re-attach the entire prior effect is already present before any initializer runs.
+(`RegisteredSubject.cs:143`), which still holds everything the previous run added. On re-attach
+the entire prior effect is already present before any initializer runs.
 
 `LifecycleInterceptor.AttachToContext` snapshots `subject.Properties.Keys` before invoking
-handlers, and on re-attach that snapshot already contains the dynamic properties. So the
-second run does not repeat the first, it runs every initializer over a strictly larger
-property set, including the properties the initializers themselves created.
+handlers, and on re-attach that snapshot already contains the dynamic properties. So the second
+run does not repeat the first. It runs every initializer over a strictly larger property set,
+including the properties the initializers themselves created.
 
-### Guarding makes it worse
+### The documented workaround makes it worse
 
-The documented workaround is for each implementation to check before adding. Measured, that
-converts a loud failure into a silent one:
+Guarding each implementation with a check before adding is what the docs currently teach.
+Measured, it converts a loud failure into a silent one:
 
 ```
 initializer invocations:                    2
@@ -44,77 +44,66 @@ capture#1 sees marker:                      True
 ```
 
 An initializer may capture the `RegisteredSubjectProperty` it was handed. `TryGetAttribute`
-resolves through `Parent.TryGetPropertyAttribute(...)` (`RegisteredSubjectProperty.cs:301`),
-and `Parent` is the `RegisteredSubject` captured at the time. `SubjectRegistry` builds a new
-one on every re-attach, so a guarded initializer keeps its first-run attribute alive with a
-getter that answers from a discarded registration instead of throwing.
+resolves through `Parent.TryGetPropertyAttribute(...)` (`RegisteredSubjectProperty.cs:301`), and
+`Parent` is the `RegisteredSubject` captured at the time. `SubjectRegistry` builds a new one on
+every re-attach, so a guarded initializer keeps its first-run attribute alive with a getter that
+answers from a discarded registration instead of throwing.
 
-This is not hypothetical. A downstream initializer creates a mutable cell in a closure and
-wires a getter and setter to it, capturing `property` in both.
+This is not hypothetical. A downstream initializer creates a mutable cell in a closure and wires
+a getter and setter to it, capturing `property` in both.
 
 ### Root cause
 
-`SubjectRegistry` discards `RegisteredSubject` on detach and rebuilds it on re-attach.
-Everything above follows from that one decision. Re-invocation is an artifact of the
-rebuild, not a use case: no implementation found across this repository, HomeBlaze, the
-downstream consumers or the docs benefits from running twice. Metadata that must change over
-time is already served by derived attributes, whose getters re-evaluate on read.
+Initialization is driven by attach, which is episodic, while its effect is structural and
+persists on the subject. Re-invocation is an artifact of that mismatch, not a use case: no
+implementation found across this repository, HomeBlaze, downstream consumers or the docs benefits
+from running twice. Metadata that must change over time is already served by derived attributes,
+whose getters re-evaluate on read.
 
 ## Decision
 
-Split by what the state belongs to.
+Initializers run **once per subject**, driven by registration and by property creation rather
+than by attach.
 
-| Layer | Owns | Scope |
-|---|---|---|
-| Registry | the structure of a subject | once per subject |
-| Lifecycle | a subject's participation in a graph | once per attach and per detach |
-
-`InitializeProperty` means what its name says: once per property, ever.
+`RegisteredSubject` ownership does not change. It stays owned by its registry and is rebuilt per
+attach exactly as today. Retaining it per subject was considered and rejected; see Alternatives.
 
 ## Design
 
-### 1. Retain `RegisteredSubject`
+### 1. Two flags at two granularities
 
-Pin it on the subject rather than in the registry alone, create it once, and reuse it.
-`SubjectRegistry` still adds and removes `_knownSubjects` entries on attach and detach, so
-attached-ness is unchanged. It stops discarding the object. The registration dies with the
-subject, so nothing leaks.
+**Subject flag**, persistent for the life of the subject: whether initializers have ever run for
+it. Stored in `subject.Data` under a single key, following the `SubjectIdKey` precedent. It
+survives detach and dies with the subject, so nothing leaks.
 
-Verified safe: detach already empties every piece of graph-scoped state the object holds.
+`subject.Data` rather than `InterceptorExecutor` deliberately. The executor is the better home
+and is where PR #419 moves other per-subject state, but that PR rewrites the executor heavily and
+this design is meant to stay independent of it. Move the flag there once #419 lands.
 
-```
-attached: middle parents=1  leaf parents=1  middle.Child children=1
-detached: middle parents=0  leaf parents=0  middle.Child children=0
-detached: refcount middle=0 leaf=0
-detached: middle in KnownSubjects=False
-detached: properties retained middle=2 leaf=1
-```
+**Registration flag**, on the `RegisteredSubject`: whether this registration should initialize its
+properties. Set when the registration is created, from an atomic read-and-set of the subject flag.
 
-At the moment of discard the object is already in the state a freshly built one would be in,
-except that it still knows its properties. That is the part worth keeping.
+Both are needed. The subject flag alone cannot drive a per-property check, because it flips to
+"done" while the first pass is still running and would skip every property after the first.
 
-The registration is shared across contexts. A subject moved from context A to context B keeps
-A's registration, so an initializer that B has and A did not will not run for it. This is
-accepted: B already inherits A's added properties either way, so a per-registry registration
-would produce a half-initialized merge rather than a clean slate.
+### 2. Three events, not one
 
-### 2. Initialize once per property
+| Event | Initializes |
+|---|---|
+| a subject is registered for the first time | all of its properties |
+| `AddProperty` creates a property | that property only |
+| a subject re-attaches | nothing |
 
-A flag on `RegisteredSubjectProperty`, set after its initializers have run. `SubjectRegistry`
-keeps invoking them from `IPropertyLifecycleHandler.AttachProperty` and only guards the call.
+`AddProperty` initializes unconditionally, ignoring both flags: a property that was just created
+has never been initialized whatever the subject's history. This covers a property added by a
+consumer at runtime, and a property added by one initializer during another's pass.
 
-Invocation is deliberately not moved to registration time. The existing ancestor-resolution
-tests pin that a derived attribute's first getter evaluation already sees the full ancestor
-chain, and that ordering should not move in the same change.
+A property added during the first pass is initialized exactly once, not twice.
+`AttachToContext` snapshots `subject.Properties.Keys` before the pass, so a property created
+during it is not in the snapshot and is not revisited by the loop, while `AddProperty` has
+already initialized it directly.
 
-### 3. Reconcile on re-registration
-
-Any property present on `subject.Properties` that the retained registration does not know
-about is added to it and initialized. `DynamicSubjectFactory.cs:49` calls
-`subject.AddProperties(...)` directly, bypassing the registry, and the current rebuild picks
-those up for free. Retention alone would not.
-
-### 4. Add `ISubjectInitializer`
+### 3. Add `ISubjectInitializer`
 
 ```csharp
 public interface ISubjectInitializer
@@ -123,42 +112,45 @@ public interface ISubjectInitializer
 }
 ```
 
-Called once per `RegisteredSubject`. This is the missing grain size: `ISubjectPropertyInitializer`
-is per property, and the only per-subject hook is `ILifecycleHandler`, which is episodic by
-design. Work that is genuinely per-subject-once had nowhere correct to live, which is why
-`MethodPropertyInitializer` is an `ILifecycleHandler`.
+Called once per subject, on the same first-registration event as the property initializers.
+
+This is the missing grain size. `ISubjectPropertyInitializer` is per property, and the only
+per-subject hook is `ILifecycleHandler`, which is episodic by design. Work that is genuinely
+per-subject-once had nowhere correct to live, which is why `MethodPropertyInitializer` is an
+`ILifecycleHandler` today.
 
 The only new public type in this design.
 
-### 5. `AddProperty` keeps throwing on a duplicate
+### 4. `AddProperty` keeps throwing on a duplicate
 
-Under once-semantics a duplicate is a real error again rather than an artifact of re-attach,
-so the throw is the correct behaviour and stays.
+Under once-semantics a duplicate is a real error again rather than an artifact of re-attach, so
+the throw is correct behaviour and stays.
 
 ## Where each member lands
 
-### Registry layer
+### Registry layer, structure, runs once per subject
 
-| Interface | Runs | Implementations |
-|---|---|---|
-| `ISubjectPropertyInitializer` | once per (`RegisteredSubject`, property) | `UnitAttribute` (SampleWeb), `DefaultValueInitializer` (docs), `PropertyAttributeInitializer` (moved in), downstream attribute and service initializers |
-| `ISubjectInitializer` (new) | once per `RegisteredSubject` | `MethodPropertyInitializer` (moved in) |
+| Interface | Implementations |
+|---|---|
+| `ISubjectPropertyInitializer` | `UnitAttribute` (SampleWeb), `DefaultValueInitializer` (docs), `PropertyAttributeInitializer` (moved in), downstream attribute and service initializers |
+| `ISubjectInitializer` (new) | `MethodPropertyInitializer` (moved in) |
 
-### Lifecycle layer
+### Lifecycle layer, episodes, runs every attach and detach
 
-| Interface | Runs | Implementations |
-|---|---|---|
-| `ILifecycleHandler` | every attach and detach | `ContextInheritanceHandler`, `ParentTrackingHandler`, `SubjectRegistry`, `HostedServiceHandler`, `SubjectPathResolver`, `TestLifecycleHandler`, `LogPropertyChangesHandler` (sample) |
-| `IPropertyLifecycleHandler` | every attach and detach | `SubjectRegistry`, `DerivedPropertyChangeHandler`, `TestLifecycleHandler` |
+| Interface | Implementations |
+|---|---|
+| `ILifecycleHandler` | `ContextInheritanceHandler`, `ParentTrackingHandler`, `SubjectRegistry`, `HostedServiceHandler`, `SubjectPathResolver`, `TestLifecycleHandler`, `LogPropertyChangesHandler` (sample) |
+| `IPropertyLifecycleHandler` | `SubjectRegistry`, `DerivedPropertyChangeHandler`, `TestLifecycleHandler` |
 
-Everything remaining in the lifecycle layer is paired: it starts what detach stops, or it
-maintains graph state that detach empties, or it is deliberately fire-every-time.
+Everything remaining in the lifecycle layer is paired: it starts what detach stops, or maintains
+graph state that detach empties, or is deliberately fire-every-time.
 
 ## Callback signatures stay as they are
 
 Considered and rejected: passing richer context so handlers could detect re-attach and defend
-against it. Fixing the scope removes the need to detect anything, and adding the flags anyway
-would preserve the shape of a problem that has been deleted.
+against it. Fixing the scope removes the need to detect anything, and adding the flags to the
+public callbacks would preserve the shape of a problem that has been deleted, putting the burden
+back on every implementer to check correctly.
 
 The registry callbacks lose nothing by staying as they are. Everything reachable from
 `RegisteredSubjectProperty` includes `Parent` and the whole registration, `Reference.Metadata`
@@ -168,18 +160,16 @@ with `IsDynamic`, `IsDerived`, `IsIntercepted`, `IsPublic` and `PropertyInfo`,
 
 Two gaps in the lifecycle layer are recorded and deferred, neither having a consumer today:
 
-- `SubjectLifecycleChange` drops the attaching context, which for a child is the parent's
-  context rather than `change.Subject.Context`.
+- `SubjectLifecycleChange` drops the attaching context, which for a child is the parent's context
+  rather than `change.Subject.Context`.
 - `SubjectPropertyLifecycleChange` cannot distinguish a subject-wide attach sweep from a
   standalone `AddProperty` on an already-attached subject.
 
-Deferring costs nothing for the first: `SubjectLifecycleChange` is a `readonly struct` with
-`init` properties, and handlers only read it, so a new non-required property is source
-compatible.
+Deferring the first costs nothing: `SubjectLifecycleChange` is a `readonly struct` with `init`
+properties and handlers only read it, so a new non-required property is source compatible.
 
-Constraint for the second: `SubjectPropertyLifecycleChange` is a positional `record struct`,
-so a new positional parameter would break its constructor. Any future field must be added as
-an `init` property.
+Constraint for the second: `SubjectPropertyLifecycleChange` is a positional `record struct`, so a
+new positional parameter would break its constructor. Any future field must be an `init` property.
 
 ## Concurrency
 
@@ -201,7 +191,7 @@ void AddProperties(params IEnumerable<SubjectPropertyMetadata> properties)
 ```
 
 A separate lock guards only the registry's copy, leaving the subject's copy free to be mutated
-concurrently through `subject.AddProperties(...)`, which `DynamicSubjectFactory` does. The
+concurrently through `subject.AddProperties(...)`, which `DynamicSubjectFactory.cs:49` does. The
 check and the add must be atomic across both views, so `SyncRoot` is required for correctness
 rather than chosen for convenience.
 
@@ -211,17 +201,17 @@ rather than chosen for convenience.
 SyncRoot  ->  RegisteredSubject._lock     (parent state; leaf, never calls back into the subject)
 ```
 
-Acyclic. `SyncRoot` is a plain `object`, so `lock` is `Monitor` and re-entrant, which resolves
-the cycle recorded in `f95dde99`: a getter or setter running under `SyncRoot` that calls
-`AddProperty` re-enters instead of deadlocking.
+Acyclic. `SyncRoot` is a plain `object`, so `lock` is `Monitor` and re-entrant, which resolves the
+cycle recorded in `f95dde99`: a getter or setter running under `SyncRoot` that calls `AddProperty`
+re-enters instead of deadlocking.
 
 ### Cost
 
 `AddProperty` is not on the hot path, so correctness, thread safety and freedom from deadlock
 decide the design and performance is optimised only within what those allow.
 
-Holding `SyncRoot` across the registry's property rebuild blocks intercepted reads and writes
-on that subject (`ReadInterceptorFactory.cs:19`, `WriteInterceptorFactory.cs:19`). The delta is
+Holding `SyncRoot` across the registry's property rebuild blocks intercepted reads and writes on
+that subject (`ReadInterceptorFactory.cs:19`, `WriteInterceptorFactory.cs:19`). The delta is
 bounded: both `AddProperties` implementations already perform an O(n) rebuild inside
 `lock (SyncRoot)`, so this makes the critical section roughly twice as long rather than
 introducing one.
@@ -232,17 +222,11 @@ the lock as well, and swapping it under the lock with a re-validation retry, wou
 roughly one rebuild. Recorded as available, not planned, because it trades a straight-line
 critical section for a retry loop to optimise a path that is not hot.
 
-### Mutate under the lock, notify outside it
-
-`Subject.AttachSubjectProperty(...)` and `SetPropertyValueWithInterception` stay outside the
-lock. Both invoke handler and initializer code that can do anything, and holding `SyncRoot`
-across it reintroduces the hazard this removes.
-
 ### Reject an add from inside an accessor
 
-Calling `AddProperty` from a getter or setter of the same subject leaves that section running
-under the caller's lock. Re-entrancy prevents a deadlock but cannot prevent the situation, so
-`AddProperty` rejects it before taking the lock:
+Calling `AddProperty` from a getter or setter of the same subject leaves the post-lock section
+running under the caller's lock. Re-entrancy prevents a deadlock but cannot prevent the
+situation, so `AddProperty` rejects it before taking the lock:
 
 ```csharp
 if (Monitor.IsEntered(Subject.SyncRoot))
@@ -252,39 +236,42 @@ if (Monitor.IsEntered(Subject.SyncRoot))
 ```
 
 The check is not racy, because it is not the question that races. `Monitor.IsEntered` asks
-whether the *current thread* holds the lock, which is thread-local: no other thread can change
-the answer, and this thread does nothing between the check and the `lock`. The racy question
-would be whether the lock is free, which is not asked.
+whether the *current thread* holds the lock, which is thread-local: no other thread can change the
+answer, and this thread does nothing between the check and the `lock`. The racy question would be
+whether the lock is free, which is not asked.
 
 Take-or-throw does not work as an alternative. `Monitor` is re-entrant, so
-`Monitor.TryEnter(SyncRoot, 0)` returns true when the current thread already owns the lock,
-which is exactly the case to reject. A non-re-entrant primitive such as `SemaphoreSlim(1,1)`
-would block forever there rather than throw, turning a diagnosable error into the deadlock, and
-it cannot replace `SyncRoot` in any case because `subject.AddProperties` takes `SyncRoot` and
-correctness requires one lock across both views.
+`Monitor.TryEnter(SyncRoot, 0)` returns true when the current thread already owns the lock, which
+is exactly the case to reject. A non-re-entrant primitive such as `SemaphoreSlim(1,1)` would block
+forever there rather than throw, turning a diagnosable error into the deadlock, and it cannot
+replace `SyncRoot` in any case.
 
-Measured cost, Release build: `Monitor.IsEntered` is 1.56 ns when the lock is not held and
-1.76 ns when it is, against 2309 ns for a single `ToFrozenDictionary` rebuild of a 12-property
-subject. `AddProperty` performs two such rebuilds, so the check is about 0.03% of one of them.
+Measured cost, Release build: `Monitor.IsEntered` is 1.56 ns when the lock is not held and 1.76 ns
+when it is, against 2309 ns for a single `ToFrozenDictionary` rebuild of a 12-property subject.
+`AddProperty` performs two such rebuilds, so the check is about 0.03% of one of them.
 
 The check is precise because `SyncRoot` is held only around a user accessor. The read and write
-terminals take it around `innerReadValue` and `innerWriteValue` (`ReadInterceptorFactory.cs:19`,
-`WriteInterceptorFactory.cs:19`), and the zero-interceptor terminal does not take it at all.
-
-No library flow that adds properties holds it. `LifecycleInterceptor.WriteProperty` calls
-`next(ref context)` first, and the terminal takes and releases `SyncRoot` within that call, so
-all attach work including every initializer runs afterwards with no lock held. That holds for a
-self-referencing subject too, which is the case most likely to look like a false positive.
+terminals take it around `innerReadValue` and `innerWriteValue`, and the zero-interceptor terminal
+does not take it at all. No library flow that adds properties holds it:
+`LifecycleInterceptor.WriteProperty` calls `next(ref context)` first, and the terminal takes and
+releases `SyncRoot` within that call, so all attach work including every initializer runs
+afterwards with no lock held. That holds for a self-referencing subject too, which is the case
+most likely to look like a false positive.
 
 Not detectable this way, and recorded rather than solved: a cross-subject cycle where A's getter
 adds a property to B while B's getter adds one to A. `Monitor.IsEntered` answers only for the
 current thread and the subject being added to.
 
+### Mutate under the lock, notify outside it
+
+`Subject.AttachSubjectProperty(...)` and `SetPropertyValueWithInterception` stay outside the lock.
+Both invoke handler and initializer code that can do anything, and holding `SyncRoot` across it
+reintroduces the hazard this removes.
+
 ## Consumer migration
 
 Two HomeBlaze classes change interface. Both are registered as one-line context services in
-`SubjectContextFactory.cs:31-36`, so each is an interface change plus a registration type
-argument.
+`SubjectContextFactory.cs:31-36`, so each is an interface change plus a registration type argument.
 
 | Class | From | To |
 |---|---|---|
@@ -304,39 +291,103 @@ No public API breaks. `ISubjectPropertyInitializer` keeps its signature, so no d
 implementation must change. Existing guards become redundant and stay harmless, and the guard
 added downstream for PR #429 can be reverted.
 
+## Alternatives considered
+
+### Retain `RegisteredSubject` per subject
+
+Pin the registration on the subject and reuse it, so initialization is once per registration by
+construction and captured references never go stale. Rejected because it is unsound on `master`.
+
+`RegisteredSubject` holds two kinds of state with different lifetimes: the property set, which
+belongs to the subject, and `Parents` and `Children`, which belong to the graph. Sharing the
+object shares both. Measured with two co-resolved registries:
+
+```
+[1 registry]    parents=1  children=1
+[2 registries]  A parents=2  A children=2   B parents=1
+[after detach]  A parents=1  A children=1
+```
+
+Two registries already resolve as separate `ILifecycleHandler` services and both receive every
+change. Today each holds its own registration, so they cannot corrupt each other. A shared
+registration would receive every `AddParent` twice by construction, and `RemoveParent` clears only
+one of the pair.
+
+This is safe only under a guarantee that a subject belongs to at most one graph, which is what
+PR #419 introduces. Building on `master` cannot assume it.
+
+### Richer lifecycle context
+
+Give handlers a first-attach flag so they can defend themselves. Rejected: it preserves the
+problem's shape after the problem has been deleted, and it requires every implementer to get the
+check right. See "Callback signatures stay as they are".
+
 ## Testing
 
-- An initializer runs exactly once across a move between parents that passes the reference
-  count through zero.
-- A captured `RegisteredSubjectProperty` still resolves against the live registration after
-  re-attach, which is the stale-read defect above and fails against current code.
-- A property added to a detached subject through `subject.AddProperties(...)` is picked up and
-  initialized on re-registration.
+- An initializer runs exactly once across a move between parents that passes the reference count
+  through zero.
+- A property added through `AddProperty` after the subject is initialized is itself initialized.
+- A property added by one initializer during the first pass is initialized exactly once.
 - `AddProperty` still throws on a genuine duplicate.
 - A concurrent `AddProperty` and `subject.AddProperties(...)` on the same subject leave the
   registry's and the subject's property sets in agreement.
-- `AddProperty` called from a property getter completes rather than deadlocking.
-- The existing ancestor-resolution tests continue to pass unchanged, pinning that initializer
-  invocation ordering did not move.
+- `AddProperty` from a property getter throws rather than deadlocking.
+- Aggregating a second registry no longer throws, where today it does. Confirms the flag is
+  per subject and not per registration.
+- The existing ancestor-resolution tests pass unchanged, pinning that initializer invocation
+  ordering did not move.
 
-## Out of scope
+## Benchmarks
 
-- **PR #419.** Open and unmerged, and it reworks this area heavily. This design targets
-  `master`. #419 confirms that simultaneous membership in two graphs throws while a sequential
-  move between contexts stays supported, which is what makes the shared-registration decision
-  in section 1 a real trade rather than a theoretical one. It also moves the reference count off
-  `subject.Data` onto `InterceptorExecutor`; if these land in that order, the retained
-  registration should follow it there.
-- **Property removal (#210).** No removal API exists. Retention makes one unnecessary here,
-  but a future removal API must clear the retained registration's entry.
+`RegistryBenchmark` covers attach and detach churn only for *new* subjects
+(`AddLotsOfPreviousCars` replaces 1000 cars per iteration, `ChangeAllTires` replaces four tires),
+and no benchmark registers an `ISubjectPropertyInitializer` at all. So the paths this design
+changes are unmeasured. Add before and after:
+
+- re-attach of the *same* subjects, which is where skipping initialization pays
+- attach with initializers registered, since `AttachProperty` currently allocates a LINQ iterator
+  per property per attach through `ReflectionAttributes.OfType<ISubjectPropertyInitializer>()`
+- `AddProperty` throughput, which is where the lock change and the accessor check land
+
+## Out of scope, to file separately
+
+- **`AddParent` and `AddChild` are not idempotent.** Measured above: aggregating a second
+  lifecycle-bearing context makes a registry record the same parent edge twice, and detach clears
+  only one of the pair. A pre-existing `master` bug, the same root cause as the initializer
+  double-add, and independent of this design.
+- **Stale captures.** This design stops initializers re-running but still rebuilds
+  `RegisteredSubject` per attach, so an initializer that captured the `RegisteredSubjectProperty`
+  it was handed keeps a delegate resolving through a discarded registration. Two downstream
+  initializers do this. Neither is fixed nor caused here: the same state already results from the
+  guard pattern the docs currently teach.
+
+  Making `Parent` resolve the live registration was measured and rejected. It costs 19.5x on
+  attribute lookup (`TryGetAttribute` 2.47 ns becomes 48.02 ns, because
+  `subject.TryGetRegisteredSubject()` is a service resolution plus a lock plus a dictionary
+  lookup at 45.56 ns against a 0.26 ns field read), it lands on read paths since `TryGetAttribute`
+  runs inside derived-property getters, it affects 27 call sites including `PathExtensions` loops,
+  and it does not solve the problem: `Children` and `AttributesCache` are fields on the property
+  instance, not on the parent, so a captured collection property still reports zero children after
+  re-attach.
+
+  The correct fix is on the capturing side, because a `RegisteredSubjectProperty` is a
+  per-registration object and must not be captured as if it were permanent. Capture
+  `property.Reference` instead, a `PropertyReference` of subject and name that are both permanent,
+  and resolve through `TryGetRegisteredProperty()` when needed. Fully correct, free for the
+  library, and a two-line change at each of the two sites. Document this on
+  `ISubjectPropertyInitializer` and file the issue.
+- **PR #419.** Independent. It strengthens this design by guaranteeing one graph per subject, which
+  is what would make retaining the registration safe, but nothing here depends on it. When it
+  lands, move the subject flag from `subject.Data` onto `InterceptorExecutor`.
+- **Property removal (#210).** No removal API exists. A future one must clear the subject flag.
 - **PR #429.** One part survives: the fix for `AddProperty` corrupting a declared property's
-  metadata when a rejected add had already called `Subject.AddProperties`. Its locking is
-  replaced rather than kept, since `_addPropertyLock` guards only one of the two views. Its
-  idempotency documentation, its `ISubjectPropertyInitializer` remarks, and the consumer guards
-  it added all come out.
+  metadata when a rejected add had already called `Subject.AddProperties`. Its locking is replaced
+  rather than kept, since `_addPropertyLock` guards only one of the two views. Its idempotency
+  documentation, its `ISubjectPropertyInitializer` remarks, and the consumer guards it added all
+  come out.
 
 ## Permanent home
 
 This spec is temporary. On implementation, fold the layer split and the concurrency rules into
-`docs/design/tracking-lifecycle.md` and update `docs/registry.md`, whose two initializer
-samples currently teach the guard pattern this removes.
+`docs/design/tracking-lifecycle.md` and update `docs/registry.md`, whose two initializer samples
+currently teach the guard pattern this removes.

--- a/docs/superpowers/specs/2026-08-07-registration-scoped-initializers-design.md
+++ b/docs/superpowers/specs/2026-08-07-registration-scoped-initializers-design.md
@@ -1,0 +1,342 @@
+# Registration-scoped subject initializers
+
+Status: approved, not yet implemented
+Issue: #430
+Supersedes the approach in PR #429
+
+## Problem
+
+Three separate extension points add properties to a subject while it attaches:
+
+| Extension point | Interface | Example |
+|---|---|---|
+| property initializer | `ISubjectPropertyInitializer` | `UnitAttribute` adds a `Unit` attribute |
+| property lifecycle handler | `IPropertyLifecycleHandler` | `PropertyAttributeInitializer` adds `State` and `Configuration` |
+| subject lifecycle handler | `ILifecycleHandler` | `MethodPropertyInitializer` adds a property per `[Operation]` method |
+
+All three re-run whenever a subject re-attaches, which an ordinary move between parents
+triggers as soon as the old reference is removed before the new one is added. Their effect
+does not re-run with them: the properties they added live on `subject.Properties` and
+survive detach. The second run therefore adds a property that is already there, and
+`RegisteredSubject.AddProperty` throws.
+
+### The re-run is redundant, not merely unsafe
+
+`RegisteredSubject`'s constructor rebuilds its property set from `subject.Properties`
+(`RegisteredSubject.cs:143`), which still holds everything the previous run added. On
+re-attach the entire prior effect is already present before any initializer runs.
+
+`LifecycleInterceptor.AttachToContext` snapshots `subject.Properties.Keys` before invoking
+handlers, and on re-attach that snapshot already contains the dynamic properties. So the
+second run does not repeat the first, it runs every initializer over a strictly larger
+property set, including the properties the initializers themselves created.
+
+### Guarding makes it worse
+
+The documented workaround is for each implementation to check before adding. Measured, that
+converts a loud failure into a silent one:
+
+```
+initializer invocations:                    2
+capture#1 Parent == live registration:      False
+capture#1 parent still in KnownSubjects:    False
+capture#1 sees marker:                      True
+```
+
+An initializer may capture the `RegisteredSubjectProperty` it was handed. `TryGetAttribute`
+resolves through `Parent.TryGetPropertyAttribute(...)` (`RegisteredSubjectProperty.cs:301`),
+and `Parent` is the `RegisteredSubject` captured at the time. `SubjectRegistry` builds a new
+one on every re-attach, so a guarded initializer keeps its first-run attribute alive with a
+getter that answers from a discarded registration instead of throwing.
+
+This is not hypothetical. A downstream initializer creates a mutable cell in a closure and
+wires a getter and setter to it, capturing `property` in both.
+
+### Root cause
+
+`SubjectRegistry` discards `RegisteredSubject` on detach and rebuilds it on re-attach.
+Everything above follows from that one decision. Re-invocation is an artifact of the
+rebuild, not a use case: no implementation found across this repository, HomeBlaze, the
+downstream consumers or the docs benefits from running twice. Metadata that must change over
+time is already served by derived attributes, whose getters re-evaluate on read.
+
+## Decision
+
+Split by what the state belongs to.
+
+| Layer | Owns | Scope |
+|---|---|---|
+| Registry | the structure of a subject | once per subject |
+| Lifecycle | a subject's participation in a graph | once per attach and per detach |
+
+`InitializeProperty` means what its name says: once per property, ever.
+
+## Design
+
+### 1. Retain `RegisteredSubject`
+
+Pin it on the subject rather than in the registry alone, create it once, and reuse it.
+`SubjectRegistry` still adds and removes `_knownSubjects` entries on attach and detach, so
+attached-ness is unchanged. It stops discarding the object. The registration dies with the
+subject, so nothing leaks.
+
+Verified safe: detach already empties every piece of graph-scoped state the object holds.
+
+```
+attached: middle parents=1  leaf parents=1  middle.Child children=1
+detached: middle parents=0  leaf parents=0  middle.Child children=0
+detached: refcount middle=0 leaf=0
+detached: middle in KnownSubjects=False
+detached: properties retained middle=2 leaf=1
+```
+
+At the moment of discard the object is already in the state a freshly built one would be in,
+except that it still knows its properties. That is the part worth keeping.
+
+The registration is shared across contexts. A subject moved from context A to context B keeps
+A's registration, so an initializer that B has and A did not will not run for it. This is
+accepted: B already inherits A's added properties either way, so a per-registry registration
+would produce a half-initialized merge rather than a clean slate.
+
+### 2. Initialize once per property
+
+A flag on `RegisteredSubjectProperty`, set after its initializers have run. `SubjectRegistry`
+keeps invoking them from `IPropertyLifecycleHandler.AttachProperty` and only guards the call.
+
+Invocation is deliberately not moved to registration time. The existing ancestor-resolution
+tests pin that a derived attribute's first getter evaluation already sees the full ancestor
+chain, and that ordering should not move in the same change.
+
+### 3. Reconcile on re-registration
+
+Any property present on `subject.Properties` that the retained registration does not know
+about is added to it and initialized. `DynamicSubjectFactory.cs:49` calls
+`subject.AddProperties(...)` directly, bypassing the registry, and the current rebuild picks
+those up for free. Retention alone would not.
+
+### 4. Add `ISubjectInitializer`
+
+```csharp
+public interface ISubjectInitializer
+{
+    void InitializeSubject(RegisteredSubject subject);
+}
+```
+
+Called once per `RegisteredSubject`. This is the missing grain size: `ISubjectPropertyInitializer`
+is per property, and the only per-subject hook is `ILifecycleHandler`, which is episodic by
+design. Work that is genuinely per-subject-once had nowhere correct to live, which is why
+`MethodPropertyInitializer` is an `ILifecycleHandler`.
+
+The only new public type in this design.
+
+### 5. `AddProperty` keeps throwing on a duplicate
+
+Under once-semantics a duplicate is a real error again rather than an artifact of re-attach,
+so the throw is the correct behaviour and stays.
+
+## Where each member lands
+
+### Registry layer
+
+| Interface | Runs | Implementations |
+|---|---|---|
+| `ISubjectPropertyInitializer` | once per (`RegisteredSubject`, property) | `UnitAttribute` (SampleWeb), `DefaultValueInitializer` (docs), `PropertyAttributeInitializer` (moved in), downstream attribute and service initializers |
+| `ISubjectInitializer` (new) | once per `RegisteredSubject` | `MethodPropertyInitializer` (moved in) |
+
+### Lifecycle layer
+
+| Interface | Runs | Implementations |
+|---|---|---|
+| `ILifecycleHandler` | every attach and detach | `ContextInheritanceHandler`, `ParentTrackingHandler`, `SubjectRegistry`, `HostedServiceHandler`, `SubjectPathResolver`, `TestLifecycleHandler`, `LogPropertyChangesHandler` (sample) |
+| `IPropertyLifecycleHandler` | every attach and detach | `SubjectRegistry`, `DerivedPropertyChangeHandler`, `TestLifecycleHandler` |
+
+Everything remaining in the lifecycle layer is paired: it starts what detach stops, or it
+maintains graph state that detach empties, or it is deliberately fire-every-time.
+
+## Callback signatures stay as they are
+
+Considered and rejected: passing richer context so handlers could detect re-attach and defend
+against it. Fixing the scope removes the need to detect anything, and adding the flags anyway
+would preserve the shape of a problem that has been deleted.
+
+The registry callbacks lose nothing by staying as they are. Everything reachable from
+`RegisteredSubjectProperty` includes `Parent` and the whole registration, `Reference.Metadata`
+with `IsDynamic`, `IsDerived`, `IsIntercepted`, `IsPublic` and `PropertyInfo`,
+`ReflectionAttributes`, and `Subject.Context`. `SubjectRegistry.AttachProperty` holds only
+`change.Subject` and `change.Property`, both derivable from the parameter.
+
+Two gaps in the lifecycle layer are recorded and deferred, neither having a consumer today:
+
+- `SubjectLifecycleChange` drops the attaching context, which for a child is the parent's
+  context rather than `change.Subject.Context`.
+- `SubjectPropertyLifecycleChange` cannot distinguish a subject-wide attach sweep from a
+  standalone `AddProperty` on an already-attached subject.
+
+Deferring costs nothing for the first: `SubjectLifecycleChange` is a `readonly struct` with
+`init` properties, and handlers only read it, so a new non-required property is source
+compatible.
+
+Constraint for the second: `SubjectPropertyLifecycleChange` is a positional `record struct`,
+so a new positional parameter would break its constructor. Any future field must be added as
+an `init` property.
+
+## Concurrency
+
+`AddProperty` is public and may be called concurrently, at runtime, on a subject that is being
+actively read and written. The design must hold for that, not only for the initializer path.
+
+### One lock, not two
+
+`AddProperty` locks on `subject.SyncRoot`. `_addPropertyLock` from PR #429 is removed.
+
+`SyncRoot` is already the lock guarding a subject's property dictionary, identically in both
+implementations (`SubjectCodeGenerator.cs:155` and `DynamicSubject.cs:39`):
+
+```csharp
+void AddProperties(params IEnumerable<SubjectPropertyMetadata> properties)
+{
+    lock (((IInterceptorSubject)this).SyncRoot) { _properties = ...ToFrozenDictionary(); }
+}
+```
+
+A separate lock guards only the registry's copy, leaving the subject's copy free to be mutated
+concurrently through `subject.AddProperties(...)`, which `DynamicSubjectFactory` does. The
+check and the add must be atomic across both views, so `SyncRoot` is required for correctness
+rather than chosen for convenience.
+
+### Lock graph
+
+```
+SyncRoot  ->  RegisteredSubject._lock     (parent state; leaf, never calls back into the subject)
+```
+
+Acyclic. `SyncRoot` is a plain `object`, so `lock` is `Monitor` and re-entrant, which resolves
+the cycle recorded in `f95dde99`: a getter or setter running under `SyncRoot` that calls
+`AddProperty` re-enters instead of deadlocking.
+
+### Cost
+
+`AddProperty` is not on the hot path, so correctness, thread safety and freedom from deadlock
+decide the design and performance is optimised only within what those allow.
+
+Holding `SyncRoot` across the registry's property rebuild blocks intercepted reads and writes
+on that subject (`ReadInterceptorFactory.cs:19`, `WriteInterceptorFactory.cs:19`). The delta is
+bounded: both `AddProperties` implementations already perform an O(n) rebuild inside
+`lock (SyncRoot)`, so this makes the critical section roughly twice as long rather than
+introducing one.
+
+Cheap work that does not need the lock still stays outside it: the property metadata and the
+`RegisteredSubjectProperty` are built before it is taken. Building the frozen dictionary outside
+the lock as well, and swapping it under the lock with a re-validation retry, would return to
+roughly one rebuild. Recorded as available, not planned, because it trades a straight-line
+critical section for a retry loop to optimise a path that is not hot.
+
+### Mutate under the lock, notify outside it
+
+`Subject.AttachSubjectProperty(...)` and `SetPropertyValueWithInterception` stay outside the
+lock. Both invoke handler and initializer code that can do anything, and holding `SyncRoot`
+across it reintroduces the hazard this removes.
+
+### Reject an add from inside an accessor
+
+Calling `AddProperty` from a getter or setter of the same subject leaves that section running
+under the caller's lock. Re-entrancy prevents a deadlock but cannot prevent the situation, so
+`AddProperty` rejects it before taking the lock:
+
+```csharp
+if (Monitor.IsEntered(Subject.SyncRoot))
+    throw new InvalidOperationException(
+        $"Cannot add property '{name}' to '{Subject.GetType().Name}' from a getter or setter of " +
+        "the same subject: the accessor already holds the subject's lock.");
+```
+
+The check is not racy, because it is not the question that races. `Monitor.IsEntered` asks
+whether the *current thread* holds the lock, which is thread-local: no other thread can change
+the answer, and this thread does nothing between the check and the `lock`. The racy question
+would be whether the lock is free, which is not asked.
+
+Take-or-throw does not work as an alternative. `Monitor` is re-entrant, so
+`Monitor.TryEnter(SyncRoot, 0)` returns true when the current thread already owns the lock,
+which is exactly the case to reject. A non-re-entrant primitive such as `SemaphoreSlim(1,1)`
+would block forever there rather than throw, turning a diagnosable error into the deadlock, and
+it cannot replace `SyncRoot` in any case because `subject.AddProperties` takes `SyncRoot` and
+correctness requires one lock across both views.
+
+Measured cost, Release build: `Monitor.IsEntered` is 1.56 ns when the lock is not held and
+1.76 ns when it is, against 2309 ns for a single `ToFrozenDictionary` rebuild of a 12-property
+subject. `AddProperty` performs two such rebuilds, so the check is about 0.03% of one of them.
+
+The check is precise because `SyncRoot` is held only around a user accessor. The read and write
+terminals take it around `innerReadValue` and `innerWriteValue` (`ReadInterceptorFactory.cs:19`,
+`WriteInterceptorFactory.cs:19`), and the zero-interceptor terminal does not take it at all.
+
+No library flow that adds properties holds it. `LifecycleInterceptor.WriteProperty` calls
+`next(ref context)` first, and the terminal takes and releases `SyncRoot` within that call, so
+all attach work including every initializer runs afterwards with no lock held. That holds for a
+self-referencing subject too, which is the case most likely to look like a false positive.
+
+Not detectable this way, and recorded rather than solved: a cross-subject cycle where A's getter
+adds a property to B while B's getter adds one to A. `Monitor.IsEntered` answers only for the
+current thread and the subject being added to.
+
+## Consumer migration
+
+Two HomeBlaze classes change interface. Both are registered as one-line context services in
+`SubjectContextFactory.cs:31-36`, so each is an interface change plus a registration type
+argument.
+
+| Class | From | To |
+|---|---|---|
+| `MethodPropertyInitializer` | `ILifecycleHandler` | `ISubjectInitializer` |
+| `PropertyAttributeInitializer` | `IPropertyLifecycleHandler` | `ISubjectPropertyInitializer` |
+
+Both get shorter, which is the signal that the interface was wrong rather than the code.
+`MethodPropertyInitializer` loses its `IsContextAttach` wrapper, its
+`TryGetRegisteredSubject() ?? throw` lookup, and the re-attach guard added in PR #429.
+`PropertyAttributeInitializer` loses its `TryGetRegisteredProperty` lookup and null check, two
+empty interface stubs, and both `TryGetAttribute(...) is null` guards.
+
+`HomeBlaze.Services/Lifecycle/` then holds no lifecycle handlers and should be renamed to
+`Initializers/`.
+
+No public API breaks. `ISubjectPropertyInitializer` keeps its signature, so no downstream
+implementation must change. Existing guards become redundant and stay harmless, and the guard
+added downstream for PR #429 can be reverted.
+
+## Testing
+
+- An initializer runs exactly once across a move between parents that passes the reference
+  count through zero.
+- A captured `RegisteredSubjectProperty` still resolves against the live registration after
+  re-attach, which is the stale-read defect above and fails against current code.
+- A property added to a detached subject through `subject.AddProperties(...)` is picked up and
+  initialized on re-registration.
+- `AddProperty` still throws on a genuine duplicate.
+- A concurrent `AddProperty` and `subject.AddProperties(...)` on the same subject leave the
+  registry's and the subject's property sets in agreement.
+- `AddProperty` called from a property getter completes rather than deadlocking.
+- The existing ancestor-resolution tests continue to pass unchanged, pinning that initializer
+  invocation ordering did not move.
+
+## Out of scope
+
+- **PR #419.** Open and unmerged, and it reworks this area heavily. This design targets
+  `master`. #419 confirms that simultaneous membership in two graphs throws while a sequential
+  move between contexts stays supported, which is what makes the shared-registration decision
+  in section 1 a real trade rather than a theoretical one. It also moves the reference count off
+  `subject.Data` onto `InterceptorExecutor`; if these land in that order, the retained
+  registration should follow it there.
+- **Property removal (#210).** No removal API exists. Retention makes one unnecessary here,
+  but a future removal API must clear the retained registration's entry.
+- **PR #429.** One part survives: the fix for `AddProperty` corrupting a declared property's
+  metadata when a rejected add had already called `Subject.AddProperties`. Its locking is
+  replaced rather than kept, since `_addPropertyLock` guards only one of the two views. Its
+  idempotency documentation, its `ISubjectPropertyInitializer` remarks, and the consumer guards
+  it added all come out.
+
+## Permanent home
+
+This spec is temporary. On implementation, fold the layer split and the concurrency rules into
+`docs/design/tracking-lifecycle.md` and update `docs/registry.md`, whose two initializer
+samples currently teach the guard pattern this removes.

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Lifecycle/MethodPropertyInitializerTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Lifecycle/MethodPropertyInitializerTests.cs
@@ -546,6 +546,36 @@ public class MethodPropertyInitializerTests
         Assert.NotNull(registered);
         Assert.NotNull(registered.TryGetProperty("Stop"));
     }
+
+    [Fact]
+    public void WhenAMethodNameClashesWithADeclaredProperty_ThenItIsReportedRatherThanSkipped()
+    {
+        // Arrange & Act: the subject declares a property named Stop and also has [Operation]
+        // StopAsync(), so the method property cannot be created.
+        var context = CreateContext();
+
+        // Assert: the re-attach guard only treats an existing method property as already done, so a
+        // genuine clash still reaches AddProperty instead of being silently dropped.
+        var exception = Assert.Throws<InvalidOperationException>(() => new ClashingMethodSubject(context));
+        Assert.Contains("Stop", exception.Message);
+    }
+}
+
+[InterceptorSubject]
+public partial class ClashingMethodSubject
+{
+    public partial string Stop { get; set; }
+
+    public ClashingMethodSubject()
+    {
+        Stop = string.Empty;
+    }
+
+    [Operation]
+    public Task StopAsync()
+    {
+        return Task.CompletedTask;
+    }
 }
 
 [InterceptorSubject]

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Lifecycle/MethodPropertyInitializerTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Lifecycle/MethodPropertyInitializerTests.cs
@@ -525,6 +525,33 @@ public class MethodPropertyInitializerTests
         // Assert
         Assert.Empty(methods);
     }
+
+    [Fact]
+    public void WhenSubjectMovesBetweenParents_ThenMethodPropertiesAreNotAddedTwice()
+    {
+        // Arrange
+        var context = CreateContext();
+        var first = new MethodTestSubjectHolder(context);
+        var second = new MethodTestSubjectHolder(context);
+        var subject = new MethodTestSubject();
+
+        // Act: the move detaches the subject, so it is registered again under the new parent and
+        // every lifecycle handler runs a second time over method properties that are already there.
+        first.Child = subject;
+        first.Child = null;
+        second.Child = subject;
+
+        // Assert
+        var registered = ((IInterceptorSubject)subject).TryGetRegisteredSubject();
+        Assert.NotNull(registered);
+        Assert.NotNull(registered.TryGetProperty("Stop"));
+    }
+}
+
+[InterceptorSubject]
+public partial class MethodTestSubjectHolder
+{
+    public partial MethodTestSubject? Child { get; set; }
 }
 
 public interface IMethodTestInterface

--- a/src/HomeBlaze/HomeBlaze.Services/Lifecycle/MethodPropertyInitializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/Lifecycle/MethodPropertyInitializer.cs
@@ -81,10 +81,8 @@ public class MethodPropertyInitializer : ILifecycleHandler
             ? method.Name[..^5]
             : method.Name;
 
-        // discoveredMethods only dedupes within one pass, for a method declared on both the class
-        // and an interface. This handler runs again every time the subject is re-attached, which
-        // includes moving it between parents, and the method property added last time is still on
-        // the subject, so adding it again would throw.
+        // discoveredMethods only dedupes within one pass (a method declared on both the class and an
+        // interface); re-attach runs this handler again over properties still on the subject.
         if (registeredSubject.TryGetProperty(propertyName) is not null)
         {
             return;

--- a/src/HomeBlaze/HomeBlaze.Services/Lifecycle/MethodPropertyInitializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/Lifecycle/MethodPropertyInitializer.cs
@@ -82,8 +82,11 @@ public class MethodPropertyInitializer : ILifecycleHandler
             : method.Name;
 
         // discoveredMethods only dedupes within one pass (a method declared on both the class and an
-        // interface); re-attach runs this handler again over properties still on the subject.
-        if (registeredSubject.TryGetProperty(propertyName) is not null)
+        // interface); re-attach runs this handler again over properties still on the subject. Only a
+        // method property counts as already done, so a real name clash with a declared property
+        // still reaches AddProperty and throws instead of being dropped.
+        if (registeredSubject.TryGetProperty(propertyName) is { Type: var existingType }
+            && existingType == typeof(MethodMetadata))
         {
             return;
         }

--- a/src/HomeBlaze/HomeBlaze.Services/Lifecycle/MethodPropertyInitializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/Lifecycle/MethodPropertyInitializer.cs
@@ -81,6 +81,15 @@ public class MethodPropertyInitializer : ILifecycleHandler
             ? method.Name[..^5]
             : method.Name;
 
+        // discoveredMethods only dedupes within one pass, for a method declared on both the class
+        // and an interface. This handler runs again every time the subject is re-attached, which
+        // includes moving it between parents, and the method property added last time is still on
+        // the subject, so adding it again would throw.
+        if (registeredSubject.TryGetProperty(propertyName) is not null)
+        {
+            return;
+        }
+
         var parameters = method.GetParameters()
             .Select(parameter =>
             {

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectPropertyInitializerIdempotencyTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectPropertyInitializerIdempotencyTests.cs
@@ -110,6 +110,28 @@ public class SubjectPropertyInitializerIdempotencyTests
         Assert.Contains(nameof(ISubjectPropertyInitializer), exception.Message);
     }
 
+    [Fact]
+    public void WhenAddingAPropertyThatAlreadyExists_ThenTheSubjectMetadataIsLeftUnchanged()
+    {
+        // Arrange
+        var (context, _) = CreateContext();
+        var subject = new MeasurementNode(context) { Name = "subject" };
+        var interceptorSubject = (IInterceptorSubject)subject;
+        var registered = interceptorSubject.TryGetRegisteredSubject()!;
+        var declaredBefore = interceptorSubject.Properties[nameof(MeasurementNode.Value)];
+
+        // Act & Assert: the name collides with a declared property, so the add is rejected.
+        Assert.Throws<InvalidOperationException>(() =>
+            registered.AddProperty(nameof(MeasurementNode.Value), typeof(string), _ => "hijacked", null));
+
+        // Assert: the rejection has to happen before the subject is written to. Adding properties is
+        // last-wins, so a check placed after it would leave the declared property carrying the
+        // caller's dynamic getter.
+        var declaredAfter = interceptorSubject.Properties[nameof(MeasurementNode.Value)];
+        Assert.False(declaredAfter.IsDynamic);
+        Assert.Equal(declaredBefore.Type, declaredAfter.Type);
+    }
+
     private sealed class IdempotentInitializer : ISubjectPropertyInitializer
     {
         public int InvocationCount { get; private set; }

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectPropertyInitializerIdempotencyTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectPropertyInitializerIdempotencyTests.cs
@@ -5,13 +5,8 @@ using Namotion.Interceptor.Tracking;
 namespace Namotion.Interceptor.Registry.Tests;
 
 /// <summary>
-/// A subject that leaves the graph is dropped from the registry, but the dynamic properties an
-/// <see cref="ISubjectPropertyInitializer"/> added stay on the subject itself. Re-attaching therefore
-/// builds a fresh registration over properties that are already there and runs every initializer
-/// again, so an initializer that adds unconditionally fails the second time.
-///
-/// Re-attaching is not an exotic operation: moving a subject from one parent to another detaches it
-/// and attaches it again, so this is reachable from an ordinary graph edit.
+/// Re-attaching a subject builds a fresh registration over properties that are still on the subject,
+/// so every initializer runs again. See <see cref="ISubjectPropertyInitializer"/>.
 /// </summary>
 public class SubjectPropertyInitializerIdempotencyTests
 {

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectPropertyInitializerIdempotencyTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectPropertyInitializerIdempotencyTests.cs
@@ -1,0 +1,167 @@
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Registry.Abstractions;
+using Namotion.Interceptor.Tracking;
+
+namespace Namotion.Interceptor.Registry.Tests;
+
+/// <summary>
+/// A subject that leaves the graph is dropped from the registry, but the dynamic properties an
+/// <see cref="ISubjectPropertyInitializer"/> added stay on the subject itself. Re-attaching therefore
+/// builds a fresh registration over properties that are already there and runs every initializer
+/// again, so an initializer that adds unconditionally fails the second time.
+///
+/// Re-attaching is not an exotic operation: moving a subject from one parent to another detaches it
+/// and attaches it again, so this is reachable from an ordinary graph edit.
+/// </summary>
+public class SubjectPropertyInitializerIdempotencyTests
+{
+    private const string UnitAttribute = "Unit";
+
+    private static (IInterceptorSubjectContext Context, IdempotentInitializer Initializer) CreateContext()
+    {
+        IInterceptorSubjectContext context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithRegistry()
+            .WithParents();
+
+        var initializer = new IdempotentInitializer();
+        context.AddService<ISubjectPropertyInitializer>(initializer);
+        return (context, initializer);
+    }
+
+    [Fact]
+    public void WhenSubjectMovesBetweenParents_ThenAnIdempotentInitializerSucceeds()
+    {
+        // Arrange
+        var (context, initializer) = CreateContext();
+        var first = new MeasurementNode(context) { Name = "first" };
+        var second = new MeasurementNode(context) { Name = "second" };
+        var child = new MeasurementNode { Name = "child" };
+
+        // Act: the move drops the reference count to zero, so the child leaves the registry and is
+        // registered again under the new parent.
+        first.Child = child;
+        first.Child = null;
+        second.Child = child;
+
+        // Assert
+        Assert.True(initializer.InvocationCount > 1, "Expected the initializer to run again on re-attach.");
+        Assert.NotNull(((IInterceptorSubject)child).TryGetRegisteredSubject()?
+            .TryGetProperty(nameof(MeasurementNode.Value))?
+            .TryGetAttribute(UnitAttribute));
+    }
+
+    [Fact]
+    public void WhenSubjectIsDetachedAndReattached_ThenAnIdempotentInitializerSucceeds()
+    {
+        // Arrange
+        var (context, _) = CreateContext();
+        var root = new MeasurementNode(context) { Name = "root" };
+        var child = new MeasurementNode { Name = "child" };
+
+        // Act
+        root.Child = child;
+        root.Child = null;
+        root.Child = child;
+
+        // Assert
+        Assert.NotNull(((IInterceptorSubject)child).TryGetRegisteredSubject()?
+            .TryGetProperty(nameof(MeasurementNode.Value))?
+            .TryGetAttribute(UnitAttribute));
+    }
+
+    [Fact]
+    public void WhenSubjectKeepsAReferenceThroughoutAMove_ThenTheInitializerDoesNotRunAgain()
+    {
+        // Arrange
+        var (context, initializer) = CreateContext();
+        var first = new MeasurementNode(context) { Name = "first" };
+        var second = new MeasurementNode(context) { Name = "second" };
+        var child = new MeasurementNode { Name = "child" };
+
+        first.Child = child;
+        var afterFirstAttach = initializer.InvocationCount;
+
+        // Act: adding the second parent before removing the first keeps the reference count above
+        // zero, so the child never leaves the registry.
+        second.Child = child;
+        first.Child = null;
+
+        // Assert
+        Assert.Equal(afterFirstAttach, initializer.InvocationCount);
+    }
+
+    [Fact]
+    public void WhenAnInitializerAddsUnconditionally_ThenReattachFailsWithAnActionableError()
+    {
+        // Arrange
+        IInterceptorSubjectContext context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithRegistry()
+            .WithParents();
+        context.AddService<ISubjectPropertyInitializer>(new UnconditionalInitializer());
+
+        var root = new MeasurementNode(context) { Name = "root" };
+        var child = new MeasurementNode { Name = "child" };
+        root.Child = child;
+        root.Child = null;
+
+        // Act & Assert: the message has to name the property and point at the initializer contract,
+        // because the underlying collection would otherwise report only a duplicate key.
+        var exception = Assert.Throws<InvalidOperationException>(() => root.Child = child);
+
+        Assert.Contains($"{nameof(MeasurementNode.Value)}@{UnitAttribute}", exception.Message);
+        Assert.Contains(nameof(MeasurementNode), exception.Message);
+        Assert.Contains(nameof(ISubjectPropertyInitializer), exception.Message);
+    }
+
+    private sealed class IdempotentInitializer : ISubjectPropertyInitializer
+    {
+        public int InvocationCount { get; private set; }
+
+        public void InitializeProperty(RegisteredSubjectProperty property)
+        {
+            if (property.IsAttribute || property.Name != nameof(MeasurementNode.Value))
+            {
+                return;
+            }
+
+            InvocationCount++;
+
+            if (property.TryGetAttribute(UnitAttribute) is not null)
+            {
+                return;
+            }
+
+            property.AddAttribute(UnitAttribute, typeof(string), _ => "celsius", null);
+        }
+    }
+
+    private sealed class UnconditionalInitializer : ISubjectPropertyInitializer
+    {
+        public void InitializeProperty(RegisteredSubjectProperty property)
+        {
+            if (property.IsAttribute || property.Name != nameof(MeasurementNode.Value))
+            {
+                return;
+            }
+
+            property.AddAttribute(UnitAttribute, typeof(string), _ => "celsius", null);
+        }
+    }
+}
+
+[InterceptorSubject]
+public partial class MeasurementNode
+{
+    public partial string Name { get; set; }
+
+    public partial double Value { get; set; }
+
+    public partial MeasurementNode? Child { get; set; }
+
+    public MeasurementNode()
+    {
+        Name = string.Empty;
+    }
+}

--- a/src/Namotion.Interceptor.Registry/Abstractions/ISubjectPropertyInitializer.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/ISubjectPropertyInitializer.cs
@@ -2,21 +2,18 @@ namespace Namotion.Interceptor.Registry.Abstractions;
 
 /// <summary>
 /// Contributes attributes or derived properties to a subject's properties as the subject is
-/// registered. Implementations are invoked by <c>SubjectRegistry</c> for every property of a subject,
-/// including properties added dynamically by other initializers, and are picked up either from the
-/// context (<c>context.AddService&lt;ISubjectPropertyInitializer&gt;(...)</c>) or from a .NET attribute
-/// on the property that implements this interface.
+/// registered. Initializers are picked up from the context
+/// (<c>context.AddService&lt;ISubjectPropertyInitializer&gt;(...)</c>) or from a .NET attribute on the
+/// property that implements this interface, and run for every property of the subject, including
+/// properties other initializers added dynamically.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Implementations must be idempotent.</b> <see cref="InitializeProperty"/> runs again for the
-/// same property every time the subject is re-attached to a graph, which includes moving a subject
-/// from one parent to another: the move detaches it, dropping it from the registry, and re-attaching
-/// builds a fresh registration. What does not reset is the subject itself, so any property or
-/// attribute added the first time is still there when the initializer runs again.
-/// </para>
-/// <para>
-/// Adding unconditionally therefore throws on the second run. Check first:
+/// Implementations must be idempotent. A subject that leaves the graph is dropped from the registry
+/// but keeps the properties an initializer added, so the next attach runs every initializer again
+/// over properties that are already there and an initializer that adds unconditionally throws.
+/// Moving a subject between parents is enough to trigger this whenever the old reference is removed
+/// before the new one is added.
 /// </para>
 /// <code>
 /// public void InitializeProperty(RegisteredSubjectProperty property)
@@ -26,20 +23,15 @@ namespace Namotion.Interceptor.Registry.Abstractions;
 ///         return;
 ///     }
 ///
-///     property.AddAttribute("Unit", typeof(string), _ => "°C", null);
+///     property.AddAttribute("Unit", typeof(string), _ => "C", null);
 /// }
 /// </code>
-/// <para>
-/// The same applies to work other than adding properties. An initializer that mutates external state
-/// should expect to see each property more than once over the subject's lifetime.
-/// </para>
 /// </remarks>
 public interface ISubjectPropertyInitializer
 {
     /// <summary>
     /// Initializes a single registered property. Called once per property per registration, so more
-    /// than once for a subject that is re-attached. Must tolerate being called again for a property
-    /// it has already initialized.
+    /// than once for a subject that is re-attached.
     /// </summary>
     /// <param name="property">The property being registered.</param>
     void InitializeProperty(RegisteredSubjectProperty property);

--- a/src/Namotion.Interceptor.Registry/Abstractions/ISubjectPropertyInitializer.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/ISubjectPropertyInitializer.cs
@@ -1,6 +1,46 @@
-﻿namespace Namotion.Interceptor.Registry.Abstractions;
+namespace Namotion.Interceptor.Registry.Abstractions;
 
+/// <summary>
+/// Contributes attributes or derived properties to a subject's properties as the subject is
+/// registered. Implementations are invoked by <c>SubjectRegistry</c> for every property of a subject,
+/// including properties added dynamically by other initializers, and are picked up either from the
+/// context (<c>context.AddService&lt;ISubjectPropertyInitializer&gt;(...)</c>) or from a .NET attribute
+/// on the property that implements this interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Implementations must be idempotent.</b> <see cref="InitializeProperty"/> runs again for the
+/// same property every time the subject is re-attached to a graph, which includes moving a subject
+/// from one parent to another: the move detaches it, dropping it from the registry, and re-attaching
+/// builds a fresh registration. What does not reset is the subject itself, so any property or
+/// attribute added the first time is still there when the initializer runs again.
+/// </para>
+/// <para>
+/// Adding unconditionally therefore throws on the second run. Check first:
+/// </para>
+/// <code>
+/// public void InitializeProperty(RegisteredSubjectProperty property)
+/// {
+///     if (property.IsAttribute || property.TryGetAttribute("Unit") is not null)
+///     {
+///         return;
+///     }
+///
+///     property.AddAttribute("Unit", typeof(string), _ => "°C", null);
+/// }
+/// </code>
+/// <para>
+/// The same applies to work other than adding properties. An initializer that mutates external state
+/// should expect to see each property more than once over the subject's lifetime.
+/// </para>
+/// </remarks>
 public interface ISubjectPropertyInitializer
 {
+    /// <summary>
+    /// Initializes a single registered property. Called once per property per registration, so more
+    /// than once for a subject that is re-attached. Must tolerate being called again for a property
+    /// it has already initialized.
+    /// </summary>
+    /// <param name="property">The property being registered.</param>
     void InitializeProperty(RegisteredSubjectProperty property);
 }

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -13,6 +13,12 @@ public class RegisteredSubject
 {
     private readonly Lock _lock = new();
 
+    // Serializes AddProperty only, and deliberately not _lock. AddProperty holds this across the
+    // subject's own add, which takes the subject's SyncRoot, while a dynamic property's getter runs
+    // under SyncRoot and can reach _lock through Parents. Sharing _lock would put those two in a
+    // cycle. This one is a leaf: nothing acquired under it takes a lock that leads back here.
+    private readonly Lock _addPropertyLock = new();
+
     private volatile FrozenDictionary<string, RegisteredSubjectProperty> _properties;
 
     // Most subjects have exactly one parent, so the first is stored inline and the
@@ -340,7 +346,7 @@ public class RegisteredSubject
 
         var subjectProperty = new RegisteredSubjectProperty(this, name, type, attributes);
 
-        lock (_lock)
+        lock (_addPropertyLock)
         {
             if (_properties.ContainsKey(subjectProperty.Name))
             {

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -329,21 +329,16 @@ public class RegisteredSubject
         Action<IInterceptorSubject, object?>? setValue,
         params Attribute[] attributes)
     {
-        // Before the subject is touched: AddProperties is last-wins, so throwing after it would
-        // leave a declared property carrying the caller's dynamic getter. AddPropertyInternal
-        // repeats the check under the lock, where it also covers a concurrent add.
-        ThrowIfPropertyExists(name);
-
-        Subject.AddProperties(new SubjectPropertyMetadata(
+        var metadata = new SubjectPropertyMetadata(
             name,
             type,
             attributes,
             getValue is not null ? s => ((IInterceptorExecutor)s.Context).GetPropertyValue(name, getValue) : null,
             setValue is not null ? (s, v) => ((IInterceptorExecutor)s.Context).SetPropertyValue(name, v, getValue?.Invoke(s), setValue) : null,
             isIntercepted: true,
-            isDynamic: true));
+            isDynamic: true);
 
-        var property = AddPropertyInternal(name, type, attributes);
+        var property = AddPropertyInternal(name, type, metadata, attributes);
 
         // Fires a null→value transition for lifecycle tracking of subject-valued initial values.
         // TODO(perf): For derived-with-setter this re-enters RecalculateDerivedProperty (total
@@ -367,13 +362,20 @@ public class RegisteredSubject
         }
     }
 
-    private RegisteredSubjectProperty AddPropertyInternal(string name, Type type, Attribute[] attributes)
+    private RegisteredSubjectProperty AddPropertyInternal(
+        string name, Type type, SubjectPropertyMetadata metadata, Attribute[] attributes)
     {
         var subjectProperty = new RegisteredSubjectProperty(this, name, type, attributes);
 
         lock (_lock)
         {
+            // The rejection and both writes are one step. The rebuild below would reject a duplicate
+            // on its own, but only after the subject had been written to, and the subject's own add
+            // is last-wins, so a rejected call would still have replaced what was there. Checking
+            // outside the lock instead would leave the same hole open to a second thread.
             ThrowIfPropertyExists(subjectProperty.Name);
+
+            Subject.AddProperties(metadata);
 
             var newProperties = _properties
                 .Append(KeyValuePair.Create(subjectProperty.Name, subjectProperty))

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -13,10 +13,8 @@ public class RegisteredSubject
 {
     private readonly Lock _lock = new();
 
-    // Serializes AddProperty only, and deliberately not _lock. AddProperty holds this across the
-    // subject's own add, which takes the subject's SyncRoot, while a dynamic property's getter runs
-    // under SyncRoot and can reach _lock through Parents. Sharing _lock would put those two in a
-    // cycle. This one is a leaf: nothing acquired under it takes a lock that leads back here.
+    // Not _lock, which a dynamic getter can reach through Parents while under SyncRoot; this is
+    // held across SyncRoot, so sharing one lock, or adding a property from a getter, deadlocks.
     private readonly Lock _addPropertyLock = new();
 
     private volatile FrozenDictionary<string, RegisteredSubjectProperty> _properties;

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -357,12 +357,6 @@ public class RegisteredSubject
 
         lock (_lock)
         {
-            // Checked explicitly because ToFrozenDictionary below would otherwise report the
-            // collision as "An item with the same key has already been added", naming neither this
-            // API nor the subject. The overwhelmingly common cause is a property initializer that
-            // adds unconditionally: initializers run again whenever a subject re-attaches, including
-            // a plain move between parents, while the property they added the first time is still
-            // on the subject. See ISubjectPropertyInitializer.
             if (_properties.ContainsKey(subjectProperty.Name))
             {
                 throw new InvalidOperationException(

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -338,22 +338,6 @@ public class RegisteredSubject
             isIntercepted: true,
             isDynamic: true);
 
-        var property = AddPropertyInternal(name, type, metadata, attributes);
-
-        // Fires a null→value transition for lifecycle tracking of subject-valued initial values.
-        // TODO(perf): For derived-with-setter this re-enters RecalculateDerivedProperty (total
-        // 3 getter invocations: AttachProperty + invoke below + recalc), but AttachProperty has
-        // already seeded LastKnownValue. Consider a dedicated lifecycle notification for derived,
-        // or passing currentValue so PropertyValueEqualityCheckHandler short-circuits the write.
-        property.Reference.SetPropertyValueWithInterception(getValue?.Invoke(Subject) ?? null,
-            null, delegate { });
-
-        return property;
-    }
-
-    private RegisteredSubjectProperty AddPropertyInternal(
-        string name, Type type, SubjectPropertyMetadata metadata, Attribute[] attributes)
-    {
         var subjectProperty = new RegisteredSubjectProperty(this, name, type, attributes);
 
         lock (_lock)
@@ -381,6 +365,15 @@ public class RegisteredSubject
         }
 
         Subject.AttachSubjectProperty(subjectProperty.Reference);
+
+        // Fires a null→value transition for lifecycle tracking of subject-valued initial values.
+        // TODO(perf): For derived-with-setter this re-enters RecalculateDerivedProperty (total
+        // 3 getter invocations: AttachProperty + invoke below + recalc), but AttachProperty has
+        // already seeded LastKnownValue. Consider a dedicated lifecycle notification for derived,
+        // or passing currentValue so PropertyValueEqualityCheckHandler short-circuits the write.
+        subjectProperty.Reference.SetPropertyValueWithInterception(getValue?.Invoke(Subject) ?? null,
+            null, delegate { });
+
         return subjectProperty;
     }
 }

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -351,17 +351,6 @@ public class RegisteredSubject
         return property;
     }
 
-    private void ThrowIfPropertyExists(string name)
-    {
-        if (_properties.ContainsKey(name))
-        {
-            throw new InvalidOperationException(
-                $"Property '{name}' already exists on '{Subject.GetType().Name}'. " +
-                "If this is an ISubjectPropertyInitializer, check for the property before adding it: " +
-                "initializers run again whenever a subject is re-attached.");
-        }
-    }
-
     private RegisteredSubjectProperty AddPropertyInternal(
         string name, Type type, SubjectPropertyMetadata metadata, Attribute[] attributes)
     {
@@ -369,11 +358,13 @@ public class RegisteredSubject
 
         lock (_lock)
         {
-            // The rejection and both writes are one step. The rebuild below would reject a duplicate
-            // on its own, but only after the subject had been written to, and the subject's own add
-            // is last-wins, so a rejected call would still have replaced what was there. Checking
-            // outside the lock instead would leave the same hole open to a second thread.
-            ThrowIfPropertyExists(subjectProperty.Name);
+            if (_properties.ContainsKey(subjectProperty.Name))
+            {
+                throw new InvalidOperationException(
+                    $"Property '{subjectProperty.Name}' already exists on '{Subject.GetType().Name}'. " +
+                    "If this is an ISubjectPropertyInitializer, check for the property before adding it: " +
+                    "initializers run again whenever a subject is re-attached.");
+            }
 
             Subject.AddProperties(metadata);
 

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -360,9 +360,9 @@ public class RegisteredSubject
             if (_properties.ContainsKey(subjectProperty.Name))
             {
                 throw new InvalidOperationException(
-                    $"Property '{subjectProperty.Name}' already exists on '{Subject.GetType().Name}' and cannot be added again. " +
-                    "If this is an ISubjectPropertyInitializer, check whether the property or attribute is already " +
-                    "present before adding it, because initializers run again every time a subject is re-attached.");
+                    $"Property '{subjectProperty.Name}' already exists on '{Subject.GetType().Name}'. " +
+                    "If this is an ISubjectPropertyInitializer, check for the property before adding it: " +
+                    "initializers run again whenever a subject is re-attached.");
             }
 
             var newProperties = _properties

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -357,6 +357,20 @@ public class RegisteredSubject
 
         lock (_lock)
         {
+            // Checked explicitly because ToFrozenDictionary below would otherwise report the
+            // collision as "An item with the same key has already been added", naming neither this
+            // API nor the subject. The overwhelmingly common cause is a property initializer that
+            // adds unconditionally: initializers run again whenever a subject re-attaches, including
+            // a plain move between parents, while the property they added the first time is still
+            // on the subject. See ISubjectPropertyInitializer.
+            if (_properties.ContainsKey(subjectProperty.Name))
+            {
+                throw new InvalidOperationException(
+                    $"Property '{subjectProperty.Name}' already exists on '{Subject.GetType().Name}' and cannot be added again. " +
+                    "If this is an ISubjectPropertyInitializer, check whether the property or attribute is already " +
+                    "present before adding it, because initializers run again every time a subject is re-attached.");
+            }
+
             var newProperties = _properties
                 .Append(KeyValuePair.Create(subjectProperty.Name, subjectProperty))
                 .ToFrozenDictionary(p => p.Key, p => p.Value);

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubject.cs
@@ -329,6 +329,11 @@ public class RegisteredSubject
         Action<IInterceptorSubject, object?>? setValue,
         params Attribute[] attributes)
     {
+        // Before the subject is touched: AddProperties is last-wins, so throwing after it would
+        // leave a declared property carrying the caller's dynamic getter. AddPropertyInternal
+        // repeats the check under the lock, where it also covers a concurrent add.
+        ThrowIfPropertyExists(name);
+
         Subject.AddProperties(new SubjectPropertyMetadata(
             name,
             type,
@@ -351,19 +356,24 @@ public class RegisteredSubject
         return property;
     }
 
+    private void ThrowIfPropertyExists(string name)
+    {
+        if (_properties.ContainsKey(name))
+        {
+            throw new InvalidOperationException(
+                $"Property '{name}' already exists on '{Subject.GetType().Name}'. " +
+                "If this is an ISubjectPropertyInitializer, check for the property before adding it: " +
+                "initializers run again whenever a subject is re-attached.");
+        }
+    }
+
     private RegisteredSubjectProperty AddPropertyInternal(string name, Type type, Attribute[] attributes)
     {
         var subjectProperty = new RegisteredSubjectProperty(this, name, type, attributes);
 
         lock (_lock)
         {
-            if (_properties.ContainsKey(subjectProperty.Name))
-            {
-                throw new InvalidOperationException(
-                    $"Property '{subjectProperty.Name}' already exists on '{Subject.GetType().Name}'. " +
-                    "If this is an ISubjectPropertyInitializer, check for the property before adding it: " +
-                    "initializers run again whenever a subject is re-attached.");
-            }
+            ThrowIfPropertyExists(subjectProperty.Name);
 
             var newProperties = _properties
                 .Append(KeyValuePair.Create(subjectProperty.Name, subjectProperty))

--- a/src/Namotion.Interceptor.SampleWeb/Program.cs
+++ b/src/Namotion.Interceptor.SampleWeb/Program.cs
@@ -81,6 +81,13 @@ namespace Namotion.Interceptor.SampleWeb
 
         public void InitializeProperty(RegisteredSubjectProperty property)
         {
+            // Initializers run again whenever the subject is re-attached, including a move between
+            // parents, and the attribute added last time is still on the subject.
+            if (property.TryGetAttribute("Unit") is not null)
+            {
+                return;
+            }
+
             property.AddAttribute("Unit", typeof(string),
                 _ => _unit, null,
                 new PathAttribute("mqtt", "unit"));

--- a/src/Namotion.Interceptor.SampleWeb/Program.cs
+++ b/src/Namotion.Interceptor.SampleWeb/Program.cs
@@ -81,8 +81,8 @@ namespace Namotion.Interceptor.SampleWeb
 
         public void InitializeProperty(RegisteredSubjectProperty property)
         {
-            // Initializers run again whenever the subject is re-attached, including a move between
-            // parents, and the attribute added last time is still on the subject.
+            // Initializers run again whenever the subject is re-attached, over attributes that are
+            // still on the subject.
             if (property.TryGetAttribute("Unit") is not null)
             {
                 return;


### PR DESCRIPTION
Draft. The design is agreed and committed as a spec; the implementation has not started. The branch still contains the earlier patch-style fix, which this design supersedes and which will come out.

Design document: `docs/superpowers/specs/2026-08-07-registration-scoped-initializers-design.md`

Closes #430.

## Problem

Three extension points add properties to a subject while it attaches:

| Extension point | Interface | Example |
|---|---|---|
| property initializer | `ISubjectPropertyInitializer` | adds a `Unit` attribute |
| property lifecycle handler | `IPropertyLifecycleHandler` | adds `State` and `Configuration` |
| subject lifecycle handler | `ILifecycleHandler` | adds a property per `[Operation]` method |

All three re-run whenever a subject re-attaches, which an ordinary move between parents triggers as soon as the old reference is removed before the new one is added. Their effect does not re-run with them: the properties they added live on `subject.Properties` and survive detach. The second run re-adds what is already there and `AddProperty` throws.

The workaround the docs currently teach, guarding each implementation with a check before adding, makes it worse rather than better. Measured:

```
initializer invocations:                    2
capture#1 Parent == live registration:      False
capture#1 parent still in KnownSubjects:    False
capture#1 sees marker:                      True
```

An initializer may capture the `RegisteredSubjectProperty` it was handed, and attribute lookups resolve through the `RegisteredSubject` captured with it. The registry builds a new one on every re-attach, so a guarded initializer keeps its first-run attribute alive with a getter that silently answers from a discarded registration instead of throwing.

The root cause is that initialization is driven by attach, which is episodic, while its effect is structural and persists on the subject.

## Design

Initializers run once per subject, driven by registration and property creation rather than by attach.

Two flags:

| Flag | Lives on | Set | Read |
|---|---|---|---|
| subject | `subject.Data` | read-and-set once at first registration | decides whether this registration initializes |
| registration | `RegisteredSubject` | from that read | consulted per property in `AttachProperty` |

Both are needed. The subject flag alone flips to "done" while the first pass is still running and would skip every property after the first.

Three events drive initialization:

| Event | Initializes |
|---|---|
| a subject is registered for the first time | all of its properties |
| `AddProperty` creates a property | that property only |
| a subject re-attaches | nothing |

`RegisteredSubject` ownership does not change. It stays owned by its registry and is rebuilt per attach exactly as today.

### New API

```csharp
public interface ISubjectInitializer
{
    void InitializeSubject(RegisteredSubject subject);
}
```

Called once per subject. This is the missing grain size: `ISubjectPropertyInitializer` is per property, and the only per-subject hook is `ILifecycleHandler`, which is episodic by design. Work that is genuinely per-subject-once had nowhere correct to live.

The only new public type. No existing signature changes, so no consumer implementation must be updated.

### Concurrency

`AddProperty` locks on `subject.SyncRoot`, and the separate add lock is removed. `SyncRoot` already guards the subject's own copy of the property set in both the generated and dynamic implementations, so a separate lock leaves that copy free to be mutated concurrently. The check and the add must be atomic across both views.

The lock graph collapses to `SyncRoot -> RegisteredSubject._lock`, acyclic, with `Monitor` re-entrancy resolving the cycle a getter could otherwise create.

`AddProperty` also rejects being called from a getter or setter of the same subject, via `Monitor.IsEntered` before the lock is taken. That check is thread-local rather than a race, and take-or-throw cannot substitute for it because `Monitor` is re-entrant and would succeed in exactly the case being rejected.

## Consumer impact

No public API breaks. `ISubjectPropertyInitializer` keeps its signature. Existing guards in consumer initializers become redundant and stay harmless.

Two HomeBlaze classes change interface, one line each plus their registrations, and both get shorter:

| Class | From | To |
|---|---|---|
| `MethodPropertyInitializer` | `ILifecycleHandler` | `ISubjectInitializer` |
| `PropertyAttributeInitializer` | `IPropertyLifecycleHandler` | `ISubjectPropertyInitializer` |

## Measurements

| Question | Result |
|---|---|
| `Monitor.IsEntered` cost | 1.56 ns, about 0.03% of one `ToFrozenDictionary` already on the same path |
| Should `Parent` resolve the live registration? | No. 19.5x on attribute lookup (2.47 ns to 48.02 ns), 27 call sites, and `Children` stays stale anyway |
| Is a two-registry configuration usable today? | No. Throws when initializers exist, double-counts parent and child edges when they do not |
| Does detach leave graph state behind? | No. Parents, children and reference count are all empty before the registry drops a subject |

## Rejected alternatives

**Retaining `RegisteredSubject` per subject.** Would make initialization once-per-registration by construction and would fix stale captures as a side effect. Rejected because `RegisteredSubject` holds both the property set, which belongs to the subject, and parent and child edges, which belong to the graph. Sharing the object shares both, and two co-resolved registries would then apply every edge twice by construction. Sound only under a guarantee that a subject belongs to at most one graph, which #419 introduces and `master` does not yet make.

**Richer lifecycle context.** Passing a first-attach flag so handlers can defend themselves. Rejected: it preserves the shape of the problem after the problem has been deleted, and puts the burden back on every implementer to check correctly.

## Follow-ups, to be filed separately

- `AddParent` and `AddChild` are not idempotent. Aggregating a second lifecycle-bearing context makes a registry record the same parent edge twice, and detach clears only one of the pair. A pre-existing bug on `master`, the same root cause as the initializer double-add, independent of this change.
- Stale captures. This design stops initializers re-running but still rebuilds `RegisteredSubject` per attach. The correct fix is on the capturing side, capturing `property.Reference` rather than the property, which is free and fully correct. Needs documenting on `ISubjectPropertyInitializer`.
- Benchmark coverage. No benchmark registers an initializer and none re-attaches the same subjects, so every path this design changes is currently unmeasured.

## Relationship to #419

Independent, and this targets `master`. #419 strengthens the design by guaranteeing that a subject belongs to at most one graph, which is what would make retaining the registration safe. Nothing here depends on it. When it lands, the subject flag should move from `subject.Data` onto `InterceptorExecutor`, where that PR already moves other per-subject state.
