### PR TITLE
Make ToRollbackChange a public member of SubjectPropertyChange

### DIFF
--- a/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
@@ -809,6 +809,140 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
+    public void WhenConvertedToRollbackChange_ThenOldAndNewValuesAreSwapped()
+    {
+        // Arrange
+        var change = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            10, 20);
+
+        // Act
+        var rollback = change.ToRollbackChange();
+
+        // Assert
+        Assert.Equal(20, rollback.GetOldValue<int>());
+        Assert.Equal(10, rollback.GetNewValue<int>());
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChange_ThenPropertyOriginAndTimestampsArePreserved()
+    {
+        // Arrange
+        var source = new object();
+        var change = SubjectPropertyChange.Create(
+            _property, ChangeOrigin.FromSource(source), _changedTimestamp, _receivedTimestamp,
+            "old", "new");
+
+        // Act
+        var rollback = change.ToRollbackChange();
+
+        // Assert
+        Assert.Equal(_property, rollback.Property);
+        Assert.Equal(ChangeOriginKind.FromSource, rollback.Origin.Kind);
+        Assert.Same(source, rollback.Origin.Source);
+        Assert.Equal(_changedTimestamp, rollback.ChangedTimestamp);
+        Assert.Equal(_receivedTimestamp, rollback.ReceivedTimestamp);
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChange_ThenRevisionIsReset()
+    {
+        // Arrange: a rollback describes a write to perform, not a commit that happened. Carrying the
+        // committed revision forward would give two changes on one property the same revision, the tie
+        // flush merging relies on being impossible.
+        var change = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            "old", "new", 7L);
+
+        // Act
+        var rollback = change.ToRollbackChange();
+
+        // Assert
+        Assert.Equal(0L, rollback.Revision);
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChangeOnEveryStoragePath_ThenTypedValuesRoundTrip()
+    {
+        // Arrange: the swap moves the storage fields directly, so each of the three storage paths has
+        // to survive it with its stored type intact rather than degrading to a boxed object.
+        var oldReference = new CustomClass { Id = 1 };
+        var newReference = new CustomClass { Id = 2 };
+
+        var inlineChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
+        var stringChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, "old", "new");
+        var referenceChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            oldReference, newReference);
+        var oversizedChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            new OversizedCustomStruct { Value1 = 1L }, new OversizedCustomStruct { Value1 = 2L });
+
+        // Act
+        var inlineRollback = inlineChange.ToRollbackChange();
+        var stringRollback = stringChange.ToRollbackChange();
+        var referenceRollback = referenceChange.ToRollbackChange();
+        var oversizedRollback = oversizedChange.ToRollbackChange();
+
+        // Assert
+        Assert.Equal(2, inlineRollback.GetOldValue<int>());
+        Assert.Equal(1, inlineRollback.GetNewValue<int>());
+        Assert.Equal("new", stringRollback.GetOldValue<string>());
+        Assert.Equal("old", stringRollback.GetNewValue<string>());
+        Assert.Same(newReference, referenceRollback.GetOldValue<CustomClass>());
+        Assert.Same(oldReference, referenceRollback.GetNewValue<CustomClass>());
+        Assert.Equal(2L, oversizedRollback.GetOldValue<OversizedCustomStruct>().Value1);
+        Assert.Equal(1L, oversizedRollback.GetNewValue<OversizedCustomStruct>().Value1);
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChangeWithNullString_ThenNullMovesToTheNewValue()
+    {
+        // Arrange
+        var change = SubjectPropertyChange.Create<string?>(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            null, "new");
+
+        // Act
+        var rollback = change.ToRollbackChange();
+
+        // Assert
+        Assert.Equal("new", rollback.GetOldValue<string>());
+        Assert.Null(rollback.GetNewValue<string>());
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChange_ThenNothingIsAllocated()
+    {
+        // Arrange: the conversion moves the storage fields instead of round-tripping both values
+        // through object, so it must not allocate. Rebuilding it through Create<object?> would cost
+        // two boxed holders per reverted change, plus a box per inline value.
+        var change = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
+
+        // Warm up so JIT compilation does not land inside the measured window.
+        var accumulator = 0L;
+        for (var i = 0; i < 100; i++)
+        {
+            accumulator += change.ToRollbackChange().GetNewValue<int>();
+        }
+
+        // Act
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+        {
+            accumulator += change.ToRollbackChange().GetNewValue<int>();
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // Assert
+        Assert.Equal(0L, allocated);
+        Assert.Equal(1100L, accumulator);
+    }
+
+    [Fact]
     public void WhenMeasuringSubjectPropertyChange_ThenSizeStaysWithinTheAcceptedBudget()
     {
         // The struct is copied on every publish, so growth is a hot-path cost that has to be a decision

--- a/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -1,5 +1,4 @@
 ﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/RicoSuter/Namotion.Interceptor")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Namotion.Interceptor.Connectors")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Namotion.Interceptor.Connectors.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Namotion.Interceptor.Tracking.Tests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
@@ -76,6 +75,7 @@ namespace Namotion.Interceptor.Tracking.Change
         public TValue GetNewValue<TValue>() { }
         public TValue GetOldValue<TValue>() { }
         public Namotion.Interceptor.Tracking.Change.SubjectPropertyChange MergeWithNewer(Namotion.Interceptor.Tracking.Change.SubjectPropertyChange newerChange) { }
+        public Namotion.Interceptor.Tracking.Change.SubjectPropertyChange ToRollbackChange() { }
         public bool TryGetNewValue<TValue>(out TValue value) { }
         public bool TryGetOldValue<TValue>(out TValue value) { }
         public Namotion.Interceptor.Tracking.Change.SubjectPropertyChange WithOrigin(Namotion.Interceptor.ChangeOrigin origin) { }

--- a/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
@@ -236,6 +236,26 @@ public readonly struct SubjectPropertyChange : IEquatable<SubjectPropertyChange>
             Revision);
 
     /// <summary>
+    /// Copies this change with its old and new values swapped, without re-boxing them, so applying the
+    /// result undoes this change. Carries no revision on purpose: it describes a write to perform, not a
+    /// commit that happened. Applying it locally goes through the terminal and takes a fresh, higher
+    /// revision of its own, which is what consumers observe. Copying this change's revision instead would
+    /// give two changes on one property the same revision, the tie the flush merging relies on being
+    /// impossible.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SubjectPropertyChange ToRollbackChange() =>
+        new(Property,
+            Origin,
+            ChangedTimestamp,
+            ReceivedTimestamp,
+            _newValueStorage,
+            _oldValueStorage,
+            _newBoxedHolder,
+            _oldBoxedHolder,
+            revision: 0);
+
+    /// <summary>
     /// Equality based on PropertyReference only for efficient HashSet/Dictionary usage.
     /// </summary>
     public bool Equals(SubjectPropertyChange other) => Property.Equals(other.Property);

--- a/src/Namotion.Interceptor.Tracking/Namotion.Interceptor.Tracking.csproj
+++ b/src/Namotion.Interceptor.Tracking/Namotion.Interceptor.Tracking.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="Namotion.Interceptor.Tracking.Tests" />
-        <InternalsVisibleTo Include="Namotion.Interceptor.Connectors" />
         <InternalsVisibleTo Include="Namotion.Interceptor.Connectors.Tests" />
     </ItemGroup>
 

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeOperations.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectPropertyChangeOperations.cs
@@ -148,22 +148,6 @@ internal static class SubjectPropertyChangeOperations
     }
 
     /// <summary>
-    /// Creates the inverse of a change (old and new values swapped) for undoing an applied change.
-    /// Carries no revision on purpose: this describes a write to perform, not a commit that happened.
-    /// Applying it locally goes through the terminal and takes a fresh, higher revision of its own,
-    /// which is what consumers observe. Copying the original's revision instead would give two changes
-    /// on one property the same revision, the tie the flush merging relies on being impossible.
-    /// </summary>
-    internal static SubjectPropertyChange ToRollbackChange(this SubjectPropertyChange change) =>
-        SubjectPropertyChange.Create(
-            change.Property,
-            origin: change.Origin,
-            changedTimestamp: change.ChangedTimestamp,
-            receivedTimestamp: change.ReceivedTimestamp,
-            oldValue: change.GetNewValue<object?>(),
-            newValue: change.GetOldValue<object?>());
-
-    /// <summary>
     /// Returns the subset of <paramref name="written"/> whose property also appears in
     /// <paramref name="failed"/> (matched by <see cref="SubjectPropertyChange.Property"/>).
     /// </summary>


### PR DESCRIPTION
## Why

`Namotion.Interceptor.Tracking` granted `InternalsVisibleTo` to `Namotion.Interceptor.Connectors` (added back in #114). Building Connectors without that entry produces exactly one error, so the whole grant existed for a single member: the internal extension method `SubjectPropertyChangeOperations.ToRollbackChange()`, called once, at `SourceTransactionWriter.cs:412`.

Handing a sibling assembly access to every internal in Tracking to reach one pure helper is the wrong trade.

## What changed

`ToRollbackChange` becomes a public instance method on `SubjectPropertyChange`, alongside `WithOrigin` and `MergeWithNewer`. Those two already do the same thing: derive a copy by moving the private storage fields. Rollback is the third of that family and was the only one living elsewhere.

Both call sites keep identical syntax, so `Namotion.Interceptor.Connectors` has no diff at all.

The move also removes two allocations per reverted change. The old version rebuilt the change through `Create<object?>`, and that type argument cannot take the inline or string storage path, so every rollback allocated two `BoxedValueHolder<object?>` wrappers plus a box per inline value type. Swapping the storage fields directly avoids all of it.

Observable behavior is unchanged. Typed reads already resolved correctly through the boxed holder, so this is an allocation win rather than a fix. Verified by reverting the implementation to the old boxing form: five of the six new tests still passed, and only the allocation test failed.

## Public API

One added method, visible in the snapshot:

```
public SubjectPropertyChange ToRollbackChange() { }
```

The snapshot also tracks assembly-level attributes, so the removed `InternalsVisibleTo` shows up there too.

## Not changed

The `InternalsVisibleTo` for `Namotion.Interceptor.Connectors.Tests` stays. It is genuinely used, by `SubjectTransactionAdditionalTests.cs:84` reading `SubjectTransaction.HasActiveTransaction`, and a test project reaching into internals is the ordinary case.

## Tests

Six new tests in `SubjectPropertyChangeTests`, covering the value swap, preservation of property, origin and timestamps, the deliberate revision reset, typed round-trips across all three storage paths (inline, string, boxed holder), null string handling, and a zero-allocation assertion that pins the reason this shape was chosen.

Full unit suite green: 2,674 passed, 0 failed. Build clean under warnings as errors.