### PR TITLE
Close the ToRollbackChange coverage and doc gaps found in review

### DIFF
--- a/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
@@ -809,22 +809,6 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void WhenConvertedToRollbackChange_ThenOldAndNewValuesAreSwapped()
-    {
-        // Arrange
-        var change = SubjectPropertyChange.Create(
-            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
-            10, 20);
-
-        // Act
-        var rollback = change.ToRollbackChange();
-
-        // Assert
-        Assert.Equal(20, rollback.GetOldValue<int>());
-        Assert.Equal(10, rollback.GetNewValue<int>());
-    }
-
-    [Fact]
     public void WhenConvertedToRollbackChange_ThenPropertyOriginAndTimestampsArePreserved()
     {
         // Arrange
@@ -847,9 +831,8 @@ public class SubjectPropertyChangeTests
     [Fact]
     public void WhenConvertedToRollbackChange_ThenRevisionIsReset()
     {
-        // Arrange: a rollback describes a write to perform, not a commit that happened. Carrying the
-        // committed revision forward would give two changes on one property the same revision, the tie
-        // flush merging relies on being impossible.
+        // Arrange: a rollback describes a write to perform, not a commit that happened, and Revision is
+        // only meaningful for the latter. Applying it commits with a revision of its own.
         var change = SubjectPropertyChange.Create(
             _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
             "old", "new", 7L);
@@ -864,15 +847,19 @@ public class SubjectPropertyChangeTests
     [Fact]
     public void WhenConvertedToRollbackChangeOnEveryStoragePath_ThenTypedValuesRoundTrip()
     {
-        // Arrange: the swap moves the storage fields directly, so each of the three storage paths has
-        // to survive it with its stored type intact rather than degrading to a boxed object.
+        // Arrange: the swap moves the storage fields directly, so every storage path has to survive it
+        // with its stored type intact rather than degrading to a boxed object.
         var oldReference = new CustomClass { Id = 1 };
         var newReference = new CustomClass { Id = 2 };
 
         var inlineChange = SubjectPropertyChange.Create(
             _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
+        var nullableChange = SubjectPropertyChange.Create<int?>(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
         var stringChange = SubjectPropertyChange.Create(
             _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, "old", "new");
+        var nullStringChange = SubjectPropertyChange.Create<string?>(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, null, "new");
         var referenceChange = SubjectPropertyChange.Create(
             _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
             oldReference, newReference);
@@ -882,35 +869,25 @@ public class SubjectPropertyChangeTests
 
         // Act
         var inlineRollback = inlineChange.ToRollbackChange();
+        var nullableRollback = nullableChange.ToRollbackChange();
         var stringRollback = stringChange.ToRollbackChange();
+        var nullStringRollback = nullStringChange.ToRollbackChange();
         var referenceRollback = referenceChange.ToRollbackChange();
         var oversizedRollback = oversizedChange.ToRollbackChange();
 
         // Assert
         Assert.Equal(2, inlineRollback.GetOldValue<int>());
         Assert.Equal(1, inlineRollback.GetNewValue<int>());
+        Assert.Equal(2, nullableRollback.GetOldValue<int?>());
+        Assert.Equal(1, nullableRollback.GetNewValue<int?>());
         Assert.Equal("new", stringRollback.GetOldValue<string>());
         Assert.Equal("old", stringRollback.GetNewValue<string>());
+        Assert.Equal("new", nullStringRollback.GetOldValue<string>());
+        Assert.Null(nullStringRollback.GetNewValue<string>());
         Assert.Same(newReference, referenceRollback.GetOldValue<CustomClass>());
         Assert.Same(oldReference, referenceRollback.GetNewValue<CustomClass>());
         Assert.Equal(2L, oversizedRollback.GetOldValue<OversizedCustomStruct>().Value1);
         Assert.Equal(1L, oversizedRollback.GetNewValue<OversizedCustomStruct>().Value1);
-    }
-
-    [Fact]
-    public void WhenConvertedToRollbackChangeWithNullString_ThenNullMovesToTheNewValue()
-    {
-        // Arrange
-        var change = SubjectPropertyChange.Create<string?>(
-            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
-            null, "new");
-
-        // Act
-        var rollback = change.ToRollbackChange();
-
-        // Assert
-        Assert.Equal("new", rollback.GetOldValue<string>());
-        Assert.Null(rollback.GetNewValue<string>());
     }
 
     [Fact]
@@ -948,9 +925,9 @@ public class SubjectPropertyChangeTests
     [Fact]
     public void WhenConvertedToRollbackChange_ThenValuesKeepTheirDeclaredStorageType()
     {
-        // Arrange: moving the storage rather than re-boxing through object means a rollback answers
-        // typed reads exactly as the change it inverts does, including refusing a narrower type.
-        // A nullable stores its own type inline, so int? does not read back as int on either.
+        // Arrange: moving the storage rather than re-boxing through object means a rollback refuses a
+        // narrower type exactly as the change it inverts does. A nullable stores its own type inline,
+        // so int? does not read back as int on either of them.
         var change = SubjectPropertyChange.Create<int?>(
             _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
 
@@ -958,8 +935,6 @@ public class SubjectPropertyChangeTests
         var rollback = change.ToRollbackChange();
 
         // Assert
-        Assert.Equal(2, rollback.GetOldValue<int?>());
-        Assert.Equal(1, rollback.GetNewValue<int?>());
         Assert.False(rollback.TryGetOldValue<int>(out _));
         Assert.False(change.TryGetOldValue<int>(out _));
     }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/SubjectPropertyChangeTests.cs
@@ -914,32 +914,112 @@ public class SubjectPropertyChangeTests
     }
 
     [Fact]
-    public void WhenConvertedToRollbackChange_ThenNothingIsAllocated()
+    public void WhenConvertedToRollbackChangeAndReadAsObject_ThenValuesAreSwapped()
     {
-        // Arrange: the conversion moves the storage fields instead of round-tripping both values
-        // through object, so it must not allocate. Rebuilding it through Create<object?> would cost
-        // two boxed holders per reverted change, plus a box per inline value.
-        var change = SubjectPropertyChange.Create(
+        // Arrange: both revert paths read a rollback through object, so that is the read that has to
+        // hold on every storage path.
+        var inlineChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
+        var nullableChange = SubjectPropertyChange.Create<int?>(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, null, 2);
+        var stringChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, "old", "new");
+        var referenceChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            new CustomClass { Id = 1 }, new CustomClass { Id = 2 });
+
+        // Act
+        var inlineRollback = inlineChange.ToRollbackChange();
+        var nullableRollback = nullableChange.ToRollbackChange();
+        var stringRollback = stringChange.ToRollbackChange();
+        var referenceRollback = referenceChange.ToRollbackChange();
+
+        // Assert
+        Assert.Equal(2, inlineRollback.GetOldValue<object?>());
+        Assert.Equal(1, inlineRollback.GetNewValue<object?>());
+        Assert.Equal(2, nullableRollback.GetOldValue<object?>());
+        Assert.Null(nullableRollback.GetNewValue<object?>());
+        Assert.Equal("new", stringRollback.GetOldValue<object?>());
+        Assert.Equal("old", stringRollback.GetNewValue<object?>());
+        Assert.Equal(2, Assert.IsType<CustomClass>(referenceRollback.GetOldValue<object?>()).Id);
+        Assert.Equal(1, Assert.IsType<CustomClass>(referenceRollback.GetNewValue<object?>()).Id);
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChange_ThenValuesKeepTheirDeclaredStorageType()
+    {
+        // Arrange: moving the storage rather than re-boxing through object means a rollback answers
+        // typed reads exactly as the change it inverts does, including refusing a narrower type.
+        // A nullable stores its own type inline, so int? does not read back as int on either.
+        var change = SubjectPropertyChange.Create<int?>(
             _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
 
+        // Act
+        var rollback = change.ToRollbackChange();
+
+        // Assert
+        Assert.Equal(2, rollback.GetOldValue<int?>());
+        Assert.Equal(1, rollback.GetNewValue<int?>());
+        Assert.False(rollback.TryGetOldValue<int>(out _));
+        Assert.False(change.TryGetOldValue<int>(out _));
+    }
+
+    [Fact]
+    public void WhenConvertedToRollbackChange_ThenNothingIsAllocatedOnAnyStoragePath()
+    {
+        // Arrange: the conversion moves the storage fields instead of round-tripping both values
+        // through object. Rebuilding it through Create<object?> would cost two boxed holders per
+        // reverted change plus a box per inline value, so every storage path has to measure zero:
+        // measuring only the inline one would miss a partial revert on the two holder paths.
+        var inlineChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, 1, 2);
+        var stringChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp, "old", "new");
+        var referenceChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            new CustomClass { Id = 1 }, new CustomClass { Id = 2 });
+        var oversizedChange = SubjectPropertyChange.Create(
+            _property, origin: ChangeOrigin.Local, _changedTimestamp, _receivedTimestamp,
+            new OversizedCustomStruct { Value1 = 1L }, new OversizedCustomStruct { Value1 = 2L });
+
+        // Act
+        var inlineAllocated = MeasureRollbackAllocations(inlineChange, c => c.GetNewValue<int>());
+        var stringAllocated = MeasureRollbackAllocations(stringChange, c => c.GetNewValue<string>().Length);
+        var referenceAllocated = MeasureRollbackAllocations(referenceChange, c => c.GetNewValue<CustomClass>().Id);
+        var oversizedAllocated = MeasureRollbackAllocations(
+            oversizedChange, c => (int)c.GetNewValue<OversizedCustomStruct>().Value1);
+
+        // Assert
+        Assert.Equal(0L, inlineAllocated);
+        Assert.Equal(0L, stringAllocated);
+        Assert.Equal(0L, referenceAllocated);
+        Assert.Equal(0L, oversizedAllocated);
+    }
+
+    /// <summary>
+    /// Converts <paramref name="change"/> in a tight loop and returns the bytes allocated. The read is
+    /// passed in as a non-capturing lambda, so its delegate is cached before the measured window and the
+    /// result is consumed, which keeps the conversion from being optimized away.
+    /// </summary>
+    private static long MeasureRollbackAllocations(
+        SubjectPropertyChange change, Func<SubjectPropertyChange, int> read)
+    {
         // Warm up so JIT compilation does not land inside the measured window.
         var accumulator = 0L;
         for (var i = 0; i < 100; i++)
         {
-            accumulator += change.ToRollbackChange().GetNewValue<int>();
+            accumulator += read(change.ToRollbackChange());
         }
 
-        // Act
         var before = GC.GetAllocatedBytesForCurrentThread();
         for (var i = 0; i < 1000; i++)
         {
-            accumulator += change.ToRollbackChange().GetNewValue<int>();
+            accumulator += read(change.ToRollbackChange());
         }
         var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
-        // Assert
-        Assert.Equal(0L, allocated);
-        Assert.Equal(1100L, accumulator);
+        Assert.NotEqual(0L, accumulator);
+        return allocated;
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
@@ -237,12 +237,16 @@ public readonly struct SubjectPropertyChange : IEquatable<SubjectPropertyChange>
 
     /// <summary>
     /// Copies this change with its old and new values swapped, without re-boxing them, so applying the
-    /// result undoes this change. Carries no revision on purpose: it describes a write to perform, not a
-    /// commit that happened. Applying it locally goes through the terminal and takes a fresh, higher
-    /// revision of its own, which is what consumers observe. Copying this change's revision instead would
-    /// give two changes on one property the same revision, the tie the flush merging relies on being
-    /// impossible.
+    /// result undoes this change.
     /// </summary>
+    /// <remarks>
+    /// The result carries no <see cref="Revision"/>: it describes a write to perform, not a commit that
+    /// happened, and a revision only means anything for the latter. Applying it produces a commit of its
+    /// own, with its own revision. This is deliberately unlike <see cref="WithOrigin"/> and
+    /// <see cref="MergeWithNewer"/>, which both carry the revision through.
+    /// Both values keep the type they were stored with, so a typed read of the result needs the same type
+    /// as a typed read of this change: swapping the values does not widen what they can be read as.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SubjectPropertyChange ToRollbackChange() =>
         new(Property,

--- a/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/SubjectPropertyChange.cs
@@ -237,15 +237,13 @@ public readonly struct SubjectPropertyChange : IEquatable<SubjectPropertyChange>
 
     /// <summary>
     /// Copies this change with its old and new values swapped, without re-boxing them, so applying the
-    /// result undoes this change.
+    /// result undoes this change. Values keep the type they were stored with, so typed reads behave as
+    /// they do on this change.
     /// </summary>
     /// <remarks>
-    /// The result carries no <see cref="Revision"/>: it describes a write to perform, not a commit that
-    /// happened, and a revision only means anything for the latter. Applying it produces a commit of its
-    /// own, with its own revision. This is deliberately unlike <see cref="WithOrigin"/> and
-    /// <see cref="MergeWithNewer"/>, which both carry the revision through.
-    /// Both values keep the type they were stored with, so a typed read of the result needs the same type
-    /// as a typed read of this change: swapping the values does not widen what they can be read as.
+    /// Unlike <see cref="WithOrigin"/> and <see cref="MergeWithNewer"/>, the result carries no
+    /// <see cref="Revision"/>: it is a write to perform, not a commit that happened. Applying it commits
+    /// with a revision of its own.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SubjectPropertyChange ToRollbackChange() =>


### PR DESCRIPTION
Follow-up to #431, from an independent review of that change. Tests and documentation only, no product behavior change.

## 1. The allocation test measured the wrong path

`WhenConvertedToRollbackChange_ThenNothingIsAllocated` only ever converted `Create(..., 1, 2)`, an int. That is the inline storage path, which is the one path where the allocation the test warns about cannot occur. The two boxed holders named in its own comment are the cost of the string, reference type and oversized struct paths.

Demonstrated by mutation: an implementation that keeps the fast field swap for inline values and falls back to a `Create<object?>` rebuild the moment either boxed holder is set passed all 874 tests, Tracking and Connectors alike. A partial revert of #431 on exactly the paths the test is about was invisible.

The test now measures all four storage paths and fails that mutation. The read is passed in as a non-capturing lambda so its delegate is cached before the measured window, and the accumulator assertion no longer hardcodes an iteration-derived constant.

## 2. The revision remark gave a reason that does not hold

The doc claimed that carrying the revision forward "would give two changes on one property the same revision, the tie the flush merging relies on being impossible."

Nothing in production compares `SubjectPropertyChange.Revision`. It is assigned in `WriteInterceptorFactory`, carried through `PropertyChangeInterceptor` and `MergeWithNewer`, and read only by tests. The single `MergeWithNewer` call site, `ChangeQueueProcessor.cs:254`, dedupes by buffer index. Flush merging does not depend on revision uniqueness.

`revision: 0` is still correct, for the reason `Revision`'s own documentation gives: 0 means the change was constructed outside a terminal write, which is exactly what a rollback instruction is. Every change that reaches `ToRollbackChange` already has `Revision == 0` anyway, since `SubjectTransaction.CaptureChange` creates without one.

The remark now says that, notes the deliberate asymmetry with `WithOrigin` and `MergeWithNewer`, and drops "the terminal", which no public XML doc defines. The same stale claim in the revision test's comment is corrected too.

## 3. Missing reads

Two tests added:

- Reading a rollback through `object`, which is what both revert paths actually do (`SubjectPropertyChangeOperations.TryApplyLocalChange` and `SourceTransactionWriter`). This was covered only indirectly, by the Connectors end to end tests.
- Pinning that a rollback answers typed reads exactly as the change it inverts does, including refusing a narrower type. This is the one observable difference #431 introduced, via `Nullable<T>`, which stores its own type inline: `GetOldValue<int>()` on an `int?` rollback used to succeed through the boxed holder and now throws, matching what the forward change already did. The test asserts both records agree.

## 4. Overlap removed

The value swap test was fully contained in the storage path test, so it is gone, and the null string and nullable cases folded into that same test. One test now owns "every storage path survives the swap with its stored type". The declared storage type test keeps only its narrowing assertions. Eight tests down to six.

## Verification

Build clean under warnings as errors. Full unit suite green across all 26 test projects.

Mutation battery re-run after the consolidation, to confirm merging tests did not quietly cost coverage. All still caught, each by a test named after the break:

| Mutation | Caught by |
|---|---|
| no swap | storage path, read as object |
| swap holders only | storage path, read as object |
| swap inline storage only | storage path, read as object |
| carry `Revision` forward | revision is reset |
| rebuild via `Create<object?>` when a holder is set | nothing allocated on any storage path |

The zero-allocation assertion itself was attacked in review across 210 runs (12-way CPU saturation, `TieredCompilation=0`, `QuickJitForLoops=0`, `TieredPGO=0`, OSR counters at 1 and 900, server GC) with zero failures, so the exact-zero assertion is kept as is.

## Not addressed here

`HomeBlaze.Storage` grants `InternalsVisibleTo` to `HomeBlaze.Storage.Blazor`, a non-test assembly, and none of its six internals appear to be referenced there. Same smell as the grant #431 removed, but separate scope.