### PR TITLE
Rename SourceState.Connecting to Synchronizing and document how it relates to OPC UA diagnostics

### DIFF
--- a/docs/connectors-monitoring.md
+++ b/docs/connectors-monitoring.md
@@ -1,6 +1,6 @@
 # Source Monitoring
 
-Every `ISubjectSource` reports whether it's still connecting, has completed its initial load, or has stopped. The `Namotion.Interceptor.Connectors.Monitoring` namespace turns that per-source state into a per-tree registry, a typed event stream, and an awaitable primitive, so an application can ask "is my tree live yet" instead of polling `TryGetSource()` in a loop.
+Every `ISubjectSource` reports whether it's still synchronizing, has completed its initial load, or has stopped. The `Namotion.Interceptor.Connectors.Monitoring` namespace turns that per-source state into a per-tree registry, a typed event stream, and an awaitable primitive, so an application can ask "is my tree live yet" instead of polling `TryGetSource()` in a loop.
 
 ## Getting Started
 
@@ -48,11 +48,13 @@ await root.Kitchen.WaitForSynchronizationAsync(stoppingToken);
 
 A source is in scope for an anchor when its root subject and the anchor lie on the same root-to-leaf path, in either direction: the source's root is an ancestor of (or is) the anchor, so it may claim into the awaited branch, or the source's root sits inside the anchor's own subtree. A source on a sibling branch is in neither set, so a source that never connects, or fails, on an unrelated branch never blocks a wait scoped to a branch it cannot claim into.
 
+Given that scope, the rule is short: once registration is complete, a wait completes when no in-scope source is `Synchronizing`. `Synchronized` and `Stopped` both count as settled, so a scope matching no source at all, or one where every source has stopped, completes rather than blocks.
+
 Two things about that scoping matter before you rely on a wait.
 
 No wait can complete before source registration is complete, whatever its scope: that is the first condition checked, ahead of any scope evaluation. So until `CompleteSourceRegistration()` has run (and any `DeferWaitCompletion()` holds are released), every wait blocks, empty scope or not.
 
-A pending wait is not frozen to the sources that existed when registration completed. It is re-evaluated on every registration, unregistration and state change, so a source registering later can block it. Only a wait that has already completed is frozen, since a completed task cannot be un-completed. A scope matching no source, or one where every source has `Stopped`, completes immediately rather than blocking.
+A pending wait is not frozen to the sources that existed when registration completed. It is re-evaluated on every registration, unregistration and state change, so a source registering later can block it. Only a wait that has already completed is frozen, since a completed task cannot be un-completed.
 
 An empty scope is the expected answer for a branch with no external source, such as configuration or computed state. It is also what you get if you anchored on the wrong branch, or if the source was never created. The library cannot tell those apart, so treat a completed wait as "nothing here is still loading" rather than as proof the branch is live.
 
@@ -71,7 +73,7 @@ var state = property.GetSourceState();
 
 See the XML docs on `SourceState` for what each member means. `Synchronized` specifically means the owning source completed its initial load, and what that guarantees differs per protocol; see [What Synchronized Means per Protocol](#what-synchronized-means-per-protocol).
 
-`GetSourceState()` is only fully meaningful once the branch containing the property has been awaited through `WaitForSynchronizationAsync`. Before any claiming has happened, `Unclaimed` cannot be distinguished from "not yet claimed, but will be." After a claim it reports `Connecting`, so "will synchronize, still loading" is already distinguishable from "no source" even before the wait completes.
+`GetSourceState()` is only fully meaningful once the branch containing the property has been awaited through `WaitForSynchronizationAsync`. Before any claiming has happened, `Unclaimed` cannot be distinguished from "not yet claimed, but will be." After a claim it reports `Synchronizing`, so "will synchronize, still loading" is already distinguishable from "no source" even before the wait completes.
 
 ## What Synchronized Means per Protocol
 
@@ -143,7 +145,7 @@ So the stream is not a ledger. It cannot reconstruct a history, because the arri
 public enum SourceState
 {
     Unclaimed,
-    Connecting,
+    Synchronizing,
     Synchronized,
     Stopped
 }
@@ -151,11 +153,11 @@ public enum SourceState
 
 See the XML docs on `SourceState` for what each member means. On a source itself (as opposed to a property, via `GetSourceState()`), `Unclaimed` never occurs.
 
-State follows the pump: construction starts at `Connecting`, `StartBuffering()` returns to `Connecting` on every connect and reconnect, a completed initial load reaches `Synchronized`, and a pump failure falls back to `Connecting` before the retry delay. A connector that detects a loss *before* it buffers calls the protected `ReportConnectionLost()` so `State` does not sit at `Synchronized` for the whole reconnect window; OPC UA does this from its keep-alive handler and its manual reconnect path.
+State follows the pump: construction starts at `Synchronizing`, `StartBuffering()` returns to `Synchronizing` on every connect and reconnect, a completed initial load reaches `Synchronized`, and a pump failure falls back to `Synchronizing` before the retry delay. A connector that detects a loss *before* it buffers calls the protected `ReportConnectionLost()` so `State` does not sit at `Synchronized` for the whole reconnect window; OPC UA does this from its keep-alive handler and its manual reconnect path.
 
 `Stopped` is terminal: no further transition succeeds, and `ExecuteAsync` sets it in a `finally` so it fires on every exit path. A guard in `SubjectSourceBase.StartAsync` enforces this, because `BackgroundService` would otherwise happily run `ExecuteAsync` again against a fresh token. Create a new instance rather than restarting a stopped one.
 
-`LastSynchronizedAt` records when the most recent initial synchronization completed (`null` if it never has), so a source that is `Connecting` after a drop can still be reported as "stale, last confirmed at T" rather than just "not synchronized." `PendingWriteCount` is orthogonal to `State`: it describes the outbound write retry queue and can be non-empty during entirely normal synchronized operation.
+`LastSynchronizedAt` records when the most recent initial synchronization completed (`null` if it never has), so a source that is `Synchronizing` after a drop can still be reported as "stale, last confirmed at T" rather than just "not synchronized." `PendingWriteCount` is orthogonal to `State`: it describes the outbound write retry queue and can be non-empty during entirely normal synchronized operation.
 
 ### The Event Stream
 

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -645,7 +645,7 @@ When a batch write to the OPC UA server partially fails, the client throws an `O
 
 `IOpcUaSubjectClientSource.Diagnostics` exposes a live facade. Resolve it once and poll (see [Resolving the Client Source](#resolving-the-client-source)).
 
-These are transport health, and OPC UA specific. Whether the model can be trusted is a separate question, answered the same way for every connector by [Source Monitoring](connectors-monitoring.md): `ISubjectSource.State` is `Synchronized` once the initial load has completed. Read the two together to tell a dropped network from a connected client that is still loading — the first is `IsConnected == false`, the second is `IsConnected == true` with a state of `Connecting`.
+These are transport health, and OPC UA specific. Whether the model can be trusted is a separate question, answered the same way for every connector by [Source Monitoring](connectors-monitoring.md): `ISubjectSource.State` is `Synchronized` once the initial load has completed. Read the two together to tell a dropped network from a connected client that is still loading: the first is `IsConnected == false`, the second is `IsConnected == true` with a state of `Synchronizing`.
 
 Categories: connection (`IsConnected`, `IsReconnecting`, `SessionId`, `LastConnectedAt`), subscriptions (`SubscriptionCount`, `MonitoredItemCount`), throughput (`IncomingChangesPerSecond`, `OutgoingChangesPerSecond`), reconnection history (`TotalReconnectionAttempts`, `SuccessfulReconnections`, `FailedReconnections`, `AbandonedReconnections`, `LastError`), [polling fallback](#polling-fallback-for-unsupported-nodes) (`PollingItemCount`), [read-after-write](#read-after-write-fallback) (`PendingReadAfterWrites`). All properties are thread-safe for reading.
 

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -645,6 +645,8 @@ When a batch write to the OPC UA server partially fails, the client throws an `O
 
 `IOpcUaSubjectClientSource.Diagnostics` exposes a live facade. Resolve it once and poll (see [Resolving the Client Source](#resolving-the-client-source)).
 
+These are transport health, and OPC UA specific. Whether the model can be trusted is a separate question, answered the same way for every connector by [Source Monitoring](connectors-monitoring.md): `ISubjectSource.State` is `Synchronized` once the initial load has completed. Read the two together to tell a dropped network from a connected client that is still loading — the first is `IsConnected == false`, the second is `IsConnected == true` with a state of `Connecting`.
+
 Categories: connection (`IsConnected`, `IsReconnecting`, `SessionId`, `LastConnectedAt`), subscriptions (`SubscriptionCount`, `MonitoredItemCount`), throughput (`IncomingChangesPerSecond`, `OutgoingChangesPerSecond`), reconnection history (`TotalReconnectionAttempts`, `SuccessfulReconnections`, `FailedReconnections`, `AbandonedReconnections`, `LastError`), [polling fallback](#polling-fallback-for-unsupported-nodes) (`PollingItemCount`), [read-after-write](#read-after-write-fallback) (`PendingReadAfterWrites`). All properties are thread-safe for reading.
 
 ## Direct Session Access

--- a/docs/connectors-opcua.md
+++ b/docs/connectors-opcua.md
@@ -48,7 +48,7 @@ var source = serviceProvider.GetRequiredService<IOpcUaSubjectClientSource>();
 Console.WriteLine(source.Diagnostics.IsConnected);
 ```
 
-See [OPC UA Client](connectors-opcua-client.md) for configuration, authentication, monitoring, resilience, and extensibility.
+See [OPC UA Client](connectors-opcua-client.md) for configuration, authentication, monitoring, resilience, and extensibility, and [Source Monitoring](connectors-monitoring.md) for waiting until the model is in sync rather than merely connected.
 
 ### Server
 

--- a/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
+++ b/src/Namotion.Interceptor.Benchmark/SubjectTransactionBenchmark.cs
@@ -128,7 +128,7 @@ public class SubjectTransactionBenchmark
             return Task.FromResult<Action?>(null);
         }
 
-        public SourceState State => SourceState.Connecting;
+        public SourceState State => SourceState.Synchronizing;
 
         public DateTimeOffset? LastSynchronizedAt => null;
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceEventEmissionTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceEventEmissionTests.cs
@@ -37,7 +37,7 @@ public class SourceEventEmissionTests
         await AsyncTestHelpers.WaitUntilAsync(() => received.Any(e => e.Kind == SourceEventKind.PropertyClaimed));
         var claimEvent = received.First(e => e.Kind == SourceEventKind.PropertyClaimed);
         Assert.Equal(SourceState.Unclaimed, claimEvent.OldState);
-        Assert.Equal(SourceState.Connecting, claimEvent.NewState);
+        Assert.Equal(SourceState.Synchronizing, claimEvent.NewState);
     }
 
     [Fact]
@@ -200,12 +200,12 @@ public class SourceEventEmissionTests
         var property = new PropertyReference(person, nameof(Person.FirstName));
         var source = new TestStateSource(person);
         property.SetSource(source);
-        // Captured while the source is still Connecting, so NewState here is Connecting - a
+        // Captured while the source is still Synchronizing, so NewState here is Synchronizing - a
         // regression that made CurrentState just return NewState instead of re-resolving fresh
         // would still pass if the source never moved on after capture. It does, below.
         var sourceEvent = new SourceEvent(
             SourceEventKind.PropertyClaimed, source, property,
-            SourceState.Unclaimed, SourceState.Connecting, DateTimeOffset.UtcNow);
+            SourceState.Unclaimed, SourceState.Synchronizing, DateTimeOffset.UtcNow);
 
         // Act - the source synchronizes after the event was captured.
         source.ReportSynchronized();
@@ -213,7 +213,7 @@ public class SourceEventEmissionTests
 
         // Assert
         Assert.Equal(SourceState.Synchronized, current);
-        Assert.Equal(SourceState.Connecting, sourceEvent.NewState);
+        Assert.Equal(SourceState.Synchronizing, sourceEvent.NewState);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
@@ -480,7 +480,7 @@ public class SourceMonitorTests
         var transition = Task.Run(() =>
         {
             transitionStarted.Set();
-            source.RaiseStateChanged(SourceState.Connecting, SourceState.Synchronized);
+            source.RaiseStateChanged(SourceState.Synchronizing, SourceState.Synchronized);
         });
         Assert.True(transitionStarted.Wait(TimeSpan.FromSeconds(10)));
 
@@ -524,7 +524,7 @@ public class SourceMonitorTests
         monitor.Unregister(source);
         inFlight?.Invoke(source, new SourceEvent(
             SourceEventKind.StateChanged, source, null,
-            SourceState.Connecting, SourceState.Synchronized, DateTimeOffset.UtcNow));
+            SourceState.Synchronizing, SourceState.Synchronized, DateTimeOffset.UtcNow));
 
         // Assert
         // A sentinel settles delivery: once its SourceRegistered arrives, anything the in-flight
@@ -621,7 +621,7 @@ internal sealed class GatedStateRaisingSource : ISubjectSource
         {
             _reachedStateRead.Set();
             _releaseStateRead.Wait(TimeSpan.FromSeconds(10));
-            return SourceState.Connecting;
+            return SourceState.Synchronizing;
         }
     }
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceStateTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceStateTests.cs
@@ -48,7 +48,7 @@ public class SourceStateTests
         var state = property.GetSourceState();
 
         // Assert
-        Assert.Equal(SourceState.Connecting, state);
+        Assert.Equal(SourceState.Synchronizing, state);
     }
 
     [Fact]
@@ -60,10 +60,10 @@ public class SourceStateTests
         source.StateChanged += (_, _) => Interlocked.Increment(ref raised);
 
         // Act
-        source.ReportConnecting();
+        source.ReportSynchronizing();
 
         // Assert
-        Assert.Equal(SourceState.Connecting, source.State);
+        Assert.Equal(SourceState.Synchronizing, source.State);
         Assert.Equal(0, raised);
     }
 
@@ -96,7 +96,7 @@ public class SourceStateTests
         var timestampAtStop = source.LastSynchronizedAt;
 
         // Act
-        source.ReportConnecting();
+        source.ReportSynchronizing();
         source.ReportSynchronized();
 
         // Assert
@@ -139,7 +139,7 @@ public class SourceStateTests
                 barrier.SignalAndWait();
                 for (var i = 0; i < hammerCountPerIteration; i++)
                 {
-                    source.ReportConnecting();
+                    source.ReportSynchronizing();
                     source.ReportSynchronized();
                 }
             });
@@ -219,7 +219,7 @@ public class SourceStateTests
     }
 
     [Fact]
-    public void WhenBufferingStartsOutsideThePump_ThenTheSourceReportsConnecting()
+    public void WhenBufferingStartsOutsideThePump_ThenTheSourceReportsSynchronizing()
     {
         // Arrange
         var person = new Person();
@@ -231,7 +231,7 @@ public class SourceStateTests
         writer.StartBuffering();
 
         // Assert
-        Assert.Equal(SourceState.Connecting, source.State);
+        Assert.Equal(SourceState.Synchronizing, source.State);
     }
 
     [Fact]
@@ -262,7 +262,7 @@ public class SourceStateTests
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => writer.LoadInitialStateAndResumeAsync(CancellationToken.None));
-        Assert.Equal(SourceState.Connecting, source.State);
+        Assert.Equal(SourceState.Synchronizing, source.State);
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public class SourceStateTests
         source.SimulateConnectionLost();
 
         // Assert
-        Assert.Equal(SourceState.Connecting, source.State);
+        Assert.Equal(SourceState.Synchronizing, source.State);
     }
 }
 
@@ -298,7 +298,7 @@ internal class TestStateSource : SubjectSourceBase
     // SubjectPropertyWriter's direct TransitionTo calls now (see SubjectPropertyWriter.StartBuffering
     // and LoadInitialStateAndResumeAsync), but the test suite still drives state machine behaviour
     // through named, state-specific entry points rather than a bare TransitionTo call.
-    public void ReportConnecting() => TransitionStateTo(SourceState.Connecting);
+    public void ReportSynchronizing() => TransitionStateTo(SourceState.Synchronizing);
 
     public void ReportSynchronized() => TransitionStateTo(SourceState.Synchronized);
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceSubscriptionTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceSubscriptionTests.cs
@@ -189,7 +189,7 @@ public class SourceSubscriptionTests
     {
         var source = new TestStateSource(new Person());
         return new SourceEvent(
-            SourceEventKind.SourceRegistered, source, null, SourceState.Connecting, SourceState.Connecting, DateTimeOffset.UtcNow);
+            SourceEventKind.SourceRegistered, source, null, SourceState.Synchronizing, SourceState.Synchronizing, DateTimeOffset.UtcNow);
     }
 }
 
@@ -240,13 +240,13 @@ public class SourceSubscriptionHandoffTests
 
     private static SourceEvent CreateEvent() => new(
         SourceEventKind.SourceRegistered, new HandoffTestSource(), null,
-        SourceState.Connecting, SourceState.Connecting, DateTimeOffset.UtcNow);
+        SourceState.Synchronizing, SourceState.Synchronizing, DateTimeOffset.UtcNow);
 
     private sealed class HandoffTestSource : ISubjectSource
     {
         public IInterceptorSubject RootSubject => throw new NotSupportedException();
         public int WriteBatchSize => 0;
-        public SourceState State => SourceState.Connecting;
+        public SourceState State => SourceState.Synchronizing;
         public DateTimeOffset? LastSynchronizedAt => null;
         public int PendingWriteCount => 0;
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceWaitTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceWaitTests.cs
@@ -313,7 +313,7 @@ public class SourceWaitTests
     }
 
     [Fact]
-    public async Task WhenAnInScopeSourceIsConnecting_ThenTheWaitBlocksUntilItSynchronizes()
+    public async Task WhenAnInScopeSourceIsSynchronizing_ThenTheWaitBlocksUntilItSynchronizes()
     {
         // Arrange
         var context = CreateContext();
@@ -354,7 +354,7 @@ public class SourceWaitTests
         await left.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
-        Assert.Equal(SourceState.Connecting, broken.State);
+        Assert.Equal(SourceState.Synchronizing, broken.State);
     }
 
     [Fact]
@@ -410,7 +410,7 @@ public class SourceWaitTests
         monitor.Register(healthySource);
 
         // A hold keeps registration incomplete while both waits below are created, so their
-        // fast-path IsSatisfied check short-circuits on IsRegistrationComplete before walking any
+        // fast-path IsBranchSynchronized check short-circuits on IsRegistrationComplete before walking any
         // scope, so the poison wait cannot throw until both waits are in the list.
         var hold = monitor.DeferWaitCompletion();
         monitor.CompleteSourceRegistration();
@@ -553,7 +553,7 @@ public class SourceWaitTests
         var monitor = context.GetSourceMonitor();
         var root = new Person(context);
         // An in-scope, unsynchronized source keeps the wait genuinely pending: an empty scope would
-        // instead complete vacuously once registration is complete (see IsSatisfied), leaving
+        // instead complete vacuously once registration is complete (see IsBranchSynchronized), leaving
         // nothing for cancellation to interrupt.
         monitor.Register(new TestStateSource(root));
         monitor.CompleteSourceRegistration();
@@ -579,7 +579,7 @@ public class SourceWaitTests
 
         // moving hangs under BOTH parents, so the single write in Act removes one parent link
         // without ever emptying the anchor's scope. That matters: an empty scope completes a wait
-        // vacuously (see IsSatisfied), which would mask exactly the staleness this test exists to
+        // vacuously (see IsBranchSynchronized), which would mask exactly the staleness this test exists to
         // catch - an earlier version of this test let the scope go empty and therefore passed with
         // the handler ordering inverted, and passed with the Act removed entirely.
         left.Mother = moving;
@@ -685,8 +685,8 @@ public class SourceWaitTests
         // Arrange
         // neverStarted is rooted at the SAME subject as started, so it would be squarely in scope if
         // registration were what put a source there. It never registers, so it must not count - and
-        // because it stays Connecting forever, a wait that did count it could never complete. An
-        // earlier version of this test let neverStarted stay Connecting but asserted only that it
+        // because it stays Synchronizing forever, a wait that did count it could never complete. An
+        // earlier version of this test let neverStarted stay Synchronizing but asserted only that it
         // was absent from Sources, which holds trivially whether or not the wait consults it.
         var context = CreateContext();
         var monitor = context.GetSourceMonitor();
@@ -705,7 +705,7 @@ public class SourceWaitTests
         // Assert - completes despite neverStarted being in scope and never synchronizing.
         await wait.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.DoesNotContain(neverStarted, monitor.Sources);
-        Assert.Equal(SourceState.Connecting, neverStarted.State);
+        Assert.Equal(SourceState.Synchronizing, neverStarted.State);
     }
 
     [Fact]
@@ -768,11 +768,11 @@ public class SourceWaitTests
             // A bounded timeout so a regression fails this test instead of wedging the run.
             await wait.WaitAsync(TimeSpan.FromSeconds(5));
 
-            // Reset for the next iteration. TransitionTo allows Synchronized -> Connecting, and
+            // Reset for the next iteration. TransitionTo allows Synchronized -> Synchronizing, and
             // wait's removal from the monitor's pending-wait list happens before the awaited task
             // above completes (see PendingWait.AwaitAsync), so the monitor has no leftover wait
             // state carried into the next iteration.
-            source.ReportConnecting();
+            source.ReportSynchronizing();
         }
 
         transitionThread.Join(TimeSpan.FromSeconds(30));
@@ -878,8 +878,8 @@ internal sealed class RecordingLoggerFactory(RecordingLogger logger) : ILoggerFa
 /// <remarks>
 /// Used as a wait anchor to make one wait's re-evaluation throw on every pass while leaving every
 /// other wait unaffected. GetParents() reads Data, and SourceScope's walk starts from the anchor, so
-/// the throw lands inside that wait's own IsSatisfied and nowhere else. A throwing source would not
-/// work here: IsSatisfied iterates the shared source list for every wait, so one poison source makes
+/// the throw lands inside that wait's own IsBranchSynchronized and nowhere else. A throwing source would not
+/// work here: IsBranchSynchronized iterates the shared source list for every wait, so one poison source makes
 /// every wait's evaluation throw.
 /// </remarks>
 internal sealed class PoisonAnchor(IInterceptorSubjectContext context) : IInterceptorSubject

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectPropertyWriterTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectPropertyWriterTests.cs
@@ -176,7 +176,7 @@ public class SubjectPropertyWriterTests
         };
 
         // A standalone writer, separate from the source's own internal pump (never started here):
-        // ReportConnecting/ReportSynchronized still drive the same source's real state machine,
+        // ReportSynchronizing/ReportSynchronized still drive the same source's real state machine,
         // since TransitionTo operates on the source instance, not on any one writer.
         var writer = new SubjectPropertyWriter(source, NullLogger.Instance);
 
@@ -192,7 +192,7 @@ public class SubjectPropertyWriterTests
 
         // Assert
         Assert.False(staleApplied, "The superseded cycle's stale snapshot must never be applied.");
-        Assert.Equal(SourceState.Connecting, source.State);
+        Assert.Equal(SourceState.Synchronizing, source.State);
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public class SubjectPropertyWriterTests
 
         // Assert
         Assert.False(applied, "A load that completes after a reported connection loss must not apply pre-outage data.");
-        Assert.Equal(SourceState.Connecting, source.State);
+        Assert.Equal(SourceState.Synchronizing, source.State);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceBaseTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceBaseTests.cs
@@ -68,11 +68,11 @@ public class SubjectSourceBaseTests
     }
 
     [Fact]
-    public async Task WhenThePumpFailsAfterReachingSynchronized_ThenTheCatchTransitionsBackToConnecting()
+    public async Task WhenThePumpFailsAfterReachingSynchronized_ThenTheCatchTransitionsBackToSynchronizing()
     {
         // Arrange
         // A first-iteration failure can never distinguish ExecuteAsync's catch-block transition
-        // from the entry-line transition that always runs first (both land on Connecting, which is
+        // from the entry-line transition that always runs first (both land on Synchronizing, which is
         // already the source's default state, so neither publishes an event). To observe the
         // catch's OWN transition, the pump must first genuinely reach Synchronized and then fail.
         // The mock context deliberately does not configure GetService<PropertyChangeInterceptor>(),
@@ -92,7 +92,7 @@ public class SubjectSourceBaseTests
             .Returns(subjectContextMock.Object);
 
         var observedStates = new ConcurrentQueue<SourceState>();
-        var sawConnectingAfterSynchronized = new ManualResetEventSlim(false);
+        var sawSynchronizingAfterSynchronized = new ManualResetEventSlim(false);
 
         var source = new TestSubjectSource(subjectMock.Object, subjectContextMock.Object, NullLogger.Instance,
             retryTime: TimeSpan.FromSeconds(30))
@@ -103,9 +103,9 @@ public class SubjectSourceBaseTests
         source.StateChanged += (_, sourceEvent) =>
         {
             observedStates.Enqueue(sourceEvent.NewState);
-            if (sourceEvent.NewState == SourceState.Connecting && observedStates.Contains(SourceState.Synchronized))
+            if (sourceEvent.NewState == SourceState.Synchronizing && observedStates.Contains(SourceState.Synchronized))
             {
-                sawConnectingAfterSynchronized.Set();
+                sawSynchronizingAfterSynchronized.Set();
             }
         };
 
@@ -113,13 +113,13 @@ public class SubjectSourceBaseTests
 
         // Act
         await source.StartAsync(cancellationTokenSource.Token);
-        var caughtBackToConnecting = sawConnectingAfterSynchronized.Wait(TimeSpan.FromSeconds(10));
+        var caughtBackToSynchronizing = sawSynchronizingAfterSynchronized.Wait(TimeSpan.FromSeconds(10));
         await source.StopAsync(cancellationTokenSource.Token);
         await cancellationTokenSource.CancelAsync();
 
         // Assert
-        Assert.True(caughtBackToConnecting,
-            "Expected the pump to reach Synchronized and then be caught back to Connecting after the failure.");
+        Assert.True(caughtBackToSynchronizing,
+            "Expected the pump to reach Synchronized and then be caught back to Synchronizing after the failure.");
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceExtensionsTests.cs
@@ -495,7 +495,7 @@ public class SubjectSourceExtensionsTests
     /// <summary>
     /// Shared ISubjectSource member implementation for the two hand-rolled test doubles below,
     /// which differ only in RootSubject and WriteChangesAsync. Neither exercises state transitions,
-    /// so State is fixed at Connecting for the lifetime of the double.
+    /// so State is fixed at Synchronizing for the lifetime of the double.
     /// </summary>
     private abstract class StateTrackingTestSource : ISubjectSource
     {
@@ -504,7 +504,7 @@ public class SubjectSourceExtensionsTests
         public abstract ValueTask<WriteResult> WriteChangesAsync(ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken cancellationToken);
         public Task<Action?> LoadInitialStateAsync(CancellationToken cancellationToken) => Task.FromResult<Action?>(null);
 
-        public SourceState State => SourceState.Connecting;
+        public SourceState State => SourceState.Synchronizing;
 
         public DateTimeOffset? LastSynchronizedAt => null;
 

--- a/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -221,7 +221,7 @@ namespace Namotion.Interceptor.Connectors.Monitoring
     public enum SourceState
     {
         Unclaimed = 0,
-        Connecting = 1,
+        Synchronizing = 1,
         Synchronized = 2,
         Stopped = 3,
     }

--- a/src/Namotion.Interceptor.Connectors/ISubjectSource.cs
+++ b/src/Namotion.Interceptor.Connectors/ISubjectSource.cs
@@ -62,7 +62,7 @@ public interface ISubjectSource : ISubjectConnector
 
     /// <summary>
     /// Gets when the most recent initial synchronization completed, or <c>null</c> if it never has.
-    /// While <see cref="SourceState.Connecting"/> after a drop, this is how a dashboard says
+    /// While <see cref="SourceState.Synchronizing"/> after a drop, this is how a dashboard says
     /// "stale, last confirmed at T".
     /// </summary>
     DateTimeOffset? LastSynchronizedAt { get; }

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitor.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitor.cs
@@ -250,9 +250,9 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
     /// </summary>
     public IDisposable DeferWaitCompletion()
     {
-        // Deliberately does not re-evaluate. The increment happens first, so IsSatisfied returns
-        // false on its registration check for every wait before it walks anything: a pass here
-        // could only ever be a no-op. Release is where re-evaluation belongs (see ReleaseHold).
+        // Deliberately does not re-evaluate. The increment happens first, so IsBranchSynchronized
+        // returns false on its registration check for every wait before it walks anything: a pass
+        // here could only ever be a no-op. Release is where re-evaluation belongs (see ReleaseHold).
         Interlocked.Increment(ref _registrationHolds);
         return new RegistrationHold(this);
     }
@@ -274,18 +274,19 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
     // use for lock-free reads.
     private ImmutableArray<PendingWait> _waits = ImmutableArray<PendingWait>.Empty;
 
-    // Reused across every scope walk in IsSatisfied, which runs per wait on every property-reference
-    // add/remove tree-wide. Callers hold _lock and SearchGraph clears both on every return path.
+    // Reused across every scope walk in IsBranchSynchronized, which runs per wait on every
+    // property-reference add/remove tree-wide. Callers hold _lock and SearchGraph clears both on
+    // every return path.
     private readonly HashSet<IInterceptorSubject> _scopeVisitedScratch = new(ReferenceEqualityComparer.Instance);
     private readonly Stack<IInterceptorSubject> _scopePendingScratch = new();
 
 
     /// <summary>
     /// Completes when the branch containing <paramref name="subject"/> is synchronized: registration
-    /// is complete, and every registered non-Stopped in-scope source is Synchronized. An empty
-    /// in-scope set is vacuously satisfied once registration is complete (see IsSatisfied); before
-    /// that, it blocks, since an empty scope is still ambiguous between "no source yet" and "no
-    /// source ever" at that point.
+    /// is complete, and no in-scope source is Synchronizing. An empty in-scope set is vacuously
+    /// satisfied once registration is complete (see IsBranchSynchronized); before that, it blocks,
+    /// since an empty scope is still ambiguous between "no source yet" and "no source ever" at that
+    /// point.
     /// </summary>
     public Task WaitForSynchronizationAsync(
         IInterceptorSubject subject, CancellationToken cancellationToken = default)
@@ -298,7 +299,7 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
             // Checked first with no PendingWait allocated: the common case for an application
             // re-awaiting per operation is already satisfied. Only the unsatisfied path below
             // allocates a PendingWait and its TaskCompletionSource.
-            if (IsSatisfied(subject))
+            if (IsBranchSynchronized(subject))
             {
                 return Task.CompletedTask;
             }
@@ -316,7 +317,11 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
         });
     }
 
-    private bool IsSatisfied(IInterceptorSubject anchor)
+    /// <summary>
+    /// Whether a wait anchored on <paramref name="anchor"/> may complete: registration is complete,
+    /// and no source in scope of the anchor is still Synchronizing.
+    /// </summary>
+    private bool IsBranchSynchronized(IInterceptorSubject anchor)
     {
         if (!IsRegistrationComplete)
         {
@@ -331,6 +336,8 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
             }
 
             var state = source.State;
+            // Reads as "this source has not settled yet". Only Synchronized and Stopped let a wait
+            // through, so the pair of inequalities is exactly "the source is still Synchronizing".
             if (state != SourceState.Stopped && state != SourceState.Synchronized)
             {
                 return false;
@@ -353,8 +360,9 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
     /// <remarks>
     /// Holds _lock across the whole pass, rather than re-acquiring it once per wait. A lock-free
     /// emptiness check used to gate this method as a performance optimization, but it caused a lost
-    /// wakeup: a signal could observe "no waits yet" in the window between a waiter's IsSatisfied
-    /// check and its add to _waits, with no later signal to re-evaluate it, hanging the wait forever.
+    /// wakeup: a signal could observe "no waits yet" in the window between a waiter's
+    /// IsBranchSynchronized check and its add to _waits, with no later signal to re-evaluate it,
+    /// hanging the wait forever.
     /// Holding _lock for the full pass serializes it with WaitForSynchronizationAsync's own
     /// check-and-add at least as strictly as before (a signal now runs fully before or fully after
     /// the whole pass, not just before or after each individual wait), so do not narrow this back to
@@ -372,8 +380,8 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
                 return;
             }
 
-            // A throw from one wait's IsSatisfied must not skip re-evaluating the rest - that would
-            // be a lost wakeup for every wait after it. Written out rather than delegated to
+            // A throw from one wait's IsBranchSynchronized must not skip re-evaluating the rest -
+            // that would be a lost wakeup for every wait after it. Written out rather than delegated to
             // ExceptionAggregation.ForEach, unlike the two cold call sites: this runs on every
             // property-reference add/remove tree-wide while any wait is pending, and the helper's
             // IEnumerable<T> parameter would box the ImmutableArray, heap-allocate its enumerator,
@@ -382,7 +390,7 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
             {
                 try
                 {
-                    if (IsSatisfied(wait.Anchor))
+                    if (IsBranchSynchronized(wait.Anchor))
                     {
                         wait.Complete();
                     }

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitoringExtensions.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitoringExtensions.cs
@@ -19,7 +19,7 @@ public static class SourceMonitoringExtensions
     /// <remarks>
     /// Only fully meaningful once the branch containing the property has been awaited through
     /// WaitForSynchronizationAsync: before claiming has happened, Unclaimed cannot be distinguished
-    /// from not-yet-claimed. After a claim it reports Connecting, so "will sync, still loading" is
+    /// from not-yet-claimed. After a claim it reports Synchronizing, so "will sync, still loading" is
     /// already distinguishable from "no source" even before the wait completes.
     /// </remarks>
     public static SourceState GetSourceState(this PropertyReference property)

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceScope.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceScope.cs
@@ -14,8 +14,8 @@ internal static class SourceScope
     /// connection from blocking a wait. Walks using caller-supplied scratch collections.
     /// </summary>
     /// <remarks>
-    /// Every caller of this overload is <c>SourceMonitor.IsSatisfied</c>, which already holds the
-    /// monitor's lock and re-evaluates on every property-reference add/remove tree-wide while any
+    /// Every caller of this overload is <c>SourceMonitor.IsBranchSynchronized</c>, which already
+    /// holds the monitor's lock and re-evaluates on every property-reference add/remove while any
     /// wait is pending - reusing scratch collections there turns a per-source, per-re-evaluation
     /// allocation into none. <paramref name="visitedScratch"/> and <paramref name="pendingScratch"/>
     /// are cleared before this method returns, so passing the same instances into a later,

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceState.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceState.cs
@@ -9,8 +9,8 @@ public enum SourceState
     /// <summary>No source has claimed the property. Only returned by the property-level API; a source is never Unclaimed.</summary>
     Unclaimed,
 
-    /// <summary>Registered or claimed, but subscribe-read-replay is not complete. Also the state after a detected connection loss, because the connect-and-load phase runs again.</summary>
-    Connecting,
+    /// <summary>Claimed and working toward sync: connecting, reconnecting, or connected with the initial load still in flight. Also the state after a detected connection loss, because the connect-and-load phase runs again.</summary>
+    Synchronizing,
 
     /// <summary>The source completed its initial load procedure. What that guarantees differs per protocol; see the source monitoring documentation.</summary>
     Synchronized,

--- a/src/Namotion.Interceptor.Connectors/SubjectPropertyWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectPropertyWriter.cs
@@ -57,7 +57,7 @@ public sealed class SubjectPropertyWriter
 
             // Under _lock, paired with the generation change that governs it, so the transition
             // cannot be observed out of sync with the buffer it belongs to.
-            _source.TransitionStateTo(SourceState.Connecting);
+            _source.TransitionStateTo(SourceState.Synchronizing);
         }
     }
 

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -23,7 +23,7 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
     private readonly SubjectPropertyWriter _propertyWriter;
 
     private readonly Lock _stateLock = new();
-    private int _state = (int)SourceState.Connecting;
+    private int _state = (int)SourceState.Synchronizing;
     private long _lastSynchronizedTicks;
     private int _started;
 
@@ -185,7 +185,7 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
                 }
                 catch (Exception ex)
                 {
-                    TransitionStateTo(SourceState.Connecting);
+                    TransitionStateTo(SourceState.Synchronizing);
                     _logger.LogError(ex, "Failed to listen for changes in source.");
                     try
                     {
@@ -341,7 +341,7 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
     /// at detection time would replace the buffer with a fresh list, and the later StartBuffering
     /// on the reconnect path would then discard everything buffered in between. Protected rather
     /// than public: application code holding an ISubjectSource reference must not be able to flip a
-    /// synchronized source back to Connecting. A concrete source in another assembly that needs to
+    /// synchronized source back to Synchronizing. A concrete source in another assembly that needs to
     /// call this from a helper object outside its own inheritance hierarchy (SessionManager for
     /// OpcUaSubjectClientSource) needs an internal forwarder on that source; see
     /// OpcUaSubjectClientSource for the pattern.
@@ -356,7 +356,7 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
     protected void ReportConnectionLost()
     {
         _propertyWriter.InvalidateGeneration();
-        TransitionStateTo(SourceState.Connecting);
+        TransitionStateTo(SourceState.Synchronizing);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Mqtt.Tests/OutageStateTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/OutageStateTests.cs
@@ -55,7 +55,7 @@ public partial class OutageStateTests
     }
 
     [Fact]
-    public async Task WhenTheConnectionIsLost_ThenTheSourceReportsConnectingUntilItRecovers()
+    public async Task WhenTheConnectionIsLost_ThenTheSourceReportsSynchronizingUntilItRecovers()
     {
         // Arrange
         var brokerPort = GetFreeTcpPort();
@@ -119,9 +119,9 @@ public partial class OutageStateTests
             // retained values have been received: MQTT provides no end-of-retained signal, so
             // asserting anything about received property values here would be dishonest.
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.State == SourceState.Connecting,
+                () => source.State == SourceState.Synchronizing,
                 timeout: TimeSpan.FromSeconds(15),
-                message: "Source should report Connecting during the outage");
+                message: "Source should report Synchronizing during the outage");
             await AsyncTestHelpers.WaitUntilAsync(
                 () => source.State == SourceState.Synchronized,
                 timeout: TimeSpan.FromSeconds(30),

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OutageStateTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OutageStateTests.cs
@@ -28,7 +28,7 @@ public class OutageStateTests
     }
 
     [Fact]
-    public async Task WhenTheConnectionIsLost_ThenTheSourceReportsConnectingUntilItRecovers()
+    public async Task WhenTheConnectionIsLost_ThenTheSourceReportsSynchronizingUntilItRecovers()
     {
         // Arrange
         var logger = new TestLogger(_output);
@@ -112,17 +112,17 @@ public class OutageStateTests
             await ((IFaultInjectable)source).InjectFaultAsync(FaultType.Disconnect, CancellationToken.None);
 
             // Assert - Diagnostics.IsReconnecting flips true inside OnKeepAlive's lock, right after
-            // ReportConnectionLost() (see SessionManager.OnKeepAlive). Asserting State==Connecting the
+            // ReportConnectionLost() (see SessionManager.OnKeepAlive). Asserting State==Synchronizing the
             // moment IsReconnecting is observed true catches the state at the start of the SDK's own
-            // reconnect window. A weaker "wait for Connecting, then wait for Synchronized" pair would
+            // reconnect window. A weaker "wait for Synchronizing, then wait for Synchronized" pair would
             // pass vacuously even without the fix: PerformFullStateSyncIfNeededAsync still buffers
-            // briefly once the SDK finishes reconnecting on its own, so Connecting would still flash by
+            // briefly once the SDK finishes reconnecting on its own, so Synchronizing would still flash by
             // right before Synchronized regardless of whether OnKeepAlive reports the loss up front.
             await AsyncTestHelpers.WaitUntilAsync(
                 () => source.Diagnostics.IsReconnecting,
                 timeout: TimeSpan.FromSeconds(30),
                 message: "SDK should begin auto-reconnecting after the transport is disconnected");
-            Assert.Equal(SourceState.Connecting, source.State);
+            Assert.Equal(SourceState.Synchronizing, source.State);
 
             await AsyncTestHelpers.WaitUntilAsync(
                 () => source.State == SourceState.Synchronized,

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -4,6 +4,14 @@ namespace Namotion.Interceptor.OpcUa.Client;
 /// Provides diagnostic information about the OPC UA client connection state.
 /// Thread-safe for reading current values.
 /// </summary>
+/// <remarks>
+/// This reports transport health, protocol-specific and OPC UA only. Whether the model can be
+/// trusted is a separate question answered by <c>ISubjectSource.State</c>, which is the same for
+/// every connector: <c>Synchronized</c> once the initial load has completed, <c>Connecting</c>
+/// otherwise. Read them together to tell "the network is down" from "connected, still loading":
+/// the first is <see cref="IsConnected"/> false, the second is <see cref="IsConnected"/> true with
+/// a state of <c>Connecting</c>. See docs/connectors-monitoring.md.
+/// </remarks>
 public class OpcUaClientDiagnostics
 {
     private readonly OpcUaSubjectClientSource _source;
@@ -14,7 +22,8 @@ public class OpcUaClientDiagnostics
     }
 
     /// <summary>
-    /// Gets a value indicating whether the client is currently connected to the server.
+    /// Gets a value indicating whether the transport is up and no reconnection is in progress.
+    /// True does not mean the model is in sync yet; see the remarks on this type.
     /// </summary>
     public bool IsConnected => _source.SessionManager?.IsConnected ?? false;
 

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -7,10 +7,10 @@ namespace Namotion.Interceptor.OpcUa.Client;
 /// <remarks>
 /// This reports transport health, protocol-specific and OPC UA only. Whether the model can be
 /// trusted is a separate question answered by <c>ISubjectSource.State</c>, which is the same for
-/// every connector: <c>Synchronized</c> once the initial load has completed, <c>Connecting</c>
+/// every connector: <c>Synchronized</c> once the initial load has completed, <c>Synchronizing</c>
 /// otherwise. Read them together to tell "the network is down" from "connected, still loading":
 /// the first is <see cref="IsConnected"/> false, the second is <see cref="IsConnected"/> true with
-/// a state of <c>Connecting</c>. See docs/connectors-monitoring.md.
+/// a state of <c>Synchronizing</c>. See docs/connectors-monitoring.md.
 /// </remarks>
 public class OpcUaClientDiagnostics
 {
@@ -23,7 +23,8 @@ public class OpcUaClientDiagnostics
 
     /// <summary>
     /// Gets a value indicating whether the transport is up and no reconnection is in progress.
-    /// True does not mean the model is in sync yet; see the remarks on this type.
+    /// True does not mean the model is in sync yet: while the initial load is still running the
+    /// source state is <c>Synchronizing</c>. See the remarks on this type.
     /// </summary>
     public bool IsConnected => _source.SessionManager?.IsConnected ?? false;
 

--- a/src/Namotion.Interceptor.WebSocket.Tests/Integration/OutageStateTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Integration/OutageStateTests.cs
@@ -31,7 +31,7 @@ public class OutageStateTests
     }
 
     [Fact]
-    public async Task WhenTheConnectionIsLost_ThenTheSourceReportsConnectingUntilItRecovers()
+    public async Task WhenTheConnectionIsLost_ThenTheSourceReportsSynchronizingUntilItRecovers()
     {
         // Arrange - server fixture copied from WebSocketServerClientTests.
         using var portLease = await WebSocketTestPortPool.AcquireAsync();
@@ -78,9 +78,9 @@ public class OutageStateTests
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.State == SourceState.Connecting,
+                () => source.State == SourceState.Synchronizing,
                 timeout: TimeSpan.FromSeconds(15),
-                message: "Source should report Connecting during the outage");
+                message: "Source should report Synchronizing during the outage");
             await AsyncTestHelpers.WaitUntilAsync(
                 () => source.State == SourceState.Synchronized,
                 timeout: TimeSpan.FromSeconds(30),


### PR DESCRIPTION
## Summary

Source monitoring (#354) added a cross-connector answer to "can I trust these values yet", but nothing said how it relates to the OPC UA diagnostics a consumer is probably already binding to. This documents that relationship, and renames the one state whose name the documenting exposed as wrong.

Closes #195

## The rename

`SourceState.Connecting` covered three situations: the transport being down, a reconnect cycle running, and a connected source whose initial load is still in flight. The third one made the documentation contradict itself, because `OpcUaClientDiagnostics.IsConnected` is true exactly then, so the same instant had to be described as both "connecting" and "connected".

The rest of the feature already speaks of synchronization (`WaitForSynchronizationAsync`, `LastSynchronizedAt`, `Synchronized`), so `Connecting` was the odd word out. The member is now `SourceState.Synchronizing`, which covers all three situations honestly and lets the wait rule be stated in one line: a wait completes when no in-scope source is `Synchronizing`.

`SourceState` has never been released, so the rename costs nothing today. It becomes a breaking change the moment the enum ships, which is why it belongs in the same PR that documents it rather than in a follow-up.

Two smaller cleanups ride along: the private `SourceMonitor.IsSatisfied` becomes `IsBranchSynchronized`, which says what the predicate actually answers, and the double negative it checks (`state != Stopped && state != Synchronized`) gets a comment stating the intent without restructuring the logic. The test helper `ReportConnecting` becomes `ReportSynchronizing`.

## Why both stay

`SourceState` is deliberately coarser than the OPC UA diagnostics, because it has to mean the same thing for MQTT and WebSocket, which have no notion of an SDK reconnect cycle. It collapses three situations the diagnostics keep apart:

| Situation | Diagnostics | `SourceState` |
|---|---|---|
| Transport down | `IsConnected: false` | `Synchronizing` |
| Reconnect cycle running | `IsReconnecting: true` | `Synchronizing` |
| Transport up, initial load in flight | `IsConnected: true` | `Synchronizing` |

So they answer different questions. `SourceState` answers whether the model is trustworthy; the diagnostics answer what the transport is doing and why. Dropping `IsConnected`/`IsReconnecting` would remove the ability to tell a dropped network from a connected client that is still loading, which is exactly the distinction [#195](https://github.com/RicoSuter/Namotion.Interceptor/issues/195) asked to expose.

Reading them together is what gives you the three states that issue asked for: disconnected is `IsConnected == false`, connected and syncing is `IsConnected == true` with a state of `Synchronizing`, connected and in sync is `IsConnected == true` with a state of `Synchronized`. No new API is needed for that, which is why this PR documents the combination instead of adding a composite property.

## Changes

- `SourceState.Connecting` renamed to `SourceState.Synchronizing` across the solution, with a member doc naming all three situations it covers
- `SourceMonitor.IsSatisfied` renamed to `IsBranchSynchronized`, plus a comment on the settled-state check
- `OpcUaClientDiagnostics` gains a type-level remark explaining the split, and `IsConnected` now says plainly that true does not mean in sync
- `docs/connectors-opcua-client.md` says the same in the Diagnostics section
- `docs/connectors-monitoring.md` uses the new name throughout and now states the wait rule in one sentence
- `docs/connectors-opcua.md` links to the monitoring page

The monitoring page already links back to the OPC UA and MQTT pages, so the cross-references are now bidirectional.

## Testing

- `dotnet build src/Namotion.Interceptor.slnx`: 0 errors, 0 warnings
- 2898 unit tests pass (`--filter "Category!=Integration"`), 0 failed, 0 skipped
- 291 OPC UA tests pass including the integration suite, 0 failed, 0 skipped
- The `Namotion.Interceptor.Connectors` public API snapshot is updated. The only difference is `Connecting = 1` becoming `Synchronizing = 1`, so the numeric values are unchanged.
