### PR TITLE
Report why a synchronization wait completed

### DIFF
--- a/docs/connectors-monitoring.md
+++ b/docs/connectors-monitoring.md
@@ -28,12 +28,21 @@ builder.Services.AddHostedService<Worker>();
 ```csharp
 using Namotion.Interceptor.Connectors.Monitoring;
 
-internal sealed class Worker(Root root) : BackgroundService
+internal sealed class Worker(Root root, ILogger<Worker> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await root.WaitForSynchronizationAsync(stoppingToken);
-        // every source in the tree has finished its initial load
+        switch (await root.WaitForSynchronizationAsync(stoppingToken))
+        {
+            case SourceSynchronizationResult.Synchronized:
+            case SourceSynchronizationResult.Stale:
+                // every source delivered its initial load, so the values are real
+                break;
+
+            case SourceSynchronizationResult.Incomplete:
+                logger.LogWarning("A source never delivered: part of the tree may hold defaults.");
+                break;
+        }
     }
 }
 ```
@@ -43,12 +52,31 @@ internal sealed class Worker(Root root) : BackgroundService
 `WaitForSynchronizationAsync` is an extension on `IInterceptorSubject`, not on the context: the subject you call it on is the wait's anchor, and only sources in scope of that anchor are waited on. Change the anchor from the tree root to a subtree to wait on only that branch:
 
 ```csharp
-await root.Kitchen.WaitForSynchronizationAsync(stoppingToken);
+var result = await root.Kitchen.WaitForSynchronizationAsync(stoppingToken);
 ```
 
 A source is in scope for an anchor when its root subject and the anchor lie on the same root-to-leaf path, in either direction: the source's root is an ancestor of (or is) the anchor, so it may claim into the awaited branch, or the source's root sits inside the anchor's own subtree. A source on a sibling branch is in neither set, so a source that never connects, or fails, on an unrelated branch never blocks a wait scoped to a branch it cannot claim into.
 
 Given that scope, the rule is short: once registration is complete, a wait completes when no in-scope source is `Synchronizing`. `Synchronized` and `Stopped` both count as settled, so a scope matching no source at all, or one where every source has stopped, completes rather than blocks.
+
+## What the Result Means
+
+Every in-scope source is `Synchronized` or `Stopped` when a wait completes, which makes these four cases total:
+
+| in-scope sources when the wait completes | result | meaning |
+|---|---|---|
+| all currently `Synchronized` | `Synchronized` | delivered and still live |
+| none (empty scope) | `Synchronized` | nothing to wait for |
+| all synchronized at least once, at least one now `Stopped` | `Stale` | delivered, values may be out of date |
+| at least one `Stopped` that never synchronized | `Incomplete` | never received data, may still hold CLR defaults |
+
+Worst wins: one `Incomplete` source makes the whole branch `Incomplete`. `Incomplete` is the enum's zero value, so an unassigned field defaults to the most pessimistic answer.
+
+The verdict is per source, not per property: it answers whether every source completed its initial load, not whether every property holds a value from the external system. A load that resolved only some of its nodes still reports `Synchronized`.
+
+`Incomplete` is not "not yet". `Stopped` is terminal, so awaiting again returns it immediately; handle it in a switch, not a retry loop. Only taking the dead source out of scope changes the verdict, by disposing or unregistering it. Adding a replacement alongside it does not, because worst wins.
+
+Host shutdown moves a branch through all three answers, so a consumer that runs during shutdown must treat `Stale` as a success and cannot read `Synchronized` as proof of anything. Hooked on `ApplicationStopping` it still sees `Synchronized`, since that fires before hosted services stop; after they stop it sees `Stale`; and once the container disposes them they unregister, so the scope empties and it reads `Synchronized` again.
 
 Two things about that scoping matter before you rely on a wait.
 
@@ -56,7 +84,11 @@ No wait can complete before source registration is complete, whatever its scope:
 
 A pending wait is not frozen to the sources that existed when registration completed. It is re-evaluated on every registration, unregistration and state change, so a source registering later can block it. Only a wait that has already completed is frozen, since a completed task cannot be un-completed.
 
-An empty scope is the expected answer for a branch with no external source, such as configuration or computed state. It is also what you get if you anchored on the wrong branch, or if the source was never created. The library cannot tell those apart, so treat a completed wait as "nothing here is still loading" rather than as proof the branch is live.
+An empty scope is the expected answer for a branch with no external source, such as configuration or computed state. It is also what you get from a wrong anchor, a source that was never created, one created but never started, and one that stopped and was then disposed, since disposal unregisters. All report `Synchronized`, and the library cannot tell them apart, so treat that result as "nothing here is still loading" rather than as proof the branch is live.
+
+Detaching the awaited branch empties its scope the same way, and there the answer is actively wrong rather than merely uninformative: scope is resolved through the parent graph, so a source rooted inside the branch leaves scope along with it, and a wait pending on that branch completes as `Synchronized` even though that source is still loading and has delivered nothing. Do not detach a subtree while something is waiting on it.
+
+A source that fails terminally sets `Stopped` but is not disposed, so it stays registered and its branch keeps reporting whatever the stop earned. The same applies to a source whose registration itself failed. That is correct while nothing replaced it, and it is not free: the monitor holds every registered source, and through it the subtree under that source's root, until the source is disposed. If you do replace it, dispose the one you are replacing: the monitor cannot distinguish an abandoned source from a dead one, so leaving both registered keeps the branch on the dead one's verdict forever, and keeps both alive.
 
 A subject referenced from two trees participates fully in only the first: the context fallback is added on first attach and left alone afterwards, so claims publish to the first tree's stream and a wait anchored through the second tree sees only the first tree's sources. Avoid sharing a subject across two independently monitored trees.
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -276,6 +276,8 @@ public interface ISubjectSource : ISubjectConnector
 
 Direct interface implementation without the base class is supported for advanced scenarios, but the implementer is then responsible for its own listening loop, buffering, and outbound dispatch, as well as the four synchronization-state members. See the XML docs on `ISubjectSource` for their exact contract, including the lock-free requirement on `State`/`LastSynchronizedAt`/`RootSubject` and the obligation to register with every reachable `SourceMonitor`.
 
+`LastSynchronizedAt` is load-bearing rather than diagnostic: branch waits use it to tell a source that stopped having delivered from one that stopped having never delivered. An implementation that reaches `Synchronized` must stamp it and never clear it, or every branch it participates in reports `Incomplete` once it stops. See [Source Monitoring](connectors-monitoring.md).
+
 #### Custom Source Example
 
 Derive from `SubjectSourceBase` and override the three hooks. The base owns the pump lifecycle (buffer, listen, load initial state, run change queue, retry on failure) and satisfies `ISubjectSource` directly through its public abstract members.

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceStateTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceStateTests.cs
@@ -106,6 +106,27 @@ public class SourceStateTests
     }
 
     [Fact]
+    public void WhenSynchronizedThenStopped_ThenLastSynchronizedAtIsNotCleared()
+    {
+        // Arrange
+        // Branch waits tell "stopped having delivered its initial load" from "stopped having never
+        // delivered anything" solely by this timestamp surviving the stop. The assertion in
+        // WhenStopped_ThenNoFurtherTransitionSucceeds compares two post-stop reads, so it would pass
+        // just as happily against an implementation that cleared the field on Stopped.
+        var source = new TestStateSource(new Person());
+        source.ReportSynchronized();
+        var timestampWhileSynchronized = source.LastSynchronizedAt;
+        Assert.NotNull(timestampWhileSynchronized);
+
+        // Act
+        source.ReportStopped();
+
+        // Assert
+        Assert.NotNull(source.LastSynchronizedAt);
+        Assert.Equal(timestampWhileSynchronized, source.LastSynchronizedAt);
+    }
+
+    [Fact]
     public async Task WhenSynchronizedIsHammeredConcurrentlyWithStopped_ThenSynchronizedIsNeverPublishedAfterStoppedAndLastSynchronizedAtFreezes()
     {
         // Arrange

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceWaitResultTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceWaitResultTests.cs
@@ -1,0 +1,599 @@
+using Namotion.Interceptor.Connectors.Monitoring;
+using Namotion.Interceptor.Connectors.Tests.Models;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Lifecycle;
+
+namespace Namotion.Interceptor.Connectors.Tests;
+
+/// <summary>
+/// Covers what a completed wait reports, as opposed to when it completes, which is SourceWaitTests.
+/// </summary>
+public class SourceWaitResultTests
+{
+    private static IInterceptorSubjectContext CreateContext() =>
+        InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithRegistry()
+            .WithLifecycle()
+            .WithSourceMonitoring();
+
+    [Fact]
+    public async Task WhenEveryInScopeSourceIsSynchronized_ThenTheResultIsSynchronized()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var first = new TestStateSource(root);
+        var second = new TestStateSource(root);
+        monitor.Register(first);
+        monitor.Register(second);
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        first.ReportSynchronized();
+        second.ReportSynchronized();
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Synchronized, result);
+    }
+
+    [Fact]
+    public async Task WhenNoSourceIsInScope_ThenTheResultIsSynchronized()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert - vacuous, and the reason Synchronized is not proof that a source exists.
+        Assert.Equal(SourceSynchronizationResult.Synchronized, result);
+    }
+
+    [Fact]
+    public async Task WhenEverySourceStoppedAfterSynchronizing_ThenTheResultIsStale()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var source = new TestStateSource(root);
+        monitor.Register(source);
+        monitor.CompleteSourceRegistration();
+
+        // Act - the initial load completed, so the values it delivered are real but no longer live.
+        source.ReportSynchronized();
+        source.ReportStopped();
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Stale, result);
+    }
+
+    [Fact]
+    public async Task WhenOneSourceStoppedAfterSynchronizingBesideALiveOne_ThenTheResultIsStale()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var live = new TestStateSource(root);
+        var dropped = new TestStateSource(root);
+        monitor.Register(live);
+        monitor.Register(dropped);
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        live.ReportSynchronized();
+        dropped.ReportSynchronized();
+        dropped.ReportStopped();
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Stale, result);
+    }
+
+    [Fact]
+    public async Task WhenOneSourceStoppedWithoutSynchronizingBesideALiveOne_ThenTheResultIsIncomplete()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var live = new TestStateSource(root);
+        var neverDelivered = new TestStateSource(root);
+        monitor.Register(live);
+        monitor.Register(neverDelivered);
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        live.ReportSynchronized();
+        neverDelivered.ReportStopped();
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Incomplete, result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WhenBothStopKindsAreInScope_ThenTheResultIsIncompleteInEitherOrder(bool neverDeliveredFirst)
+    {
+        // Arrange
+        // Registration order decides walk order, and only one of the two orders pins the worst-wins
+        // comparison: registered second, an unconditional assignment would also land on Incomplete.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var neverDelivered = new TestStateSource(root);
+        var dropped = new TestStateSource(root);
+
+        if (neverDeliveredFirst)
+        {
+            monitor.Register(neverDelivered);
+            monitor.Register(dropped);
+        }
+        else
+        {
+            monitor.Register(dropped);
+            monitor.Register(neverDelivered);
+        }
+
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        dropped.ReportSynchronized();
+        dropped.ReportStopped();
+        neverDelivered.ReportStopped();
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Incomplete, result);
+    }
+
+    [Fact]
+    public void WhenASourceIsStillSynchronizingBesideAStoppedOne_ThenTheWaitStaysPending()
+    {
+        // Arrange
+        // The stopped source is registered first on purpose: in the opposite order the walk
+        // short-circuits before reaching it, and this would pass against an early exit on Incomplete.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var neverDelivered = new TestStateSource(root);
+        var stillLoading = new TestStateSource(root);
+        monitor.Register(neverDelivered);
+        monitor.Register(stillLoading);
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        neverDelivered.ReportStopped();
+        var wait = root.WaitForSynchronizationAsync(CancellationToken.None);
+
+        // Assert
+        Assert.False(wait.IsCompleted);
+    }
+
+    [Fact]
+    public async Task WhenASourceStopsWithoutSynchronizingWhileAWaitIsPending_ThenTheWaitResolvesToIncomplete()
+    {
+        // Arrange
+        // The only path carrying the verdict through OnWaitConditionChanged rather than the
+        // already-satisfied fast path.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var source = new TestStateSource(root);
+        monitor.Register(source);
+        monitor.CompleteSourceRegistration();
+
+        var wait = root.WaitForSynchronizationAsync(CancellationToken.None);
+        Assert.False(wait.IsCompleted);
+
+        // Act
+        source.ReportStopped();
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Incomplete, await wait.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task WhenAFailedSourceIsDisposedWhileAWaitIsPending_ThenTheWaitResolvesToIncomplete()
+    {
+        // Arrange
+        // Dispose publishes Stopped while still registered and only then unregisters. The other
+        // order would shrink the scope to empty first and report a vacuous Synchronized.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var source = new NeverLoadingSource(root);
+        await source.StartAsync(CancellationToken.None);
+        monitor.CompleteSourceRegistration();
+
+        var wait = root.WaitForSynchronizationAsync(CancellationToken.None);
+        Assert.False(wait.IsCompleted);
+
+        // Act
+        source.Dispose();
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Incomplete, await wait.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task WhenAStoppedSourceIsUnregistered_ThenALaterWaitReportsSynchronized()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var source = new TestStateSource(root);
+        monitor.Register(source);
+        monitor.CompleteSourceRegistration();
+        source.ReportStopped();
+
+        Assert.Equal(
+            SourceSynchronizationResult.Incomplete,
+            await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5)));
+
+        // Act - unregistering removes it from every scope, so the branch has nothing left to report on.
+        monitor.Unregister(source);
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert - a failure that is cleaned up stops being visible, so Synchronized is not proof
+        // the branch was ever loaded.
+        Assert.Equal(SourceSynchronizationResult.Synchronized, result);
+    }
+
+    [Fact]
+    public async Task WhenASourceReportsSynchronizedWithoutATimestamp_ThenTheResultIsSynchronized()
+    {
+        // Arrange
+        // Only a stopped source's timestamp carries the "never synchronized" meaning, so a missing
+        // one while synchronized must not be read as a failure.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        monitor.Register(new TimestamplessSource(root));
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        var result = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Synchronized, result);
+    }
+
+    [Fact]
+    public async Task WhenTheResultIsIncomplete_ThenReAwaitingReturnsIncompleteAgain()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var source = new TestStateSource(root);
+        monitor.Register(source);
+        monitor.CompleteSourceRegistration();
+        source.ReportStopped();
+
+        // Act - Stopped is terminal and the source stays registered, so waiting again cannot
+        // improve the answer.
+        var first = await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        var second = root.WaitForSynchronizationAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Incomplete, first);
+        Assert.True(second.IsCompleted);
+        Assert.Equal(SourceSynchronizationResult.Incomplete, await second);
+    }
+
+    [Fact]
+    public void WhenTheWaitIsAlreadySatisfied_ThenTheCompletedTaskIsCached()
+    {
+        // Arrange - the documented usage is re-awaiting per operation, so the already-satisfied
+        // path must not allocate a task per call.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        monitor.CompleteSourceRegistration();
+
+        // Act
+        var first = root.WaitForSynchronizationAsync(CancellationToken.None);
+        var second = root.WaitForSynchronizationAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task WhenTwoMonitorsDisagree_ThenTheWorseResultWins(
+        bool worseMonitorSettlesLast, bool worseMonitorIsTheChild)
+    {
+        // Arrange
+        // Registered manually against one monitor each: a source started the ordinary way registers
+        // with every reachable monitor, making the aggregation idempotent rather than tested.
+        // Varying which monitor carries the failure rules out folding to one fixed constituent, and
+        // varying which settles last rules out first-to-complete and last-to-complete winning.
+        var parent = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithLifecycle()
+            .WithSourceMonitoring();
+        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        child.AddFallbackContext(parent);
+
+        var parentMonitor = parent.GetSourceMonitor();
+        var childMonitor = child.GetServices<SourceMonitor>()[0];
+
+        var root = new Person(child);
+        var healthy = new TestStateSource(root);
+        var neverDelivered = new TestStateSource(root);
+        (worseMonitorIsTheChild ? childMonitor : parentMonitor).Register(neverDelivered);
+        (worseMonitorIsTheChild ? parentMonitor : childMonitor).Register(healthy);
+        parentMonitor.CompleteSourceRegistration();
+        childMonitor.CompleteSourceRegistration();
+
+        // Leaving one source unsettled runs the aggregation through its asynchronous path rather
+        // than folding two already-completed tasks.
+        var wait = root.WaitForSynchronizationAsync(CancellationToken.None);
+        Assert.False(wait.IsCompleted);
+
+        // Act
+        if (worseMonitorSettlesLast)
+        {
+            healthy.ReportSynchronized();
+            Assert.False(wait.IsCompleted);
+            neverDelivered.ReportStopped();
+        }
+        else
+        {
+            neverDelivered.ReportStopped();
+            Assert.False(wait.IsCompleted);
+            healthy.ReportSynchronized();
+        }
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Incomplete, await wait.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WhenAMonitorIsSatisfiedOnlyBriefly_ThenTheAggregationHasAlreadyCapturedIt(
+        bool transientOnTheChild)
+    {
+        // Arrange
+        // Pins that every constituent wait is created before the first await. A sequential
+        // implementation would not ask the second monitor until the first completed, by which point
+        // the transient satisfaction below has been withdrawn, and it would block forever. Which
+        // monitor comes first in the aggregation is an implementation detail, so both placements run:
+        // whichever order holds, one of them puts the transient source second and would hang.
+        var parent = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithLifecycle()
+            .WithSourceMonitoring();
+        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        child.AddFallbackContext(parent);
+
+        var parentMonitor = parent.GetSourceMonitor();
+        var childMonitor = child.GetServices<SourceMonitor>()[0];
+
+        var root = new Person(child);
+        var slow = new TestStateSource(root);
+        var transient = new TestStateSource(root);
+        (transientOnTheChild ? childMonitor : parentMonitor).Register(transient);
+        (transientOnTheChild ? parentMonitor : childMonitor).Register(slow);
+        parentMonitor.CompleteSourceRegistration();
+        childMonitor.CompleteSourceRegistration();
+
+        var wait = root.WaitForSynchronizationAsync(CancellationToken.None);
+        Assert.False(wait.IsCompleted);
+
+        // Act - satisfied, then withdrawn before the other monitor settles.
+        transient.ReportSynchronized();
+        transient.ReportSynchronizing();
+        slow.ReportSynchronized();
+
+        // Assert
+        Assert.Equal(SourceSynchronizationResult.Synchronized, await wait.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task WhenDisposeRacesAFailingRegistration_ThenTheSourceIsNeverLeftRegistered()
+    {
+        // Arrange
+        // If Dispose wins the race before Register has added the source, its unregister no-ops and
+        // the registration failure is the only thing left that can clean up. However the race lands,
+        // a stranded source is both a leak and a branch pinned to Incomplete for good. The
+        // throwing-Register counterpart of
+        // SourceMonitorTests.WhenDisposeLandsInsideStartAsyncsRegistrationLoop_ThenNoStoppedSourceStaysRegistered,
+        // with fewer iterations because each one arms and retires a poison wait.
+        var leaked = 0;
+        for (var iteration = 0; iteration < 500; iteration++)
+        {
+            var context = CreateContext();
+            var monitor = context.GetSourceMonitor();
+            using var cancellation = new CancellationTokenSource();
+            var poisonWait = ArmFailingRegistration(context, monitor, cancellation.Token);
+            var source = new TestStateSource(new Person(context));
+
+            using var ready = new Barrier(2);
+            var disposal = Task.Run(() =>
+            {
+                ready.SignalAndWait();
+
+                // Unregistering re-evaluates the armed poison wait, which throws after the
+                // unregister itself has happened. That is the fixture, not a disposal defect.
+                return Record.Exception(() => source.Dispose());
+            });
+
+            // Act - the start may also find the source already stopped and return without ever
+            // registering, so the failure is recorded rather than asserted on.
+            ready.SignalAndWait();
+            await Record.ExceptionAsync(() => source.StartAsync(CancellationToken.None));
+            await disposal;
+
+            if (monitor.Sources.Contains(source))
+            {
+                leaked++;
+            }
+
+            await cancellation.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => poisonWait);
+        }
+
+        // Assert - a leaked source keeps a live StateChanged subscription and holds its root subject
+        // for the monitor's lifetime, with nothing left that would ever remove it.
+        Assert.Equal(0, leaked);
+    }
+
+    [Fact]
+    public async Task WhenARegistrationFails_ThenTheSourceIsReportedStoppedAndTheBranchIsIncomplete()
+    {
+        // Arrange
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var poisonWait = ArmFailingRegistration(context, monitor);
+        var source = new TestStateSource(root);
+
+        // Act - Register adds the source under the lock and only then re-evaluates waits, so the
+        // throw arrives with it already registered.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => source.StartAsync(CancellationToken.None));
+
+        // Assert
+        Assert.Equal(SourceState.Stopped, source.State);
+        Assert.Contains(source, monitor.Sources);
+        Assert.Equal(
+            SourceSynchronizationResult.Incomplete,
+            await root.WaitForSynchronizationAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.False(poisonWait.IsCompleted);
+    }
+
+    [Fact]
+    public async Task WhenARegistrationFails_ThenTheOriginalExceptionPropagates()
+    {
+        // Arrange
+        // Reporting the failure re-enters the same wait re-evaluation that just threw.
+        // TransitionStateTo isolates each handler, so the caller must still see the original.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        _ = ArmFailingRegistration(context, monitor);
+        var source = new TestStateSource(root);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => source.StartAsync(CancellationToken.None));
+
+        // Assert
+        Assert.Equal("scope walk is broken", exception.Message);
+    }
+
+    [Fact]
+    public async Task WhenASourceWithAFailedRegistrationIsDisposed_ThenItUnregistersCleanly()
+    {
+        // Arrange - the failure path keeps the monitor list populated so Dispose can still unwind it.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        using var cancellation = new CancellationTokenSource();
+        var poisonWait = ArmFailingRegistration(context, monitor, cancellation.Token);
+        var source = new TestStateSource(root);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => source.StartAsync(CancellationToken.None));
+
+        // Cancelling retires the poison wait, so the unregistration below has nothing left to
+        // re-evaluate and its scope walk cannot surface instead.
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => poisonWait);
+
+        // Act
+        var exception = Record.Exception(() => source.Dispose());
+
+        // Assert
+        Assert.Null(exception);
+        Assert.DoesNotContain(source, monitor.Sources);
+    }
+
+    /// <summary>
+    /// Leaves the monitor in a state where any further wait re-evaluation throws, which is what makes
+    /// <c>SourceMonitor.Register</c> throw. Returns the poison wait, which stays pending throughout.
+    /// </summary>
+    /// <remarks>
+    /// The hold keeps registration incomplete while the poison wait is created, so its own fast-path
+    /// check short-circuits before walking any scope. Releasing it triggers the first re-evaluation.
+    /// </remarks>
+    private static Task<SourceSynchronizationResult> ArmFailingRegistration(
+        IInterceptorSubjectContext context, SourceMonitor monitor, CancellationToken cancellationToken = default)
+    {
+        // The walk runs per source, so with none registered the poison anchor never throws and the
+        // wait completes vacuously. This sentinel is rooted on an unrelated subject, so it is out of
+        // scope for every other anchor here.
+        monitor.Register(new TestStateSource(new Person(context)));
+
+        var hold = monitor.DeferWaitCompletion();
+        monitor.CompleteSourceRegistration();
+
+        var poisonWait = new PoisonAnchor(context).WaitForSynchronizationAsync(cancellationToken);
+        Assert.False(poisonWait.IsCompleted);
+
+        Assert.Throws<InvalidOperationException>(() => hold.Dispose());
+        return poisonWait;
+    }
+
+    /// <summary>
+    /// A source whose initial load never completes, so it stays Synchronizing until it is stopped.
+    /// </summary>
+    /// <remarks><see cref="TestStateSource"/> reaches Synchronized as soon as its pump runs.</remarks>
+    private sealed class NeverLoadingSource(IInterceptorSubject rootSubject) : TestStateSource(rootSubject)
+    {
+        public override async Task<Action?> LoadInitialStateAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="ISubjectSource"/> implemented directly that reports Synchronized while never
+    /// stamping <see cref="ISubjectSource.LastSynchronizedAt"/>, unlike <see cref="SubjectSourceBase"/>.
+    /// </summary>
+    private sealed class TimestamplessSource(IInterceptorSubject rootSubject) : ISubjectSource
+    {
+        public IInterceptorSubject RootSubject { get; } = rootSubject;
+
+        public int WriteBatchSize => 0;
+
+        public SourceState State => SourceState.Synchronized;
+
+        public DateTimeOffset? LastSynchronizedAt => null;
+
+        public int PendingWriteCount => 0;
+
+        public event EventHandler<SourceEvent>? StateChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public Task<Action?> LoadInitialStateAsync(CancellationToken cancellationToken)
+            => Task.FromResult<Action?>(null);
+
+        public ValueTask<WriteResult> WriteChangesAsync(
+            ReadOnlyMemory<SubjectPropertyChange> changes, CancellationToken cancellationToken)
+            => new(WriteResult.Success);
+    }
+}

--- a/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -221,7 +221,7 @@ namespace Namotion.Interceptor.Connectors.Monitoring
         public void Register(Namotion.Interceptor.Connectors.ISubjectSource source) { }
         public Namotion.Interceptor.Connectors.Monitoring.SourceSubscription Subscribe(System.Action<Namotion.Interceptor.Connectors.Monitoring.SourceEvent> handler) { }
         public void Unregister(Namotion.Interceptor.Connectors.ISubjectSource source) { }
-        public System.Threading.Tasks.Task WaitForSynchronizationAsync(Namotion.Interceptor.IInterceptorSubject subject, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Namotion.Interceptor.Connectors.Monitoring.SourceSynchronizationResult> WaitForSynchronizationAsync(Namotion.Interceptor.IInterceptorSubject subject, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public static class SourceMonitoringExtensions
     {
@@ -229,7 +229,7 @@ namespace Namotion.Interceptor.Connectors.Monitoring
         public static System.IDisposable DeferWaitCompletion(this Namotion.Interceptor.IInterceptorSubjectContext context) { }
         public static Namotion.Interceptor.Connectors.Monitoring.SourceMonitor GetSourceMonitor(this Namotion.Interceptor.IInterceptorSubjectContext context) { }
         public static Namotion.Interceptor.Connectors.Monitoring.SourceState GetSourceState(this Namotion.Interceptor.PropertyReference property) { }
-        public static System.Threading.Tasks.Task WaitForSynchronizationAsync(this Namotion.Interceptor.IInterceptorSubject subject, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<Namotion.Interceptor.Connectors.Monitoring.SourceSynchronizationResult> WaitForSynchronizationAsync(this Namotion.Interceptor.IInterceptorSubject subject, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public enum SourceState
     {
@@ -242,6 +242,12 @@ namespace Namotion.Interceptor.Connectors.Monitoring
     {
         public System.Collections.Immutable.ImmutableArray<Namotion.Interceptor.Connectors.ISubjectSource> Sources { get; }
         public void Dispose() { }
+    }
+    public enum SourceSynchronizationResult
+    {
+        Incomplete = 0,
+        Stale = 1,
+        Synchronized = 2,
     }
 }
 namespace Namotion.Interceptor.Connectors.Paths

--- a/src/Namotion.Interceptor.Connectors/ISubjectSource.cs
+++ b/src/Namotion.Interceptor.Connectors/ISubjectSource.cs
@@ -65,6 +65,14 @@ public interface ISubjectSource : ISubjectConnector
     /// While <see cref="SourceState.Synchronizing"/> after a drop, this is how a dashboard says
     /// "stale, last confirmed at T".
     /// </summary>
+    /// <remarks>
+    /// Load-bearing, not only diagnostic: branch waits use it to tell a source that stopped having
+    /// delivered from one that never did. An implementation reaching
+    /// <see cref="SourceState.Synchronized"/> must stamp it, never clear it, and make the stamp
+    /// visible before <see cref="State"/> becomes <see cref="SourceState.Stopped"/>, or every branch
+    /// it participates in reports <see cref="SourceSynchronizationResult.Incomplete"/> once it stops.
+    /// Only a stopped source's value is read, so <c>null</c> while synchronized costs nothing.
+    /// </remarks>
     DateTimeOffset? LastSynchronizedAt { get; }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitor.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitor.cs
@@ -281,14 +281,24 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
     private readonly Stack<IInterceptorSubject> _scopePendingScratch = new();
 
 
+    // Indexed by (int)SourceSynchronizationResult. Task.FromResult caches only the default value of
+    // an enum, so Stale and Synchronized would allocate on every already-satisfied call without this.
+    private static readonly Task<SourceSynchronizationResult>[] CompletedResults =
+    [
+        Task.FromResult(SourceSynchronizationResult.Incomplete),
+        Task.FromResult(SourceSynchronizationResult.Stale),
+        Task.FromResult(SourceSynchronizationResult.Synchronized)
+    ];
+
     /// <summary>
-    /// Completes when the branch containing <paramref name="subject"/> is synchronized: registration
-    /// is complete, and no in-scope source is Synchronizing. An empty in-scope set is vacuously
+    /// Completes when the branch containing <paramref name="subject"/> has settled: registration is
+    /// complete, and no in-scope source is Synchronizing. An empty in-scope set is vacuously
     /// satisfied once registration is complete (see IsBranchSynchronized); before that, it blocks,
     /// since an empty scope is still ambiguous between "no source yet" and "no source ever" at that
-    /// point.
+    /// point. The result says whether every in-scope source delivered its initial load, and whether
+    /// they are all still live.
     /// </summary>
-    public Task WaitForSynchronizationAsync(
+    public Task<SourceSynchronizationResult> WaitForSynchronizationAsync(
         IInterceptorSubject subject, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(subject);
@@ -299,9 +309,9 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
             // Checked first with no PendingWait allocated: the common case for an application
             // re-awaiting per operation is already satisfied. Only the unsatisfied path below
             // allocates a PendingWait and its TaskCompletionSource.
-            if (IsBranchSynchronized(subject))
+            if (IsBranchSynchronized(subject, out var result))
             {
-                return Task.CompletedTask;
+                return CompletedResults[(int)result];
             }
 
             wait = new PendingWait(subject);
@@ -319,14 +329,30 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
 
     /// <summary>
     /// Whether a wait anchored on <paramref name="anchor"/> may complete: registration is complete,
-    /// and no source in scope of the anchor is still Synchronizing.
+    /// and no source in scope of the anchor is still Synchronizing. When it may, <paramref name="result"/>
+    /// carries the verdict; when it may not, <paramref name="result"/> is meaningless and callers
+    /// must ignore it, since a downgrade can already have been applied before the early return.
     /// </summary>
-    private bool IsBranchSynchronized(IInterceptorSubject anchor)
+    /// <remarks>
+    /// State and LastSynchronizedAt are read lock-free per source, so the verdict is a walk-consistent
+    /// snapshot rather than an atomic instant: a source visited early can stop before the walk ends,
+    /// leaving the result one grade better than the truth. That is indistinguishable from completing
+    /// an instant earlier. It cannot err the other way for a SubjectSourceBase, whose Stopped can
+    /// never carry a stale null timestamp, since that transition takes the state lock after the one
+    /// that stamped the ticks.
+    /// </remarks>
+    private bool IsBranchSynchronized(IInterceptorSubject anchor, out SourceSynchronizationResult result)
     {
+        // Assigned once, on the true path only, so every false path leaves the most pessimistic
+        // answer for a caller that ignores the contract above.
+        result = SourceSynchronizationResult.Incomplete;
+
         if (!IsRegistrationComplete)
         {
             return false;
         }
+
+        var verdict = SourceSynchronizationResult.Synchronized;
 
         foreach (var source in _sources[0])
         {
@@ -336,13 +362,33 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
             }
 
             var state = source.State;
-            // Reads as "this source has not settled yet". Only Synchronized and Stopped let a wait
-            // through, so the pair of inequalities is exactly "the source is still Synchronizing".
-            if (state != SourceState.Stopped && state != SourceState.Synchronized)
+
+            // Returns before any timestamp is read, which is what keeps an implementation that
+            // reports Synchronized without stamping one from being read as a failure. It also hides
+            // TransitionStateTo's window between publishing Synchronized and stamping the ticks.
+            if (state == SourceState.Synchronized)
+            {
+                continue;
+            }
+
+            // Not settled, so block rather than answer. The only early return: after a downgrade the
+            // walk must go on, because a later source may still be loading.
+            if (state != SourceState.Stopped)
             {
                 return false;
             }
+
+            var downgrade = source.LastSynchronizedAt is not null
+                ? SourceSynchronizationResult.Stale
+                : SourceSynchronizationResult.Incomplete;
+
+            if (downgrade < verdict)
+            {
+                verdict = downgrade;
+            }
         }
+
+        result = verdict;
 
         // An empty scope, and a scope whose sources have all Stopped, both complete rather than
         // block. Once the application has declared registration complete it has asserted its sources
@@ -390,9 +436,9 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
             {
                 try
                 {
-                    if (IsBranchSynchronized(wait.Anchor))
+                    if (IsBranchSynchronized(wait.Anchor, out var result))
                     {
-                        wait.Complete();
+                        wait.Complete(result);
                     }
                 }
                 catch (Exception exception)
@@ -407,17 +453,23 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
 
     private sealed class PendingWait(IInterceptorSubject anchor)
     {
-        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<SourceSynchronizationResult> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public IInterceptorSubject Anchor { get; } = anchor;
 
-        public void Complete() => _completion.TrySetResult();
+        /// <summary>
+        /// First verdict wins. A completed wait leaves _waits asynchronously, so a later pass can
+        /// reach it and offer a different verdict; TrySetResult drops it.
+        /// </summary>
+        public void Complete(SourceSynchronizationResult result) => _completion.TrySetResult(result);
 
-        public async Task AwaitAsync(CancellationToken cancellationToken, Action onFinished)
+        public async Task<SourceSynchronizationResult> AwaitAsync(
+            CancellationToken cancellationToken, Action onFinished)
         {
             try
             {
-                await _completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                return await _completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitoringExtensions.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitoringExtensions.cs
@@ -87,22 +87,51 @@ public static class SourceMonitoringExtensions
     }
 
     /// <summary>
-    /// Waits until every source that can claim into this subject's branch has completed its initial
-    /// load. The subject IS the scope, so waiting on the tree root means the whole tree.
+    /// Waits until every source that can claim into this subject's branch has settled, and reports
+    /// whether they all delivered their initial load and are all still live. The subject IS the
+    /// scope, so waiting on the tree root means the whole tree.
     /// </summary>
     /// <exception cref="InvalidOperationException">No monitor is reachable from the subject's context.</exception>
-    public static Task WaitForSynchronizationAsync(
+    public static Task<SourceSynchronizationResult> WaitForSynchronizationAsync(
         this IInterceptorSubject subject, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(subject);
 
+        // Outside the async helper, so a null subject and an unreachable monitor keep throwing
+        // synchronously rather than surfacing on await.
         var monitors = ResolveMonitorsOrThrow(subject.Context);
-        if (monitors.Length == 1)
+        return monitors.Length == 1
+            ? monitors[0].WaitForSynchronizationAsync(subject, cancellationToken)
+            : WaitForAllMonitorsAsync(monitors, subject, cancellationToken);
+    }
+
+    /// <summary>
+    /// Worst wins across monitors, which is a minimum over the result values.
+    /// </summary>
+    /// <remarks>
+    /// Every wait is created before the first await: awaiting them one at a time would leave the
+    /// later monitors unregistered until the earlier ones completed.
+    /// </remarks>
+    private static async Task<SourceSynchronizationResult> WaitForAllMonitorsAsync(
+        ImmutableArray<SourceMonitor> monitors, IInterceptorSubject subject, CancellationToken cancellationToken)
+    {
+        var waits = new Task<SourceSynchronizationResult>[monitors.Length];
+        for (var index = 0; index < monitors.Length; index++)
         {
-            return monitors[0].WaitForSynchronizationAsync(subject, cancellationToken);
+            waits[index] = monitors[index].WaitForSynchronizationAsync(subject, cancellationToken);
         }
 
-        return Task.WhenAll(monitors.Select(
-            monitor => monitor.WaitForSynchronizationAsync(subject, cancellationToken)));
+        var results = await Task.WhenAll(waits).ConfigureAwait(false);
+
+        var worst = SourceSynchronizationResult.Synchronized;
+        foreach (var result in results)
+        {
+            if (result < worst)
+            {
+                worst = result;
+            }
+        }
+
+        return worst;
     }
 }

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceSynchronizationResult.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceSynchronizationResult.cs
@@ -1,0 +1,35 @@
+namespace Namotion.Interceptor.Connectors.Monitoring;
+
+/// <summary>
+/// Why a synchronization wait completed: whether every source on the awaited branch delivered its
+/// initial load, and whether they are all still live.
+/// </summary>
+/// <remarks>
+/// Answers per source, not per property: whether every in-scope source completed its initial load,
+/// not whether every property holds a value from the external system. See the source monitoring
+/// documentation.
+/// <para>
+/// Do not reorder the members. Worst-wins aggregation is a minimum over them, and Incomplete at zero
+/// makes the CLR default the most pessimistic answer.
+/// </para>
+/// </remarks>
+public enum SourceSynchronizationResult
+{
+    /// <summary>
+    /// At least one in-scope source stopped having never synchronized, so part of the branch never
+    /// received data and may still hold CLR defaults.
+    /// </summary>
+    Incomplete = 0,
+
+    /// <summary>
+    /// Every in-scope source synchronized at least once, but at least one has since stopped, so the
+    /// values are real and possibly out of date.
+    /// </summary>
+    Stale = 1,
+
+    /// <summary>
+    /// Every in-scope source completed its initial load and is still live. Also the answer for a
+    /// branch with no source in scope, which is why this is not proof that a source exists.
+    /// </summary>
+    Synchronized = 2
+}

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -130,33 +130,44 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
         }
         catch
         {
-            // A half-registered source that never pumps hangs every in-scope wait, which is worse
-            // than not being monitored at all. Unwind and let the failure propagate.
-            ImmutableInterlocked.InterlockedExchange(ref _registeredMonitors, ImmutableArray<SourceMonitor>.Empty);
-            foreach (var monitor in monitors)
+            // Read before the transition below sets it, so Stopped still means Dispose, whose own
+            // unwind may have found nothing registered yet.
+            if (State == SourceState.Stopped)
             {
-                monitor.Unregister(this);
+                UnwindRegistrations(monitors);
+                throw;
             }
 
+            // This source will never pump. Reporting a stop keeps it in scope as never-synchronized,
+            // so in-scope waits answer Incomplete; unwinding left them on a vacuous Synchronized.
+            // Nothing unregisters it until Dispose, which a graph-attached source may never get.
+            TransitionStateTo(SourceState.Stopped);
             throw;
         }
 
-        // Dispose can interleave with the registration above. Stopped is terminal, so seeing it here
-        // means Dispose already ran: unwind what was just registered. Through the LOCAL array, not
-        // the field, which Dispose has already emptied - re-reading it would strand these
-        // registrations. Unregister no-ops on an unregistered source, so a double unwind is safe.
+        // Dispose can interleave with the registration above, and Stopped is terminal, so seeing it
+        // here means Dispose already ran.
         if (State == SourceState.Stopped)
         {
-            ImmutableInterlocked.InterlockedExchange(ref _registeredMonitors, ImmutableArray<SourceMonitor>.Empty);
-            foreach (var monitor in monitors)
-            {
-                monitor.Unregister(this);
-            }
-
+            UnwindRegistrations(monitors);
             return Task.CompletedTask;
         }
 
         return base.StartAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Drops the registrations <see cref="StartAsync"/> just made, through its LOCAL array rather
+    /// than the field, which a concurrent <see cref="Dispose"/> may already have emptied: re-reading
+    /// it would strand them. Unregister no-ops on an unregistered source, so a double unwind is safe.
+    /// </summary>
+    private void UnwindRegistrations(ImmutableArray<SourceMonitor> monitors)
+    {
+        ImmutableInterlocked.InterlockedExchange(ref _registeredMonitors, ImmutableArray<SourceMonitor>.Empty);
+        foreach (var monitor in monitors)
+        {
+            monitor.Unregister(this);
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Problem

`WaitForSynchronizationAsync` returned `Task` and completed when no in-scope source was still `Synchronizing`, which means `Synchronized` and `Stopped` both let it through. The caller learned that the branch settled and nothing else, so it could not distinguish:

- a source that **synchronized and then stopped**, whose properties hold values that came from the external system and may now be out of date, which is safe to persist
- a source that **stopped having never synchronized**, whose properties still hold CLR defaults, where a persist step writes those defaults over whatever was stored before

The second case is silent data loss and there was no way to detect it from the wait.

## Change

The wait returns `Task<SourceSynchronizationResult>`. Completion timing is unchanged.

| in-scope sources when the wait completes | result |
|---|---|
| all currently `Synchronized` | `Synchronized` |
| none (empty scope) | `Synchronized` |
| all synchronized at least once, at least one now `Stopped` | `Stale` |
| at least one `Stopped` that never synchronized | `Incomplete` |

Worst wins within a branch and across monitors. `Incomplete` is the enum's zero value, so an unassigned field defaults to the most pessimistic answer.

The verdict is computed inside the scope walk that already decides completion, so the re-evaluation path that runs on every property-reference add or remove while a wait is pending stays allocation-free. The already-satisfied fast path returns cached tasks, because `Task.FromResult` caches only an enum's default value, so `Stale` and `Synchronized` would otherwise allocate on every call.

## Registration failure no longer reports success

A source whose `Register` throws was unwound out of every monitor while still `Synchronizing`, so its branch reported an empty scope and answered a vacuous `Synchronized`. It is now reported as stopped-without-synchronizing and stays registered, so the branch answers `Incomplete`.

The unwind was correct on its own terms: while a registered source stuck at `Synchronizing` could only hang an in-scope wait forever, not being monitored really was the lesser evil. Having a verdict to report makes a third option available.

The unwind is kept for the case it was really guarding, which review caught this change dropping. `Dispose` can complete before `StartAsync` assigns the monitor list, so its own unwind finds nothing registered and this method then registers anyway. Without the unwind that source stays in the monitor for the process lifetime, leaked and pinning its branch to `Incomplete`. The state is read before the transition sets it, so `Stopped` still means `Dispose`, and a race test covers both landings.

## `LastSynchronizedAt` becomes load-bearing

It is the only thing separating `Stale` from `Incomplete`, so it is now a correctness obligation for direct `ISubjectSource` implementers rather than a dashboard aid, documented on the interface and in `connectors.md`. An implementation that reaches `Synchronized` must stamp it, never clear it, and make the stamp visible no later than `State` becomes `Stopped`, since that is the ordering the walk relies on. Only a stopped source's value is read this way, so returning `null` while synchronized costs nothing.

No in-repo source is affected: `SubjectSourceBase` stamps correctly, and the direct implementations that return a hardcoded `null` are all test and benchmark doubles that never report `Synchronized`.

Its monotonicity across the stop had no coverage: the existing assertion read the timestamp after `ReportStopped()` and compared it to a later post-stop read, so it would pass just as happily against an implementation that cleared the field. That is now pinned.

## What the result deliberately does not claim

Documented in `connectors-monitoring.md` rather than left implicit:

- **It is per source, not per property.** It answers whether every source completed its initial load, not whether every property holds a value from the external system. A load that resolved only some nodes still reports `Synchronized`, and a source that claimed nothing and stopped still reports `Incomplete`.
- **`Synchronized` is not proof a source exists.** An empty scope reports it, and so does a branch whose failed source was disposed, since disposal unregisters.
- **`Incomplete` is not "not yet".** `Stopped` is terminal, so awaiting again returns it immediately. Handle it in a switch, not a retry loop.
- **Host shutdown moves a branch through all three answers.** `ApplicationStopping` fires before hosted services stop, so a consumer hooked there still sees `Synchronized`; after they stop it sees `Stale`; once the container disposes them they unregister and the empty scope reads `Synchronized` again. A consumer running during shutdown must treat `Stale` as a success and read `Synchronized` as proof of nothing.

## Breaking change

`Task` becomes `Task<SourceSynchronizationResult>` on `SourceMonitor` and the `IInterceptorSubject` extension. Binary breaking, source compatible for every existing call site, since `await` may discard the result and `Task<T>` satisfies the `Func<Task>` and `.WaitAsync`/`.IsCompleted` uses in the tests. No production callers existed.

## Size

| | lines |
|---|---|
| Production code | +170 / -29, across 5 files |
| Tests | +620 / -0, across 2 files |
| Public API snapshot (generated) | +8 / -2 |
| Documentation | +37 / -5, across 2 files |

Production code splits as +35 for the new enum, +69 / -17 in `SourceMonitor`, +36 / -7 in `SourceMonitoringExtensions`, +19 / -5 for the registration-failure path in `SubjectSourceBase`, and +11 of interface documentation.

## Verification

- Full solution: 3057 unit tests, 0 failures
- `Namotion.Interceptor.OpcUa.Tests` including integration, against real sessions on port 4840: 295 tests, 0 failures
- Public API snapshot re-accepted; the diff is the two return types plus the new enum, whose member values the snapshot now pins against reordering
- Two independent review passes over the full diff. Both are reflected in the branch: the first found that the registration-failure path had dropped an unwind master performed, the second found comment drift from a subsequent editing pass plus two untested invariants
- The eager task creation in the multi-monitor aggregation is verified by mutation: replacing it with a sequential await makes `WhenAMonitorIsSatisfiedOnlyBriefly_ThenTheAggregationHasAlreadyCapturedIt` fail

The API itself states only what each answer means about the sources; what a consumer does with `Stale` or `Incomplete` is left to the call site. Persisting is one such consumer and is used above only to motivate the problem.
