### PR TITLE
fix: Clean up after attached hosted service starts that never run

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -144,9 +144,11 @@ await person.AttachHostedServiceAsync(
 
 Attaching a hosted service queues its `StartAsync` rather than running it inline, so the service is not running when the attach returns. Any subsystem that treats "the graph has finished starting" as a completion point would otherwise pass that point while a queued start is still on its way in.
 
-A subsystem says so by implementing `IStartupCompletionDeferrer` and registering it on the context. Before queueing a start, the hosting layer takes a hold on every reachable deferrer and releases it once the start has actually run, including when the start throws. Both attach paths do this, awaiting and fire-and-forget alike: awaiting the start blocks the caller, but it does not block whatever else is deciding that startup is finished, so the gap still needs holding open.
+A subsystem says so by implementing `IStartupCompletionDeferrer` and registering it on the context. Before queueing a start, the hosting layer takes a hold on every reachable deferrer and releases it once the start has actually run, including when the start throws and when the host stopped before the start could run. Both attach paths do this, awaiting and fire-and-forget alike: awaiting the start blocks the caller, but it does not block whatever else is deciding that startup is finished, so the gap still needs holding open.
 
 Holds are counted, so nested attaches compose: a service that attaches children during its own `StartAsync` takes their holds before its own is released.
+
+A start queued against a host that is already stopping never runs, so `AttachHostedServiceAsync` throws `OperationCanceledException` rather than waiting for a service that will not start.
 
 `SourceMonitor` is the one implementation in this repository. It is what makes an attached source count towards source registration from the moment it is attached rather than from the moment it finally starts, so a synchronization wait cannot complete against a tree whose sources have not registered yet. See [Applications That Create Sources at Runtime](connectors-monitoring.md#applications-that-create-sources-at-runtime).
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceDisposeIsolationTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceDisposeIsolationTests.cs
@@ -1,0 +1,105 @@
+using Namotion.Interceptor.Connectors.Monitoring;
+using Namotion.Interceptor.Connectors.Tests.Models;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Lifecycle;
+
+namespace Namotion.Interceptor.Connectors.Tests;
+
+public class SourceDisposeIsolationTests
+{
+    private static IInterceptorSubjectContext CreateContext() =>
+        InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithRegistry()
+            .WithLifecycle()
+            .WithSourceMonitoring();
+
+    [Fact]
+    public async Task WhenOneMonitorsUnregisterThrows_ThenTheOtherMonitorStillUnregisters()
+    {
+        // Arrange
+        // What the first throw skips can never be unwound later, so it stays registered for good,
+        // holding the source and the subtree under its root.
+        var parent = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithRegistry()
+            .WithLifecycle()
+            .WithSourceMonitoring();
+        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        child.AddFallbackContext(parent);
+
+        var root = new Person(child);
+        var source = new TestStateSource(root);
+
+        // The order the source itself unwinds in. Arming the first is what makes a throw skip one.
+        var monitors = ((IInterceptorSubject)root).Context.GetServices<SourceMonitor>();
+        Assert.Equal(2, monitors.Length);
+
+        // Started rather than registered by hand: only StartAsync records the monitors on the source,
+        // and Dispose unwinds that record, so a hand-registered source would have nothing to unwind.
+        await source.StartAsync(CancellationToken.None);
+        foreach (var monitor in monitors)
+        {
+            monitor.CompleteSourceRegistration();
+        }
+
+        ArmThrowingUnregister(monitors[0], child);
+
+        // Act
+        Assert.ThrowsAny<Exception>(source.Dispose);
+
+        // Assert
+        foreach (var monitor in monitors)
+        {
+            Assert.DoesNotContain(source, monitor.Sources);
+        }
+    }
+
+    [Fact]
+    public async Task WhenUnregisterThrowsOnDispose_ThenThePumpIsStillCancelled()
+    {
+        // Arrange
+        // The unregister loop runs before the base disposal that cancels the pump's token source, so
+        // a throw used to leave a "disposed" source still pumping.
+        var context = CreateContext();
+        var monitor = context.GetSourceMonitor();
+        var root = new Person(context);
+        var source = new TestStateSource(root);
+        await source.StartAsync(CancellationToken.None);
+        monitor.CompleteSourceRegistration();
+
+        ArmThrowingUnregister(monitor, context);
+
+        // Act
+        Assert.ThrowsAny<Exception>(source.Dispose);
+
+        // Assert
+        Assert.NotNull(source.ExecuteTask);
+        await source.ExecuteTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Leaves <paramref name="monitor"/> with a pending wait whose scope walk throws, which is what
+    /// makes its <c>Unregister</c> throw.
+    /// </summary>
+    private static void ArmThrowingUnregister(SourceMonitor monitor, IInterceptorSubjectContext context)
+    {
+        // The walk runs per registered source, so without a source that outlives the one under test
+        // it would stop throwing the moment that one is unregistered, which is exactly when the
+        // throw has to happen. Rooted on an unrelated subject, so it is in no other test's scope.
+        monitor.Register(new TestStateSource(new Person(context)));
+
+        // The hold keeps registration incomplete while the wait is created, so its own fast-path
+        // check short-circuits before walking any scope. Releasing it triggers the first walk.
+        var hold = monitor.DeferWaitCompletion();
+        monitor.CompleteSourceRegistration();
+
+        // On the monitor directly, not through the subject extension, which would create a wait on
+        // every reachable monitor and throw out of the arming itself.
+        var poisonWait = monitor.WaitForSynchronizationAsync(new PoisonAnchor(context), CancellationToken.None);
+        Assert.False(poisonWait.IsCompleted);
+
+        Assert.ThrowsAny<Exception>(hold.Dispose);
+    }
+}

--- a/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitor.cs
+++ b/src/Namotion.Interceptor.Connectors/Monitoring/SourceMonitor.cs
@@ -428,7 +428,7 @@ public class SourceMonitor : ILifecycleHandler, IStartupCompletionDeferrer
 
             // A throw from one wait's IsBranchSynchronized must not skip re-evaluating the rest -
             // that would be a lost wakeup for every wait after it. Written out rather than delegated to
-            // ExceptionAggregation.ForEach, unlike the two cold call sites: this runs on every
+            // ExceptionAggregation.ForEach, unlike the cold call sites: this runs on every
             // property-reference add/remove tree-wide while any wait is pending, and the helper's
             // IEnumerable<T> parameter would box the ImmutableArray, heap-allocate its enumerator,
             // and allocate a closure per pass, since the lambda captures this.

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -134,7 +134,16 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
             // unwind may have found nothing registered yet.
             if (State == SourceState.Stopped)
             {
-                UnwindRegistrations(monitors);
+                try
+                {
+                    UnwindRegistrations(monitors);
+                }
+                catch (Exception unwindException)
+                {
+                    // Logged, not thrown: it would replace the registration failure being propagated.
+                    _logger.LogError(unwindException, "Unwinding a failed source registration threw.");
+                }
+
                 throw;
             }
 
@@ -164,11 +173,16 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
     private void UnwindRegistrations(ImmutableArray<SourceMonitor> monitors)
     {
         ImmutableInterlocked.InterlockedExchange(ref _registeredMonitors, ImmutableArray<SourceMonitor>.Empty);
-        foreach (var monitor in monitors)
-        {
-            monitor.Unregister(this);
-        }
+        UnregisterFromAll(monitors);
     }
+
+    /// <summary>
+    /// Isolated per monitor: Unregister re-evaluates pending waits, so a poisoned anchor makes it
+    /// throw, and both callers have already taken and cleared the field, so whatever a first throw
+    /// skipped could never be unwound afterwards.
+    /// </summary>
+    private void UnregisterFromAll(ImmutableArray<SourceMonitor> monitors)
+        => ExceptionAggregation.ForEach(monitors, monitor => monitor.Unregister(this));
 
     /// <inheritdoc />
     protected sealed override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -636,12 +650,23 @@ public abstract class SubjectSourceBase : BackgroundService, ISubjectSource
         // on a later call, and so the field is never read while another thread is writing it.
         var monitors = ImmutableInterlocked.InterlockedExchange(
             ref _registeredMonitors, ImmutableArray<SourceMonitor>.Empty);
-        foreach (var monitor in monitors)
-        {
-            monitor.Unregister(this);
-        }
 
-        WriteRetryQueue?.Dispose();
-        base.Dispose();
+        try
+        {
+            UnregisterFromAll(monitors);
+        }
+        finally
+        {
+            // base.Dispose cancels the pump's token source, so nothing may skip it: a disposed
+            // source that keeps pumping is what this guards against.
+            try
+            {
+                WriteRetryQueue?.Dispose();
+            }
+            finally
+            {
+                base.Dispose();
+            }
+        }
     }
 }

--- a/src/Namotion.Interceptor.Hosting.Tests/StartupHoldReleaseTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/StartupHoldReleaseTests.cs
@@ -1,0 +1,219 @@
+using Microsoft.Extensions.Hosting;
+using Namotion.Interceptor.Hosting.Tests.Models;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Lifecycle;
+
+namespace Namotion.Interceptor.Hosting.Tests;
+
+/// <summary>
+/// Covers the paths where an attached service's queued start never runs, which used to leak its
+/// startup-completion hold.
+/// </summary>
+public class StartupHoldReleaseTests
+{
+    [Fact]
+    public async Task WhenAServiceIsAttachedAfterTheHostStopped_ThenItsStartupHoldIsStillReleased()
+    {
+        // Arrange
+        var deferrer = new CountingDeferrer();
+        var (context, host) = await CreateStartedHostAsync(deferrer);
+        await host.StopAsync();
+
+        // Act - the queue is no longer drained, so this start will never run.
+        var person = new Person(context);
+        person.AttachHostedService(new PersonBackgroundService(person));
+
+        // Assert - synchronous on this path, since StopAsync has already awaited the pump.
+        Assert.Equal(0, deferrer.OutstandingHolds);
+    }
+
+    [Fact]
+    public async Task WhenAStartIsStillQueuedAsTheHostStops_ThenItsStartupHoldIsStillReleased()
+    {
+        // Arrange
+        // The case the tracking exists for. Starts run one at a time, so parking the first leaves the
+        // second sitting in the queue; the pump then exits without ever dequeuing it, and its holds
+        // live only in a closure nobody will run.
+        var deferrer = new CountingDeferrer();
+        var (context, host) = await CreateStartedHostAsync(deferrer);
+
+        using var firstEntered = new ManualResetEventSlim(false);
+        using var releaseFirst = new ManualResetEventSlim(false);
+        var person = new Person(context);
+        person.AttachHostedService(new GatedHostedService(firstEntered, releaseFirst));
+        Assert.True(firstEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        person.AttachHostedService(new PersonBackgroundService(person));
+        Assert.Equal(2, deferrer.TakenCount);
+
+        // Act - the queued second start is abandoned when the pump exits.
+        var stopping = host.StopAsync();
+        releaseFirst.Set();
+        await stopping;
+
+        // Assert
+        await AsyncTestHelpers.WaitUntilAsync(() => deferrer.OutstandingHolds == 0);
+    }
+
+    [Fact]
+    public async Task WhenAnAwaitedAttachIsAbandoned_ThenTheCallerIsUnblockedRatherThanLeftWaiting()
+    {
+        // Arrange
+        var deferrer = new CountingDeferrer();
+        var (context, host) = await CreateStartedHostAsync(deferrer);
+        await host.StopAsync();
+
+        // Act & Assert - the start will never run, so the awaiter has to be released rather than
+        // left waiting on a completion nothing will ever set. Timed out rather than left to hang, so
+        // a regression here fails CI instead of wedging it.
+        var person = new Person(context);
+        var attach = person.AttachHostedServiceAsync(new PersonBackgroundService(person), CancellationToken.None);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => attach.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task WhenAnAwaitedAttachIsStillQueuedAsTheHostStops_ThenTheCallerIsUnblocked()
+    {
+        // Arrange
+        // The sweep's own completion path, which the test above does not reach: there the host had
+        // already stopped, so the attach never reached the queue at all.
+        var deferrer = new CountingDeferrer();
+        var (context, host) = await CreateStartedHostAsync(deferrer);
+
+        using var firstEntered = new ManualResetEventSlim(false);
+        using var releaseFirst = new ManualResetEventSlim(false);
+        var person = new Person(context);
+        person.AttachHostedService(new GatedHostedService(firstEntered, releaseFirst));
+        Assert.True(firstEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        // Queued behind the parked start, so the pump exits without ever dequeuing it.
+        var attach = person.AttachHostedServiceAsync(
+            new PersonBackgroundService(person), CancellationToken.None);
+
+        // Act
+        var stopping = host.StopAsync();
+        releaseFirst.Set();
+        await stopping;
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => attach.WaitAsync(TimeSpan.FromSeconds(5)));
+        await AsyncTestHelpers.WaitUntilAsync(() => deferrer.OutstandingHolds == 0);
+    }
+
+    [Fact]
+    public async Task WhenTheHostIsDisposedWhileAStartIsRunning_ThenThatStartsHoldIsNotReleasedEarly()
+    {
+        // Arrange
+        // Disposal must not open the completion gate for a start that is still executing, which is
+        // the very thing the hold exists to prevent. Disposing does not wait for the pump, so the
+        // sweep has to leave a running start's hold alone and let the start release it itself.
+        var deferrer = new CountingDeferrer();
+        var (context, host) = await CreateStartedHostAsync(deferrer);
+
+        using var startEntered = new ManualResetEventSlim(false);
+        using var releaseStart = new ManualResetEventSlim(false);
+        var person = new Person(context);
+        person.AttachHostedService(new GatedHostedService(startEntered, releaseStart));
+
+        Assert.True(startEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        // Act
+        host.Dispose();
+
+        // Assert
+        Assert.Equal(1, deferrer.OutstandingHolds);
+
+        releaseStart.Set();
+        await AsyncTestHelpers.WaitUntilAsync(() => deferrer.OutstandingHolds == 0);
+    }
+
+    [Fact]
+    public async Task WhenAnAttachedServiceStartsNormally_ThenItsStartupHoldIsReleasedExactlyOnce()
+    {
+        // Arrange
+        var deferrer = new CountingDeferrer();
+        var (context, host) = await CreateStartedHostAsync(deferrer);
+
+        // Act
+        var person = new Person(context);
+        await person.AttachHostedServiceAsync(new PersonBackgroundService(person), CancellationToken.None);
+
+        // Assert
+        await AsyncTestHelpers.WaitUntilAsync(() => deferrer.OutstandingHolds == 0);
+        await host.StopAsync();
+        Assert.Equal(1, deferrer.TakenCount);
+
+        // The raw count, since the latch would hide the sweep releasing what the start released.
+        Assert.Equal(1, deferrer.DisposeCallCount);
+    }
+
+    private static async Task<(IInterceptorSubjectContext Context, IHost Host)> CreateStartedHostAsync(
+        CountingDeferrer deferrer)
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithHostedServices(builder.Services);
+
+        context.AddService(deferrer);
+
+        var host = builder.Build();
+        await host.StartAsync();
+        return (context, host);
+    }
+
+    /// <summary>A service whose start parks until released, so a start can be caught mid-flight.</summary>
+    private sealed class GatedHostedService(ManualResetEventSlim entered, ManualResetEventSlim release) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            entered.Set();
+            release.Wait(TimeSpan.FromSeconds(30));
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>Stands in for the real deferrer, counting holds instead of gating anything.</summary>
+    private sealed class CountingDeferrer : IStartupCompletionDeferrer
+    {
+        private int _taken;
+        private int _released;
+        private int _disposeCalls;
+
+        public int TakenCount => Volatile.Read(ref _taken);
+
+        public int OutstandingHolds => TakenCount - Volatile.Read(ref _released);
+
+        /// <summary>Every Dispose call, latched or not, so a double release is visible.</summary>
+        public int DisposeCallCount => Volatile.Read(ref _disposeCalls);
+
+        public IDisposable DeferCompletion()
+        {
+            Interlocked.Increment(ref _taken);
+            return new Hold(this);
+        }
+
+        private sealed class Hold(CountingDeferrer deferrer) : IDisposable
+        {
+            private int _disposed;
+
+            public void Dispose()
+            {
+                Interlocked.Increment(ref deferrer._disposeCalls);
+
+                // Latched like the real hold.
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                {
+                    Interlocked.Increment(ref deferrer._released);
+                }
+            }
+        }
+    }
+}

--- a/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
@@ -19,6 +19,12 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     private readonly BufferBlock<Func<CancellationToken, Task>> _actions = new();
     private readonly HashSet<IHostedService> _hostedServices = [];
 
+    // A second owner for the cleanup a queued start carries in its closure: the pump abandons
+    // whatever is still buffered when it exits, and an unreleased hold blocks every wait on the tree
+    // forever while an unfinished completion blocks its awaiter just as long.
+    private readonly HashSet<PendingStart> _pendingStarts = [];
+    private volatile bool _stopped;
+
     public HostedServiceHandler(Func<ILogger?> loggerResolver)
     {
         _loggerResolver = loggerResolver;
@@ -74,22 +80,30 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
 
     private async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger ??= _loggerResolver();
-
-        while (!stoppingToken.IsCancellationRequested)
+        try
         {
-            try
+            _logger ??= _loggerResolver();
+
+            while (!stoppingToken.IsCancellationRequested)
             {
-                var action = await _actions.ReceiveAsync(stoppingToken);
-                await action(stoppingToken);
-            }
-            catch (Exception exception)
-            {
-                if (exception is not OperationCanceledException)
+                try
                 {
-                    _logger?.LogError(exception, "Failed to execute hosted service action.");
+                    var action = await _actions.ReceiveAsync(stoppingToken);
+                    await action(stoppingToken);
+                }
+                catch (Exception exception)
+                {
+                    if (exception is not OperationCanceledException)
+                    {
+                        _logger?.LogError(exception, "Failed to execute hosted service action.");
+                    }
                 }
             }
+        }
+        finally
+        {
+            _stopped = true;
+            ReleaseAbandonedStarts();
         }
     }
 
@@ -241,8 +255,19 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     }
 
     private void PostStartService(
-        IHostedService hostedService, TaskCompletionSource? tcs, IDisposable[]? startupHolds = null)
+        IHostedService hostedService, TaskCompletionSource? tcs, IDisposable[] startupHolds)
     {
+        var pending = Track(startupHolds, tcs);
+
+        // Read after the add, which is what makes it decisive: the add happens inside the lock the
+        // sweep takes after setting _stopped, so lock release and acquire order that write ahead of
+        // this read.
+        if (_stopped)
+        {
+            Abandon(pending);
+            return;
+        }
+
         _actions.Post(async token =>
         {
             try
@@ -259,29 +284,121 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
             }
             finally
             {
-                // In a finally, so a start that throws or is cancelled releases its hold too.
-                // Leaking a hold would block every synchronization wait on the tree forever - a
-                // hang rather than a wrong answer, which is the safer direction, but still a hang.
-                if (startupHolds is not null)
+                // In a finally, so a start that throws or is cancelled releases its holds too. The
+                // completion is already set by the paths above.
+                if (Claim(pending))
                 {
-                    foreach (var hold in startupHolds)
-                    {
-                        try
-                        {
-                            hold.Dispose();
-                        }
-                        catch (Exception holdException)
-                        {
-                            // One deferrer throwing must not strand the others: a leaked hold blocks
-                            // every wait on that tree forever. Logged rather than swallowed, since
-                            // this used to surface through the action loop.
-                            _logger?.LogError(
-                                holdException, "Releasing a startup completion hold threw and was ignored.");
-                        }
-                    }
+                    ReleaseHolds(pending!);
                 }
             }
         });
+    }
+
+    /// <summary>
+    /// Records what a queued start would leave behind if it never ran, or null when there is nothing
+    /// to clean up. That is the common case, a fire-and-forget attach in an application with no
+    /// deferrer, and it costs one length check and no lock.
+    /// </summary>
+    private PendingStart? Track(IDisposable[] startupHolds, TaskCompletionSource? completion)
+    {
+        if (startupHolds.Length == 0 && completion is null)
+        {
+            return null;
+        }
+
+        var pending = new PendingStart(startupHolds, completion);
+        lock (_pendingStarts)
+        {
+            _pendingStarts.Add(pending);
+        }
+
+        return pending;
+    }
+
+    /// <summary>
+    /// Takes ownership of a pending start's cleanup: only the caller that removes it cleans up, so
+    /// the sweep and the queued action can never both do it.
+    /// </summary>
+    private bool Claim(PendingStart? pending)
+    {
+        if (pending is null)
+        {
+            return false;
+        }
+
+        lock (_pendingStarts)
+        {
+            return _pendingStarts.Remove(pending);
+        }
+    }
+
+    private void Abandon(PendingStart? pending)
+    {
+        if (Claim(pending))
+        {
+            ReleaseHolds(pending!);
+            pending!.Completion?.TrySetCanceled();
+        }
+    }
+
+    private void ReleaseHolds(PendingStart pending)
+    {
+        foreach (var hold in pending.StartupHolds)
+        {
+            try
+            {
+                hold.Dispose();
+            }
+            catch (Exception holdException)
+            {
+                // One deferrer throwing must not strand the others, so the log is guarded too.
+                try
+                {
+                    _logger?.LogError(
+                        holdException, "Releasing a startup completion hold threw and was ignored.");
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+    }
+
+    /// <summary>Cleans up after every start that was posted but will never run.</summary>
+    private void ReleaseAbandonedStarts()
+    {
+        PendingStart[] abandoned;
+        lock (_pendingStarts)
+        {
+            if (_pendingStarts.Count == 0)
+            {
+                return;
+            }
+
+            // Clearing under the same lock claims all of them at once, so a queued action racing
+            // this finds its entry gone and leaves the cleanup here.
+            abandoned = [.. _pendingStarts];
+            _pendingStarts.Clear();
+        }
+
+        foreach (var pending in abandoned)
+        {
+            ReleaseHolds(pending);
+            pending.Completion?.TrySetCanceled();
+        }
+
+        _logger?.LogWarning(
+            "Cleaned up after {Count} attached service start(s) that will no longer run.",
+            abandoned.Length);
+    }
+
+    /// <summary>What a queued start leaves behind if the pump never dequeues it.</summary>
+    private sealed class PendingStart(IDisposable[] startupHolds, TaskCompletionSource? completion)
+    {
+        public IDisposable[] StartupHolds { get; } = startupHolds;
+
+        public TaskCompletionSource? Completion { get; } = completion;
     }
 
     private void PostStopService(IHostedService hostedService, TaskCompletionSource? tcs)
@@ -305,6 +422,9 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
 
     public void Dispose()
     {
+        // Cancelling is all that is needed: the pump sweeps from its own finally, after the action it
+        // is awaiting has finished. Sweeping here would race that action and release the holds of a
+        // start still running, opening the completion gate early.
         _stoppingCts?.Cancel();
     }
 }


### PR DESCRIPTION
Hardening for two pre-existing lifetime defects found by an audit of the monitoring layer. **Neither is reachable by a correctly written application today**, so this is not fixing something users are hitting. One commit on top of current `master`.

## A queued start that never runs left two things dangling

Attaching a hosted service queues its `StartAsync` and, before queueing, takes an `IStartupCompletionDeferrer` hold on every reachable deferrer, released once that start has run. Some attaches also carry a `TaskCompletionSource` the caller awaits.

If the start never runs, because the pump has already exited or exits while the start is still queued, both are left dangling. The hold is never released, `IsRegistrationComplete` never returns true again, and every `WaitForSynchronizationAsync` on that tree blocks for the process lifetime. The awaiting caller waits on a completion nothing will ever set. Both live only inside the queued action's closure, so nothing else could clean them up.

A queued start's cleanup now has a second owner outside the closure. **Removing the entry is the ownership claim**, so the sweep and the queued action can never both run it; cleanup is exactly-once by construction rather than by relying on handles being idempotent. Nothing is tracked when there is nothing to clean up, which is the common case of a fire-and-forget attach in an application with no deferrer.

`Dispose` deliberately does **not** sweep, it only cancels, as before. The pump sweeps from its own `finally`, which runs after the action it is awaiting has completed, so it cannot touch a start in flight. An earlier revision of this branch swept on `Dispose` and released the hold of a start still executing, opening the completion gate early, which is the exact hazard the mechanism exists to prevent.

**Reachability:** the pump only exits when `_stoppingCts` is cancelled, which only `StopAsync` or `Dispose` does. The leak is confined to a handler that is already stopping or stopped, and a correct application is not awaiting tree synchronization after it has stopped its host. It bites where a context outlives its host, such as a test suite cycling hosts against a shared context.

### One user-visible behaviour change

`AttachHostedServiceAsync` against a host that has already stopped now throws `OperationCanceledException` where it previously hung forever. Both in-repo callers already wrap that call, so it degrades to a logged error during shutdown instead of a wedge. Documented in `docs/hosting.md`.

## Unregistration could strand registrations and leave a disposed source pumping

`SubjectSourceBase` unregistered from its monitors in loops with no exception isolation. `Unregister` re-evaluates pending waits, so a poisoned anchor makes it throw. Each loop is preceded by a take-and-clear of the monitor list, so whatever the throw skipped could never be unwound afterwards: a permanent retention of the source, its root subject and the subtree beneath it, with a live `StateChanged` subscription. In `Dispose` it additionally skipped `base.Dispose()`, which cancels the pump's token source, so a "disposed" source kept running.

Every unwind now goes through one method that isolates per monitor, and `Dispose`'s teardown runs in a `finally`. On the registration-failure path the unwind failure is logged rather than thrown, so it cannot replace the registration exception being propagated.

**Reachability:** requires `source.RootSubject`, `source.State`, or an anchor's `GetParents()` to throw. Every production implementation is a plain field read, so nothing in this repository can reach it; the tests hand-build a poisoned anchor.

## Tests

Six of eight fail against `master`'s version of the two production files, verified by running them against it rather than assumed:

| Test | Against master |
|---|---|
| `WhenAServiceIsAttachedAfterTheHostStopped_ThenItsStartupHoldIsStillReleased` | fails |
| `WhenAStartIsStillQueuedAsTheHostStops_ThenItsStartupHoldIsStillReleased` | fails (30s) |
| `WhenAnAwaitedAttachIsAbandoned_ThenTheCallerIsUnblockedRatherThanLeftWaiting` | fails (5s) |
| `WhenAnAwaitedAttachIsStillQueuedAsTheHostStops_ThenTheCallerIsUnblocked` | fails (5s) |
| `WhenOneMonitorsUnregisterThrows_ThenTheOtherMonitorStillUnregisters` | fails |
| `WhenUnregisterThrowsOnDispose_ThenThePumpIsStillCancelled` | fails (5s) |
| `WhenTheHostIsDisposedWhileAStartIsRunning_ThenThatStartsHoldIsNotReleasedEarly` | passes by construction |
| `WhenAnAttachedServiceStartsNormally_ThenItsStartupHoldIsReleasedExactlyOnce` | passes by construction |

The last two guard hazards this change could introduce rather than ones it fixes. The awaited tests carry an explicit timeout so a future regression fails CI rather than wedging it.

Coverage is verified by mutation, not assumed: deleting the line that records a queued start's cleanup fails four tests. An earlier revision passed that mutation entirely, which is how the gap was found.

## Verification

- Full solution: 3157 unit tests, 0 failures; hosting suite run repeatedly for flakiness
- Six independent review passes across the branch's history. Two found regressions this branch had introduced (an early completion-gate open, and cleanup that covered the hold but not the awaiter); both are fixed and pinned by tests.

## Not included

`_waits` growth and the unbounded subscription queue were also found by the audit. Neither is a mechanical fix: the first is a caller dropping a `Task` on a wait that never settles, which needs an API contract decision, and the second means choosing to drop events and picking a policy. `SourceSubscription.Sources` pinning its snapshot forever is the one with genuine normal-use exposure, and changing it alters public API behaviour.

Two follow-ups the final review raised, both pre-existing and unchanged here: `DetachHostedServiceAsync` has the same dangling-completion problem as the attach path did, and a handler whose pump was never started never sweeps.
