### PR TITLE
Fix transaction lifecycle and derived tracking correctness

### DIFF
--- a/docs/design/tracking-derived-properties.md
+++ b/docs/design/tracking-derived-properties.md
@@ -20,7 +20,7 @@ public partial class Person
 
 The source generator detects `[Derived]` and sets `IsDerived = true` on `SubjectPropertyMetadata`, but does not generate a backing field. The getter body is the user's original C# expression.
 
-Derived properties can also be added at runtime via `RegisteredSubject.AddDerivedProperty<T>(name, getValue, setValue)`. These work identically with the dependency tracking system — the getter/setter lambdas are wrapped in interception calls and dependencies are recorded on first evaluation.
+Derived properties can also be added at runtime via `RegisteredSubject.AddDerivedProperty<T>(name, getValue, setValue)`. These work identically with the dependency tracking system: the getter/setter lambdas are wrapped in interception calls and dependencies are recorded on first evaluation.
 
 ## Interceptor Ordering
 
@@ -53,7 +53,7 @@ Dependencies (RequiredProperties):      Used-by properties (UsedByProperties):
 - **Dependencies** (`data.RequiredPropertiesSpan`): Which properties a derived property reads. Stored as a private `PropertyReference[]` with separate count, accessed via `ReadOnlySpan` under `lock(data)`. Buffer is reused when capacity is sufficient to avoid allocation on re-evaluation.
 - **Used-by properties** (`data.GetUsedByProperties()`): Which derived properties depend on this property. Stored as private `PropertyReferenceCollection`, updated via lock-free CAS.
 
-The two use different data structures because of their access patterns. Dependencies are always read and written under `lock(data)` (the derived property's own data), so a plain array with buffer reuse is sufficient. Used-by properties are read without any lock (`WriteProperty` iterates dependents via `GetUsedByProperties()` which does `Volatile.Read`) and mutated from multiple lock scopes (`Remove` is called under the *derived* property's lock, not the *source* property's lock — so two derived properties detaching concurrently can call `Remove` on the same source's `UsedByProperties`). This requires the lock-free CAS copy-on-write wrapper.
+The two use different data structures because of their access patterns. Dependencies are always read and written under `lock(data)` (the derived property's own data), so a plain array with buffer reuse is sufficient. Used-by properties are read without any lock (`WriteProperty` iterates dependents via `GetUsedByProperties()` which does `Volatile.Read`) and mutated from multiple lock scopes (`Remove` is called under the *derived* property's lock, not the *source* property's lock, so two derived properties detaching concurrently can call `Remove` on the same source's `UsedByProperties`). This requires the lock-free CAS copy-on-write wrapper.
 
 Both directions are needed:
 - Dependencies enable cleanup when a derived property is detached (remove itself from all dependencies' used-by properties).
@@ -82,7 +82,7 @@ sequenceDiagram
     participant Full as FullName (derived)
     participant Sub as Subscribers
 
-    Note over App,Sub: Attach — evaluate getter, build dependency graph
+    Note over App,Sub: Attach - evaluate getter, build dependency graph
     App->>Full: AttachProperty(FullName)
     Full->>FN: reads FirstName (recorded as dependency)
     Full->>LN: reads LastName (recorded as dependency)
@@ -90,7 +90,7 @@ sequenceDiagram
     Note over LN: UsedBy += [FullName]
     Note over Full: LastKnownValue = initial value
 
-    Note over App,Sub: Write — cascade via UsedByProperties
+    Note over App,Sub: Write - cascade via UsedByProperties
     App->>FN: FirstName = "Jane"
     FN->>Full: lookup UsedBy → RecalculateDerivedProperty
     Full->>FN: evaluate getter (reads FirstName)
@@ -98,7 +98,7 @@ sequenceDiagram
     Note over Full: commit new LastKnownValue
     Full->>Sub: notify(oldValue, newValue)
 
-    Note over App,Sub: Detach — clean up both directions
+    Note over App,Sub: Detach - clean up both directions
     App->>Full: DetachProperty(FullName)
     Note over FN: UsedBy -= [FullName]
     Note over LN: UsedBy -= [FullName]
@@ -117,7 +117,7 @@ AttachProperty(FullName)
       data.LastKnownValue = EvaluateAndStabilize(data, FullName)
       SetWriteTimestamp(...)
     catch:
-      // Getter threw — value will be computed on the next dependency write.
+      // Getter threw - value will be computed on the next dependency write.
 ```
 
 `EvaluateAndStabilize` handles the dependency recording, generation check, and stabilization loop internally (see Section 4 for details). If the getter throws during initial evaluation (typically during concurrent state transitions), the exception is caught and `LastKnownValue` remains null. The next dependency write triggers recalculation which retries with consistent state.
@@ -136,7 +136,7 @@ EvaluateAndStabilize(data, FullName)
     dependenciesChanged = data.UpdateDependencies(FullName, recordedDeps, recorder)
     if !dependenciesChanged || Volatile.Read(_writeGeneration) == generationBefore:
       return result                              // common path: no concurrent write
-    // Concurrent write detected — stabilize
+    // Concurrent write detected - stabilize
     for iteration in 0..<MaxStabilizationIterations:
       StartRecordingTouchedProperties()
       result = getter.Invoke(subject)
@@ -148,7 +148,7 @@ EvaluateAndStabilize(data, FullName)
     DiscardActiveRecording()                     // always clears recorder buffer
 ```
 
-On the common path (single-threaded construction), `_writeGeneration` is unchanged and the loop is skipped entirely — zero extra getter evaluations. If a concurrent write is detected, the full stabilization loop runs for correctness.
+On the common path (single-threaded construction), `_writeGeneration` is unchanged and the loop is skipped entirely: zero extra getter evaluations. If a concurrent write is detected, the full stabilization loop runs for correctness.
 
 ### 2. Read (recording)
 
@@ -184,7 +184,7 @@ WriteProperty(FirstName = "Jane")
       RecalculateDerivedProperty(FullName, timestamp)
 ```
 
-The `_writeGeneration` increment uses `Interlocked.Increment` (full fence) so that each concurrent writer produces a unique counter value — no lost increments. `AttachProperty`/`RecalculateDerivedProperty` detect concurrent writes via `Volatile.Read` (acquire semantics). The full fence from `Interlocked.Increment` pairs with `Volatile.Read`'s acquire semantics to guarantee that committed property values are visible when the counter change is observed.
+The `_writeGeneration` increment uses `Interlocked.Increment` (full fence) so that each concurrent writer produces a unique counter value: no lost increments. `AttachProperty`/`RecalculateDerivedProperty` detect concurrent writes via `Volatile.Read` (acquire semantics). The full fence from `Interlocked.Increment` pairs with `Volatile.Read`'s acquire semantics to guarantee that committed property values are visible when the counter change is observed.
 
 **Derived properties with setters** (created via `AddDerivedProperty<T>(name, getValue, setValue)`) have both a getter and a setter. The setter modifies internal state as a side effect, but the actual property value is always determined by the getter. When the setter is called, `WriteProperty` detects `HasRequiredProperties && SetValue != null` and triggers recalculation to re-evaluate the getter and fire a change notification with the correct computed value.
 
@@ -194,7 +194,7 @@ The `_writeGeneration` increment uses `Interlocked.Increment` (full fence) so th
 
 The following sequence diagrams illustrate the concrete execution flow of `RecalculateDerivedProperty`. The single-threaded trace shows the straight-line happy path where all concurrency guards are inert. The concurrent trace shows how `IsRecalculating` serializes notification delivery to prevent stale out-of-order notifications.
 
-**Single-threaded recalculation** — all concurrency guards are no-ops:
+**Single-threaded recalculation**: all concurrency guards are no-ops:
 
 ```mermaid
 sequenceDiagram
@@ -215,7 +215,7 @@ sequenceDiagram
     W->>D: finally: IsRecalculating = false
 ```
 
-**Concurrent write during notification** — the scenario that `IsRecalculating` serialization prevents:
+**Concurrent write during notification**: the scenario that `IsRecalculating` serialization prevents:
 
 ```mermaid
 sequenceDiagram
@@ -248,7 +248,7 @@ sequenceDiagram
     A->>D: finally: IsRecalculating = false
 ```
 
-Without the `IsRecalculating` serialization (the pre-fix behavior), Thread B could have entered `RecalculateDerivedProperty` during Thread A's notification delivery, completed a full recalculation with the newer value, and delivered its notification first. Thread A would then resume and deliver its stale notification second — violating the invariant that the last notification reflects the final computed value.
+Without the `IsRecalculating` serialization (the pre-fix behavior), Thread B could have entered `RecalculateDerivedProperty` during Thread A's notification delivery, completed a full recalculation with the newer value, and delivered its notification first. Thread A would then resume and deliver its stale notification second, violating the invariant that the last notification reflects the final computed value.
 
 #### Algorithm
 
@@ -267,7 +267,7 @@ RecalculateDerivedProperty(FullName, timestamp)
 
   // Outer loop: handles post-notification RecalculationNeeded without recursion.
   // The try-finally wraps the entire loop so IsRecalculating stays true during
-  // NotifyDerivedPropertyChanged — this serializes notification delivery with
+  // NotifyDerivedPropertyChanged - this serializes notification delivery with
   // recalculation, preventing stale notifications from being delivered after newer ones.
   try:
     for outerIteration in 0..<MaxStabilizationIterations:
@@ -330,16 +330,16 @@ NotifyDerivedPropertyChanged(derivedProperty, data, sequence, newValue, oldValue
 The getter is evaluated inside `EvaluateAndStabilize` **without holding `lock(data)`** (when `callerHoldsLock` is false). The lock is acquired only briefly for `UpdateDependencies`. If the getter throws (typically during concurrent state transitions), the exception is caught and `LastKnownValue` remains unchanged. The concurrent writer's `WriteProperty` cascade will re-trigger recalculation with consistent state.
 
 The `RecalculationNeeded` flag is set under `lock(data)` by three sources when `IsRecalculating` is true:
-- **Concurrent `RecalculateDerivedProperty`**: Another write triggered recalculation but the current one is in progress — the concurrent call bails and signals the flag.
-- **`AttachProperty`**: The property is being reattached while recalculation is in progress — the evaluation result may be stale.
-- **`DetachProperty`**: The property is being detached while recalculation is in progress — the evaluation result is invalid.
+- **Concurrent `RecalculateDerivedProperty`**: Another write triggered recalculation but the current one is in progress, so the concurrent call bails and signals the flag.
+- **`AttachProperty`**: The property is being reattached while recalculation is in progress, so the evaluation result may be stale.
+- **`DetachProperty`**: The property is being detached while recalculation is in progress, so the evaluation result is invalid.
 
-Phase 3 checks the flag before committing. If set, the stale result is discarded and the inner loop re-evaluates with fresh state. Because `IsRecalculating` stays true during notification delivery, any concurrent write sets `RecalculationNeeded` and bails — the outer loop picks it up after notification completes and re-evaluates with the latest state.
+Phase 3 checks the flag before committing. If set, the stale result is discarded and the inner loop re-evaluates with fresh state. Because `IsRecalculating` stays true during notification delivery, any concurrent write sets `RecalculationNeeded` and bails, and the outer loop picks it up after notification completes and re-evaluates with the latest state.
 
 The generation check inside `EvaluateAndStabilize` avoids re-evaluation when dependencies change but no concurrent write occurred. The stabilization loop only runs when a concurrent write is actually detected.
 
 Key details of the change notification:
-- **Notifications outside lock but inside `IsRecalculating`**: `NotifyDerivedPropertyChanged` fires `SetPropertyValueWithInterception` and `RaisePropertyChanged` without holding `lock(data)` (preventing deadlock with `lock(_attachedSubjects)`), but while `IsRecalculating` is still true. This serializes notification delivery with recalculation — no concurrent recalculation (and thus no competing notification) can start during delivery. Two additional guards provide defense-in-depth: a `RecalculationSequence` check and a `ReferenceEquals` check on `LastKnownValue`. See the "Deadlock prevention" section for details.
+- **Notifications outside lock but inside `IsRecalculating`**: `NotifyDerivedPropertyChanged` fires `SetPropertyValueWithInterception` and `RaisePropertyChanged` without holding `lock(data)` (preventing deadlock with `lock(_attachedSubjects)`), but while `IsRecalculating` is still true. This serializes notification delivery with recalculation, so no concurrent recalculation (and thus no competing notification) can start during delivery. Two additional guards provide defense-in-depth: a `RecalculationSequence` check and a `ReferenceEquals` check on `LastKnownValue`. See the "Deadlock prevention" section for details.
 - **Timestamp inheritance**: The derived property receives the same timestamp as the write that triggered the recalculation, ensuring consistent timestamps within a mutation context. This also holds under an explicit-null scope (`WithChangedTimestamp(null)`): storage remains the never-written sentinel, but trigger and cascade dependents share a single captured publishing time so change events stay consistent.
 - **Local origin by default**: Origin is stamped per write and nothing inherits it, so the recalculation notification publishes with a `Local` origin without any scope. The local model computed the value and no source confirmed it, so the change flows to bound sources like any local write.
 - **`NoOpWriteDelegate`**: Since derived properties have no backing field, the write delegate is a no-op (`static (_, _) => { }`). The call to `SetPropertyValueWithInterception` exists solely to fire the change notification through the interceptor chain (observable, queue, etc.) with the correct old and new values.
@@ -349,7 +349,7 @@ Key details of the change notification:
 
 When a subject is removed from the object graph, `DetachProperty` cleans up both directions.
 
-`DetachProperty` uses `TryGetDerivedPropertyData()` and returns early if no tracking data exists. This avoids `ConcurrentDictionary.GetOrAdd` allocations for source properties that were never dependencies — a significant performance optimization when detaching subjects with many non-dependency properties (e.g., detaching 1000 cars where only 1 of 18 properties per car participates in derived property tracking).
+`DetachProperty` uses `TryGetDerivedPropertyData()` and returns early if no tracking data exists. This avoids `ConcurrentDictionary.GetOrAdd` allocations for source properties that were never dependencies, a significant performance optimization when detaching subjects with many non-dependency properties (e.g., detaching 1000 cars where only 1 of 18 properties per car participates in derived property tracking).
 
 For properties with tracking data, both cases are handled in a single `lock(data)` block, followed by Case 2 cleanup outside the lock:
 
@@ -371,7 +371,7 @@ DetachProperty(property)
       derivedData.RemoveRequiredProperty(property)
 ```
 
-The single lock ensures `IsAttached`, dependency cleanup (Case 1), and used-by snapshot (Case 2) are atomic — no window where a concurrent thread could see `IsAttached=false` but `UsedByProperties` still populated.
+The single lock ensures `IsAttached`, dependency cleanup (Case 1), and used-by snapshot (Case 2) are atomic: no window exists where a concurrent thread could see `IsAttached=false` but `UsedByProperties` still populated.
 
 The lock serializes with `UpdateDependencies`' used-by Add (which also acquires `lock(depData)` on the same object). This ensures either:
 - The used-by property was added before the snapshot → we see it and clean up the dependency.
@@ -401,7 +401,7 @@ The `bool` return drives the stabilization loop in `RecalculateDerivedProperty` 
 - `RequiredProperties` reads and writes (via `UpdateDependencies`)
 - `RecalculationNeeded` signaling (set by concurrent operations, consumed by recalculation)
 
-In `RecalculateDerivedProperty`, the lock is acquired briefly for state transitions (Phase 1, Phase 3, outer loop check, finally with re-trigger check) but **not held during getter evaluation or notification delivery**. The `IsRecalculating` flag stays true during notification delivery (serializing notifications with recalculations), but no lock is held — preventing deadlock with `lock(_attachedSubjects)` in `LifecycleInterceptor`. In `AttachProperty`, the lock is held throughout evaluation because the caller already holds `lock(_attachedSubjects)` (correct lock ordering).
+In `RecalculateDerivedProperty`, the lock is acquired briefly for state transitions (Phase 1, Phase 3, outer loop check, finally with re-trigger check) but **not held during getter evaluation or notification delivery**. The `IsRecalculating` flag stays true during notification delivery (serializing notifications with recalculations), but no lock is held, preventing deadlock with `lock(_attachedSubjects)` in `LifecycleInterceptor`. In `AttachProperty`, the lock is held throughout evaluation because the caller already holds `lock(_attachedSubjects)` (correct lock ordering).
 
 This is a fine-grained lock (per derived property), so different derived properties can recalculate concurrently.
 
@@ -425,7 +425,7 @@ internal bool Add(in PropertyReference item)
         if (ReferenceEquals(
             Interlocked.CompareExchange(ref _items, newArr, snapshot), snapshot))
             return true;
-        // CAS failed — retry
+        // CAS failed - retry
     }
 }
 ```
@@ -438,11 +438,11 @@ This is necessary because multiple derived properties on different threads may c
 
 ### Lock ordering follows the dependency DAG
 
-`EvaluateAndStabilize` (when `callerHoldsLock` is false) and `UpdateDependencies` nest locks in the derived → dependency direction: `lock(D_data)` (from `EvaluateAndStabilize`'s brief lock for `UpdateDependencies`) → `lock(X_data)` (inner, from the used-by Add loop in `UpdateDependencies`). A deadlock would require a cycle in the lock acquisition order, which would imply a circular dependency in the property graph — but circular getter dependencies cause infinite recursion before any lock is reached, so the graph is always a DAG and deadlock is impossible.
+`EvaluateAndStabilize` (when `callerHoldsLock` is false) and `UpdateDependencies` nest locks in the derived-to-dependency direction: `lock(D_data)` (from `EvaluateAndStabilize`'s brief lock for `UpdateDependencies`) → `lock(X_data)` (inner, from the used-by Add loop in `UpdateDependencies`). A deadlock would require a cycle in the lock acquisition order, which would imply a circular dependency in the property graph, but circular getter dependencies cause infinite recursion before any lock is reached, so the graph is always a DAG and deadlock is impossible.
 
-`RecalculateDerivedProperty` does **not** hold `lock(data)` during getter evaluation or notification delivery. The `IsRecalculating` flag stays true during both (serializing concurrent recalculations and notifications), but no lock is held — so getter side effects and notification interceptors can safely acquire `lock(_attachedSubjects)` in `LifecycleInterceptor` without lock ordering inversion. `AttachProperty` holds both `lock(_attachedSubjects)` (from LifecycleInterceptor, outer) and `lock(data)` (inner) during evaluation — correct ordering, and reentrant for getter side effects on the same thread.
+`RecalculateDerivedProperty` does **not** hold `lock(data)` during getter evaluation or notification delivery. The `IsRecalculating` flag stays true during both (serializing concurrent recalculations and notifications), but no lock is held, so getter side effects and notification interceptors can safely acquire `lock(_attachedSubjects)` in `LifecycleInterceptor` without lock ordering inversion. `AttachProperty` holds both `lock(_attachedSubjects)` (from LifecycleInterceptor, outer) and `lock(data)` (inner) during evaluation: correct ordering, and reentrant for getter side effects on the same thread.
 
-`DetachProperty` uses a single `lock(data)` for all local cleanup (`IsAttached`, `RecalculationNeeded` signaling, dependencies, used-by snapshot), then acquires `lock(derivedData)` sequentially for `RequiredProperties` cleanup. Because it never holds two locks simultaneously, it cannot participate in a lock cycle. Case 1's dependency cleanup (removing from dependencies' `UsedByProperties`) uses CAS inside the lock — no nested lock acquisition.
+`DetachProperty` uses a single `lock(data)` for all local cleanup (`IsAttached`, `RecalculationNeeded` signaling, dependencies, used-by snapshot), then acquires `lock(derivedData)` sequentially for `RequiredProperties` cleanup. Because it never holds two locks simultaneously, it cannot participate in a lock cycle. Case 1's dependency cleanup (removing from dependencies' `UsedByProperties`) uses CAS inside the lock, with no nested lock acquisition.
 
 ## Concurrency Scenarios
 
@@ -452,7 +452,7 @@ Derived properties with setters (added via `AddDerivedProperty<T>(name, getValue
 
 ### Deadlock prevention: unlocked getter evaluation
 
-The following diagrams illustrate the ABBA deadlock that would occur if `RecalculateDerivedProperty` held `lock(data)` during getter evaluation, and how the actual design prevents it. Inversion 2 (notifications) follows the same pattern — `NotifyDerivedPropertyChanged` fires `SetPropertyValueWithInterception` which can acquire `lock(_attachedSubjects)` through the interceptor chain.
+The following diagrams illustrate the ABBA deadlock that would occur if `RecalculateDerivedProperty` held `lock(data)` during getter evaluation, and how the actual design prevents it. Inversion 2 (notifications) follows the same pattern: `NotifyDerivedPropertyChanged` fires `SetPropertyValueWithInterception` which can acquire `lock(_attachedSubjects)` through the interceptor chain.
 
 **Hypothetical deadlock** (if getter ran inside `lock(data)`):
 
@@ -467,7 +467,7 @@ sequenceDiagram
     B->>AL: holder.Person = null: lock(_attachedSubjects)
     A-xAL: getter writes Companion → needs lock(_attachedSubjects)
     B-xDL: DetachProperty(Greeting) → needs lock(data)
-    Note over A,B: Both threads wait for each other — deadlock
+    Note over A,B: Both threads wait for each other - deadlock
 ```
 
 **Actual behavior** (getter and notification run outside `lock(data)`):
@@ -479,7 +479,7 @@ sequenceDiagram
     participant AL as lock(_attachedSubjects)
     participant B as Thread B
 
-    A->>DL: Phase 1: lock — IsRecalculating=true, unlock
+    A->>DL: Phase 1: lock - IsRecalculating=true, unlock
     Note over A: Phase 2: evaluate getter (no lock held)
     A->>AL: getter writes Companion → lock/unlock
     B->>AL: holder.Person=null → lock(_attachedSubjects)
@@ -487,31 +487,31 @@ sequenceDiagram
     Note over DL: RecalculationNeeded=true, IsAttached=false
     B-->>DL: unlock
     B-->>AL: unlock
-    A->>DL: Phase 3: lock — sees !IsAttached → return
-    Note over A,B: No deadlock — lock(data) never held during getter or notification
+    A->>DL: Phase 3: lock - sees !IsAttached → return
+    Note over A,B: No deadlock - lock(data) never held during getter or notification
 ```
 
 `RecalculateDerivedProperty` evaluates the getter **outside** `lock(data)` and fires notifications after releasing `lock(data)`. This prevents two lock ordering inversions between `lock(data)` and `lock(_attachedSubjects)` in `LifecycleInterceptor`:
 
-**Inversion 1 — Getter side effects**: A derived property getter may write to a subject-typed property as a side effect (e.g., lazy initialization, derived-with-setter patterns). This triggers `LifecycleInterceptor.WriteProperty` → `lock(_attachedSubjects)`. If the getter ran inside `lock(data)`, the ordering would be `lock(data)` → `lock(_attachedSubjects)`. Meanwhile, a concurrent `LifecycleInterceptor` operation holds `lock(_attachedSubjects)` → `AttachProperty`/`DetachProperty` → `lock(data)`. Deadlock.
+**Inversion 1: Getter side effects**: A derived property getter may write to a subject-typed property as a side effect (e.g., lazy initialization, derived-with-setter patterns). This triggers `LifecycleInterceptor.WriteProperty` → `lock(_attachedSubjects)`. If the getter ran inside `lock(data)`, the ordering would be `lock(data)` → `lock(_attachedSubjects)`. Meanwhile, a concurrent `LifecycleInterceptor` operation holds `lock(_attachedSubjects)` → `AttachProperty`/`DetachProperty` → `lock(data)`. Deadlock.
 
-**Inversion 2 — Notifications**: `NotifyDerivedPropertyChanged` fires `SetPropertyValueWithInterception` which enters the interceptor chain, potentially acquiring `lock(_attachedSubjects)` via `LifecycleInterceptor.WriteProperty`. Same ordering inversion as above.
+**Inversion 2: Notifications**: `NotifyDerivedPropertyChanged` fires `SetPropertyValueWithInterception` which enters the interceptor chain, potentially acquiring `lock(_attachedSubjects)` via `LifecycleInterceptor.WriteProperty`. Same ordering inversion as above.
 
-Both are prevented because `lock(data)` is never held during getter evaluation or notification in `RecalculateDerivedProperty`. The `IsRecalculating` flag (set/cleared under brief `lock(data)` acquisitions) serializes concurrent recalculations — and, crucially, notification delivery — without holding the lock for the entire evaluation. The `RecalculationNeeded` flag catches state changes (writes, attach, detach) that arrive during the unlocked window.
+Both are prevented because `lock(data)` is never held during getter evaluation or notification in `RecalculateDerivedProperty`. The `IsRecalculating` flag (set/cleared under brief `lock(data)` acquisitions) serializes concurrent recalculations and, crucially, notification delivery without holding the lock for the entire evaluation. The `RecalculationNeeded` flag catches state changes (writes, attach, detach) that arrive during the unlocked window.
 
-In `AttachProperty`, the getter runs inside `lock(data)` — this is safe because the caller (`LifecycleInterceptor`) already holds `lock(_attachedSubjects)`, so the ordering is `lock(_attachedSubjects)` → `lock(data)` (correct, and reentrant for getter side effects on the same thread).
+In `AttachProperty`, the getter runs inside `lock(data)`. This is safe because the caller (`LifecycleInterceptor`) already holds `lock(_attachedSubjects)`, so the ordering is `lock(_attachedSubjects)` → `lock(data)` (correct, and reentrant for getter side effects on the same thread).
 
 ### Notification ordering: `IsRecalculating` serialization
 
-`IsRecalculating` stays true during `NotifyDerivedPropertyChanged`. This is the primary mechanism preventing out-of-order notifications: since only one thread at a time can have `IsRecalculating = true` for a given derived property, and notifications are delivered within that scope, no two notifications for the same property can race. Concurrent writes during delivery set `RecalculationNeeded = true` and bail — the outer loop handles them after notification completes.
+`IsRecalculating` stays true during `NotifyDerivedPropertyChanged`. This is the primary mechanism preventing out-of-order notifications: since only one thread at a time can have `IsRecalculating = true` for a given derived property, and notifications are delivered within that scope, no two notifications for the same property can race. Concurrent writes during delivery set `RecalculationNeeded = true` and bail, and the outer loop handles them after notification completes.
 
 Three additional guards provide defense-in-depth:
 
-1. **`RecalculationNeeded` check**: Set under `lock(data)` by concurrent operations (writes, attach, detach) when `IsRecalculating` is true. Checked before committing in Phase 3 — if set, the evaluation result is discarded and the getter is re-evaluated. This ensures the committed value reflects the latest state.
+1. **`RecalculationNeeded` check**: Set under `lock(data)` by concurrent operations (writes, attach, detach) when `IsRecalculating` is true. Checked before committing in Phase 3: if set, the evaluation result is discarded and the getter is re-evaluated. This ensures the committed value reflects the latest state.
 
 2. **`RecalculationSequence` check**: A monotonic counter incremented under `lock(data)` on each recalculation. In `NotifyDerivedPropertyChanged`, `Volatile.Read` compares the thread's captured sequence against the current value. If a newer recalculation completed in between, the notification is skipped.
 
-3. **`ReferenceEquals` check on `LastKnownValue`**: A second guard compares the thread's computed `newValue` reference against `data.LastKnownValue` via `Volatile.Read`. Since `data.LastKnownValue = newValue` stores the same reference inside the lock, a mismatch means another thread overwrote it — the notification is skipped. This works for boxed value types because each getter evaluation produces a distinct boxed reference.
+3. **`ReferenceEquals` check on `LastKnownValue`**: A second guard compares the thread's computed `newValue` reference against `data.LastKnownValue` via `Volatile.Read`. Since `data.LastKnownValue = newValue` stores the same reference inside the lock, a mismatch means another thread overwrote it, so the notification is skipped. This works for boxed value types because each getter evaluation produces a distinct boxed reference.
 
 With `IsRecalculating` serialization, guards 2 and 3 are technically redundant (no concurrent recalculation can change the sequence or value during delivery). They are retained as defense-in-depth.
 
@@ -521,7 +521,7 @@ Additionally, `LifecycleInterceptor.WriteProperty` uses `context.Property.Metada
 
 ### Concurrent write detection via `_writeGeneration`
 
-When a derived property has conditional dependencies (e.g., `Display => UseFirstName ? FirstName : LastName`), the dependency set changes based on runtime state. A concurrent write to a newly-added dependency could land between getter evaluation and used-by registration — the write would not trigger recalculation because the used-by property isn't registered yet.
+When a derived property has conditional dependencies (e.g., `Display => UseFirstName ? FirstName : LastName`), the dependency set changes based on runtime state. A concurrent write to a newly-added dependency could land between getter evaluation and used-by registration, so the write would not trigger recalculation because the used-by property isn't registered yet.
 
 Both `AttachProperty` and `RecalculateDerivedProperty` use a generation-based detection scheme instead of unconditionally re-evaluating:
 
@@ -530,17 +530,17 @@ Both `AttachProperty` and `RecalculateDerivedProperty` use a generation-based de
 3. If unchanged → no concurrent write occurred → skip the stabilization loop.
 4. If changed → a concurrent write happened → fall back to the full stabilization loop.
 
-`Interlocked.Increment` provides a full memory fence, pairing with `Volatile.Read`'s acquire semantics: if the counter change is observed, all prior writes (including the committed property value) are guaranteed visible to the reading thread. Each concurrent writer produces a unique counter value — no lost increments.
+`Interlocked.Increment` provides a full memory fence, pairing with `Volatile.Read`'s acquire semantics: if the counter change is observed, all prior writes (including the committed property value) are guaranteed visible to the reading thread. Each concurrent writer produces a unique counter value: no lost increments.
 
-`_writeGeneration` is a static field, shared across all handler instances. This ensures writes from any context are detected, even when dependencies span contexts (e.g., via context inheritance). The tradeoff is that unrelated writes (from other contexts) may cause false positives — triggering the stabilization loop when no relevant concurrent write occurred. False positives only affect `AttachProperty` and `RecalculateDerivedProperty` when dependencies change; the steady-state write path (`dependenciesChanged = false`) never checks the generation, so there is zero overhead from false positives in the common case. A false positive costs one extra getter evaluation that exits immediately (deps unchanged).
+`_writeGeneration` is a static field, shared across all handler instances. This ensures writes from any context are detected, even when dependencies span contexts (e.g., via context inheritance). The tradeoff is that unrelated writes (from other contexts) may cause false positives, triggering the stabilization loop when no relevant concurrent write occurred. False positives only affect `AttachProperty` and `RecalculateDerivedProperty` when dependencies change; the steady-state write path (`dependenciesChanged = false`) never checks the generation, so there is zero overhead from false positives in the common case. A false positive costs one extra getter evaluation that exits immediately (deps unchanged).
 
-In the common case (stable dependencies or single-threaded construction), the generation is unchanged and the loop is skipped — zero extra getter evaluations. The stabilization loop only runs when a concurrent write is actually detected.
+In the common case (stable dependencies or single-threaded construction), the generation is unchanged and the loop is skipped: zero extra getter evaluations. The stabilization loop only runs when a concurrent write is actually detected.
 
 ### Concurrent detach and recalculation
 
 The following diagrams show the two race conditions and how lock serialization on `DerivedPropertyData` ensures correctness regardless of thread scheduling.
 
-**Race 1 — Zombie used-by resurrection**: `WriteProperty` snapshots `UsedByProperties` and calls `RecalculateDerivedProperty` for each dependent. A concurrent `DetachProperty` on the derived property D serializes via `lock(D.data)`:
+**Race 1: Zombie used-by resurrection**: `WriteProperty` snapshots `UsedByProperties` and calls `RecalculateDerivedProperty` for each dependent. A concurrent `DetachProperty` on the derived property D serializes via `lock(D.data)`:
 
 ```mermaid
 sequenceDiagram
@@ -551,20 +551,20 @@ sequenceDiagram
     W->>W: WriteProperty(X): snapshot X.UsedBy → [D]
 
     alt Detach completes before Phase 1
-        Det->>DD: lock — IsAttached=false, clear deps/UsedBy, unlock
+        Det->>DD: lock - IsAttached=false, clear deps/UsedBy, unlock
         W->>DD: RecalculateDerivedProperty(D) Phase 1: lock
         Note over DD: IsAttached=false → return
-        Note over W,Det: Bails at Phase 1 — no zombie
+        Note over W,Det: Bails at Phase 1 - no zombie
     else Recalculation enters Phase 1 first
-        W->>DD: Phase 1: lock — IsRecalculating=true, unlock
+        W->>DD: Phase 1: lock - IsRecalculating=true, unlock
         W->>W: Phase 2: evaluate getter (no lock)
-        Det->>DD: lock — RecalculationNeeded=true, IsAttached=false, unlock
-        W->>DD: Phase 3: lock — !IsAttached → return
-        Note over W,Det: Bails at Phase 3 — no zombie
+        Det->>DD: lock - RecalculationNeeded=true, IsAttached=false, unlock
+        W->>DD: Phase 3: lock - !IsAttached → return
+        Note over W,Det: Bails at Phase 3 - no zombie
     end
 ```
 
-**Race 2 — Missed used-by in snapshot**: `DetachProperty` on source X snapshots `X.UsedByProperties`. A concurrent `UpdateDependencies` adding derived D to `X.UsedByProperties` serializes via `lock(X.data)`:
+**Race 2: Missed used-by in snapshot**: `DetachProperty` on source X snapshots `X.UsedByProperties`. A concurrent `UpdateDependencies` adding derived D to `X.UsedByProperties` serializes via `lock(X.data)`:
 
 ```mermaid
 sequenceDiagram
@@ -573,20 +573,20 @@ sequenceDiagram
     participant Upd as UpdateDependencies(D→X)
 
     alt DetachProperty wins lock
-        Det->>XD: lock — IsAttached=false, snapshot UsedBy, clear, unlock
-        Upd->>XD: lock — IsAttached=false → skip Add, unlock
-        Note over Det,Upd: D not added — ReconcileSkippedDependencies filters it
+        Det->>XD: lock - IsAttached=false, snapshot UsedBy, clear, unlock
+        Upd->>XD: lock - IsAttached=false → skip Add, unlock
+        Note over Det,Upd: D not added - ReconcileSkippedDependencies filters it
     else UpdateDependencies wins lock
-        Upd->>XD: lock — IsAttached=true → Add D to UsedBy, unlock
-        Det->>XD: lock — IsAttached=false, snapshot (includes D), clear, unlock
+        Upd->>XD: lock - IsAttached=true → Add D to UsedBy, unlock
+        Det->>XD: lock - IsAttached=false, snapshot (includes D), clear, unlock
         Det->>Det: Case 2 cleanup: RemoveRequiredProperty(X) from D
-        Note over Det,Upd: D in snapshot — cleaned up normally
+        Note over Det,Upd: D in snapshot - cleaned up normally
     end
 ```
 
 Two race conditions must be handled when `DetachProperty` runs concurrently with `RecalculateDerivedProperty` / `UpdateDependencies`:
 
-**Race 1 — Zombie used-by resurrection (Case 1):** `WriteProperty` takes a snapshot of `UsedByProperties` and iterates it. A concurrent `DetachProperty` may remove a derived property's used-by entries between the snapshot and the recalculation call. Without protection, `RecalculateDerivedProperty` would re-add the used-by entries, creating zombie dependencies.
+**Race 1: Zombie used-by resurrection (Case 1):** `WriteProperty` takes a snapshot of `UsedByProperties` and iterates it. A concurrent `DetachProperty` may remove a derived property's used-by entries between the snapshot and the recalculation call. Without protection, `RecalculateDerivedProperty` would re-add the used-by entries, creating zombie dependencies.
 
 `DetachProperty` and `RecalculateDerivedProperty` both acquire `lock(data)` on the same derived property's data. `DetachProperty` sets `data.IsAttached = false` and `data.RecalculationNeeded = true` (if `IsRecalculating`) inside the lock. `RecalculateDerivedProperty` checks `IsAttached` at Phase 3 (commit) and `RecalculationNeeded` inside `EvaluateAndStabilize`'s brief lock for `UpdateDependencies`. `AttachProperty` sets `IsAttached = true` and `RecalculationNeeded = true` (if `IsRecalculating`) under lock to support re-attachment.
 
@@ -595,7 +595,7 @@ Both orderings produce a correct final state:
 - **Evaluation's UpdateDependencies wins lock**: registers used-by entries. Detach then runs, clears them. Final state is clean.
 - **Detach + reattach during evaluation**: `RecalculationNeeded` is set by both operations. Phase 3 sees the flag, discards the stale result, and re-evaluates with the post-reattach state.
 
-**Race 2 — Missed used-by property in Case 2 snapshot:** When a source property X is being detached, `DetachProperty` Case 2 takes a snapshot of `X.UsedByProperties` to find dependent derived properties. Concurrently, `UpdateDependencies` may be adding a new used-by entry (D → X) to `X.UsedByProperties`. If the Add completes after the snapshot, `DetachProperty` misses D, leaving a stale dependency (`D.RequiredProperties` contains X) and a stale used-by entry (D in `X.UsedByProperties`).
+**Race 2: Missed used-by property in Case 2 snapshot:** When a source property X is being detached, `DetachProperty` Case 2 takes a snapshot of `X.UsedByProperties` to find dependent derived properties. Concurrently, `UpdateDependencies` may be adding a new used-by entry (D → X) to `X.UsedByProperties`. If the Add completes after the snapshot, `DetachProperty` misses D, leaving a stale dependency (`D.RequiredProperties` contains X) and a stale used-by entry (D in `X.UsedByProperties`).
 
 This is solved by locking `X.DerivedPropertyData` in both places:
 - `DetachProperty` Case 2: `lock(data)` → `DetachAndSnapshotUsedBy` sets `IsAttached = false` + takes snapshot + clears `UsedByProperties` → release lock.
@@ -626,13 +626,13 @@ Every piece of shared mutable state is protected by exactly one synchronization 
 | `data.RecalculationSequence` | `lock(data)` (write) / `Volatile.Read` (read) | `RecalculateDerivedProperty` (increment under lock, read outside lock for stale notification check) |
 | `_writeGeneration` (static) | `Interlocked.Increment` (full fence) / `Volatile.Read` (acquire) | `WriteProperty` (increment), `AttachProperty` + `RecalculateDerivedProperty` (check) |
 
-Nested locks occur in `UpdateDependencies`: `lock(D_data)` (outer, from `EvaluateAndStabilize`'s brief lock) → `lock(X_data)` (inner, used-by Add). The acquisition order follows the dependency DAG (derived → source). Circular dependencies would cause infinite recursion in getters before any lock is reached, so deadlock is impossible. `DetachProperty` uses a single `lock(data)` for all local cleanup (via `DetachAndSnapshotUsedBy`), then acquires `lock(derivedData)` sequentially (never nested), so it cannot participate in a lock cycle. `RecalculateDerivedProperty` never holds `lock(data)` during getter evaluation or notification — both may acquire `lock(_attachedSubjects)` in `LifecycleInterceptor`, and since `lock(data)` is not held, no cycle is possible.
+Nested locks occur in `UpdateDependencies`: `lock(D_data)` (outer, from `EvaluateAndStabilize`'s brief lock) → `lock(X_data)` (inner, used-by Add). The acquisition order follows the dependency DAG (derived → source). Circular dependencies would cause infinite recursion in getters before any lock is reached, so deadlock is impossible. `DetachProperty` uses a single `lock(data)` for all local cleanup (via `DetachAndSnapshotUsedBy`), then acquires `lock(derivedData)` sequentially (never nested), so it cannot participate in a lock cycle. `RecalculateDerivedProperty` never holds `lock(data)` during getter evaluation or notification; both may acquire `lock(_attachedSubjects)` in `LifecycleInterceptor`, and since `lock(data)` is not held, no cycle is possible.
 
 ### Value correctness: derived value always reflects current state
 
 After all concurrent writes complete and recalculations settle, every derived property's value matches what its getter would return if called with the current source values. This is guaranteed by four mechanisms working together:
 
-1. **Used-by-driven recalculation**: Once a dependency's used-by properties include a derived property, any write to that dependency triggers `RecalculateDerivedProperty` via `WriteProperty`. The `IsRecalculating` flag serializes concurrent recalculations of the same derived property — each successful evaluation sees the most recent source values.
+1. **Used-by-driven recalculation**: Once a dependency's used-by properties include a derived property, any write to that dependency triggers `RecalculateDerivedProperty` via `WriteProperty`. The `IsRecalculating` flag serializes concurrent recalculations of the same derived property: each successful evaluation sees the most recent source values.
 
 2. **`RecalculationNeeded` flag**: When a concurrent write, attach, or detach occurs while `IsRecalculating` is true, the `RecalculationNeeded` flag is set under `lock(data)`. The in-progress recalculation checks this flag before committing (Phase 3) and inside `EvaluateAndStabilize`'s brief lock for `UpdateDependencies`. If set, the stale evaluation result is discarded and the getter is re-evaluated. The outer loop checks after notification delivery to catch writes that arrived during evaluation or notification. The `finally` block includes a re-trigger check for the narrow gap between the outer loop's return and `IsRecalculating` cleanup.
 
@@ -643,9 +643,9 @@ After all concurrent writes complete and recalculations settle, every derived pr
    - **Subsequent iterations**: re-evaluate with used-by properties in place, catching writes that happened before registration. Each iteration that acquires used-by properties ensures any *further* concurrent write to those dependencies triggers recalculation via the normal path.
    - The loop exits when `UpdateDependencies` returns `false` (deps unchanged).
 
-   In the common case (no concurrent writes, or stable dependencies), the generation check avoids the loop entirely — zero extra getter evaluations.
+   In the common case (no concurrent writes, or stable dependencies), the generation check avoids the loop entirely: zero extra getter evaluations.
 
-Because `_writeGeneration` is static (global), writes from any context are detected — no cross-context blind spots. False positives from unrelated contexts only trigger re-evaluation when deps actually changed, and the re-evaluation exits immediately when deps are stable.
+Because `_writeGeneration` is static (global), writes from any context are detected, so there are no cross-context blind spots. False positives from unrelated contexts only trigger re-evaluation when deps actually changed, and the re-evaluation exits immediately when deps are stable.
 
 ### No zombie dependencies after detach
 
@@ -656,7 +656,7 @@ When a property is detached, no stale references remain in the dependency graph:
 - **Atomic state transition**: The single lock ensures `IsAttached = false`, dependency cleanup (Case 1), and used-by snapshot (Case 2) happen atomically. No concurrent thread can observe `IsAttached = false` while `UsedByProperties` is still populated.
 - **No resurrection (Case 1)**: `DetachProperty` sets `IsAttached = false` and `RecalculationNeeded = true` (if `IsRecalculating`) inside the lock. Any concurrent `RecalculateDerivedProperty` with an in-flight evaluation sees `!IsAttached` or `RecalculationNeeded` at the next lock acquisition (`EvaluateAndStabilize` bail check or Phase 3) and either bails or re-evaluates. No stale used-by entries are committed.
 - **No missed used-by properties (Case 2)**: For properties **with** tracking data, `DetachAndSnapshotUsedBy` sets `IsAttached = false` under `lock(data)`. The lock serializes with `UpdateDependencies`' used-by Add (which also locks `depData`). Any used-by property added before the lock is in the snapshot; any Add attempt after the lock sees `IsAttached = false` and skips. Skipped entries trigger `ReconcileSkippedDependencies` which re-checks `IsAttached` under `lock(depData)`: if the dependency was re-attached concurrently, the filter calls idempotent `Add(derivedProperty)` to repair the missing used-by property; if still detached, it removes the dependency from `RequiredProperties` and cleans the used-by entry.
-- **Untracked source properties**: For source properties that were **never** dependencies (no `DerivedPropertyData` exists), `DetachProperty` skips them entirely via `TryGetDerivedPropertyData() → null → return`. A theoretical race exists where a concurrent `UpdateDependencies` creates data with `IsAttached = true` after `DetachProperty` exits, leaving a stale dependency in the derived property's `RequiredProperties`. However, this is safe in practice: for a derived property D to read source property X on subject S, the getter must reach S through the object graph — meaning S is already kept alive by a structural reference from the getter's reachable path (a tracked property, closure capture, etc.), not solely by `RequiredProperties`. The stale dependency is redundant with the existing structural reference and is cleaned up on the next recalculation of D (when the structural reference changes, D re-records its dependencies and drops X). This tradeoff avoids `ConcurrentDictionary.GetOrAdd` for every untracked property during detach, which profiling showed to be the dominant cost in bulk detach scenarios.
+- **Untracked source properties**: For source properties that were **never** dependencies (no `DerivedPropertyData` exists), `DetachProperty` skips them entirely via `TryGetDerivedPropertyData() → null → return`. A theoretical race exists where a concurrent `UpdateDependencies` creates data with `IsAttached = true` after `DetachProperty` exits, leaving a stale dependency in the derived property's `RequiredProperties`. However, this is safe in practice: for a derived property D to read source property X on subject S, the getter must reach S through the object graph, meaning S is already kept alive by a structural reference from the getter's reachable path (a tracked property, closure capture, etc.), not solely by `RequiredProperties`. The stale dependency is redundant with the existing structural reference and is cleaned up on the next recalculation of D (when the structural reference changes, D re-records its dependencies and drops X). This tradeoff avoids `ConcurrentDictionary.GetOrAdd` for every untracked property during detach, which profiling showed to be the dominant cost in bulk detach scenarios.
 
 ### No memory leaks from cross-subject dependencies
 
@@ -685,13 +685,19 @@ In all cases for tracked properties, both dependencies and used-by properties ar
 
 ### Equality check (`WithEqualityCheck`)
 
-When `PropertyValueEqualityCheckHandler` is registered (included in `WithFullPropertyTracking`), it compares old and new values before the write proceeds. If they are equal, the entire interceptor chain is skipped — no `WriteProperty` call, no dependent recalculation. This prevents redundant cascading recalculations when a source property is set to its current value.
+When `PropertyValueEqualityCheckHandler` is registered (included in `WithFullPropertyTracking`), it compares old and new values before the write proceeds. If they are equal, the entire interceptor chain is skipped: no `WriteProperty` call and no dependent recalculation. This prevents redundant cascading recalculations when a source property is set to its current value.
 
 The equality check also applies to the `SetPropertyValueWithInterception` call during recalculation. If the derived property's new computed value equals the old value, the change notification is suppressed.
 
 ### Transactions
 
-During transaction capture (`SubjectTransaction.HasActiveTransaction && !IsCommitting`), dependent recalculations are suppressed. Derived properties are recalculated when the transaction commits and replays the writes. Additionally, derived property writes are never captured in transactions (`SubjectTransactionInterceptor` checks `!context.Property.Metadata.IsDerived`), since derived values are always computed from their dependencies.
+Dependent recalculations are suppressed only while the ambient transaction is not committing and at least one dependent's recorded property set intersects the transaction's pending keys. A dependent getter could otherwise observe uncommitted state and publish a value that rollback leaves behind. Commit replay runs the cascades after pending reads are disabled. Empty, unrelated, committing, and disposed ambient transactions do not suppress a landed write because the dependent cannot read pending state from them.
+
+Derived properties are recalculated when the transaction commits and replays the writes. Additionally, derived property writes are never captured in transactions (`SubjectTransactionInterceptor` checks `!context.Property.Metadata.IsDerived`), since derived values are always computed from their dependencies.
+
+#### Writes that never reached the model
+
+When `IsWritten == false`, `DerivedPropertyChangeHandler.WriteProperty` returns before generation tracking, recalculation, cascading, and timestamp resolution. A vetoed write therefore has no derived-property side effects.
 
 ## Design Notes
 

--- a/docs/design/tracking-derived-properties.md
+++ b/docs/design/tracking-derived-properties.md
@@ -145,7 +145,7 @@ EvaluateAndStabilize(data, FullName)
         break                                    // deps stabilized
     return result
   finally:
-    DiscardActiveRecording()                     // always clears recorder buffer
+    DiscardActiveRecording(ownsActiveRecording)  // clears only this invocation's frame
 ```
 
 On the common path (single-threaded construction), `_writeGeneration` is unchanged and the loop is skipped entirely: zero extra getter evaluations. If a concurrent write is detected, the full stabilization loop runs for correctness.
@@ -691,9 +691,13 @@ The equality check also applies to the `SetPropertyValueWithInterception` call d
 
 ### Transactions
 
-Dependent recalculations are suppressed only while the ambient transaction is not committing and at least one dependent's recorded property set intersects the transaction's pending keys. A dependent getter could otherwise observe uncommitted state and publish a value that rollback leaves behind. Commit replay runs the cascades after pending reads are disabled. Empty, unrelated, committing, and disposed ambient transactions do not suppress a landed write because the dependent cannot read pending state from them.
+Direct property reads inside a transaction return pending values. Shared derived tracking has a different view: `LastKnownValue`, dependencies, timestamps, and notifications always represent values that landed in the model. Attach-time evaluation, automatic recalculation, manual recalculation, and every stabilization retry therefore evaluate getters while transaction-local pending reads are bypassed. The ambient transaction remains unchanged, so getter side-effect writes retain normal transaction behavior.
 
-Derived properties are recalculated when the transaction commits and replays the writes. Additionally, derived property writes are never captured in transactions (`SubjectTransactionInterceptor` checks `!context.Property.Metadata.IsDerived`), since derived values are always computed from their dependencies.
+The existing thread-static recorder depth defines this model-read extent. Nested and derived-of-derived evaluations remain in the model view until the outermost recorder frame finishes. Dependency recording still flattens intercepted source reads into the graph. Each evaluation owns one frame, so normal or exceptional cleanup finishes only that invocation's unfinished frame and cannot pop an outer frame.
+
+Captured non-derived writes stop at the transaction interceptor and produce no cascade or notification until commit replay lands them. Derived property writes are never captured. When a derived write lands while a transaction is open, it recalculates every dependent immediately from landed model inputs. This keeps unrelated dependents current and prevents rollback from leaving a transaction-local value in shared tracking state.
+
+A top-level recalculation publishes after its final recorder frame ends, so synchronous subscribers perform ordinary pending-aware reads. Reentrant publication inside an outer getter, including publication caused by a landed getter side-effect write, remains inside the outer model-read extent. Those synchronous subscribers read landed model values until the outer getter finishes.
 
 #### Writes that never reached the model
 

--- a/docs/design/tracking-derived-properties.md
+++ b/docs/design/tracking-derived-properties.md
@@ -171,11 +171,12 @@ When a source property is written, `WriteProperty` triggers recalculation of all
 ```
 WriteProperty(FirstName = "Jane")
   next(ref context)                              // write the value
+  if !context.IsWritten → return                 // vetoed write did not land
   Interlocked.Increment(_writeGeneration)        // signal for AttachProperty/RecalculateDerivedProperty
   data = FirstName.TryGetDerivedPropertyData()
   if data is null → return                       // fast path: no tracking data
   // Self-recalculation: if this is a derived-with-setter property, recalculate it
-  if data.HasRequiredProperties && Metadata.SetValue != null:
+  if Volatile.Read(ref data.IsDerived) && Metadata.SetValue != null:
     RecalculateDerivedProperty(FirstName, timestamp)
   // Cascade: recalculate all dependent derived properties
   usedByItems = data.GetUsedByProperties()                      // Volatile.Read + Items span
@@ -186,7 +187,7 @@ WriteProperty(FirstName = "Jane")
 
 The `_writeGeneration` increment uses `Interlocked.Increment` (full fence) so that each concurrent writer produces a unique counter value: no lost increments. `AttachProperty`/`RecalculateDerivedProperty` detect concurrent writes via `Volatile.Read` (acquire semantics). The full fence from `Interlocked.Increment` pairs with `Volatile.Read`'s acquire semantics to guarantee that committed property values are visible when the counter change is observed.
 
-**Derived properties with setters** (created via `AddDerivedProperty<T>(name, getValue, setValue)`) have both a getter and a setter. The setter modifies internal state as a side effect, but the actual property value is always determined by the getter. When the setter is called, `WriteProperty` detects `HasRequiredProperties && SetValue != null` and triggers recalculation to re-evaluate the getter and fire a change notification with the correct computed value.
+**Derived properties with setters** (created via `AddDerivedProperty<T>(name, getValue, setValue)`) have both a getter and a setter. The setter modifies internal state as a side effect, but the actual property value is always determined by the getter. After confirming that the write landed, `WriteProperty` detects `IsDerived && SetValue != null` and triggers recalculation to re-evaluate the getter and fire a change notification with the correct computed value.
 
 ### 4. Recalculation
 

--- a/docs/tracking-transactions.md
+++ b/docs/tracking-transactions.md
@@ -396,12 +396,12 @@ When `OnChanging/OnChanged` throws:
 
 ### Derived Properties
 
-Derived properties (marked with `[Derived]`) are handled specially:
+Derived properties (marked with `[Derived]`) are handled specially. The pending read view belongs to each execution flow carrying a live ambient transaction, while derived tracking is shared across flows and therefore uses only values that have landed in the model:
 
-- **Direct reads**: Getters called by application code use pending transaction values.
+- **Direct reads**: Getters called by application code in a flow carrying a live transaction use that transaction's pending values. A flow without a live transaction reads the landed model.
 - **Shared tracking**: Cached derived values, dependencies, timestamps, and notifications use values that have landed in the model.
 - **Captured writes**: Non-derived writes remain silent until commit replay applies them.
-- **Landed writes**: Derived writes are not captured and can recalculate and notify immediately while a transaction is open.
+- **Landed writes**: Writes to settable derived properties are not captured. They land, recalculate, and notify immediately while a transaction is open, and survive transaction disposal or rollback.
 - **Derived chains**: Derived-of-derived tracking uses the landed model view and retains flattened source dependencies.
 
 ```csharp

--- a/docs/tracking-transactions.md
+++ b/docs/tracking-transactions.md
@@ -521,6 +521,8 @@ Note that concurrent `CommitAsync` calls on the same transaction are rejected: o
 - Exclusive transactions use a per-context semaphore
 - Each async execution context has its own transaction scope
 - `Dispose()` clears the transaction only for the disposing flow. A flow that captured its execution context earlier can retain the disposed transaction in its slot; reads and writes on that flow treat it as inactive.
+- A successful or terminally failed commit is inactive for property interception even before disposal. Later reads and writes use the landed model normally; retryable failures remain active.
+- While `CommitAsync()` is in progress, property access carrying that live ambient transaction is rejected unless it is synchronous model replay owned by the commit. This authorization does not extend into the external writer or child tasks.
 - A transaction must be begun, used, committed, and disposed within the same async flow; committing from another flow throws
 - Concurrent `CommitAsync` calls on the same transaction instance are rejected
 

--- a/docs/tracking-transactions.md
+++ b/docs/tracking-transactions.md
@@ -514,7 +514,7 @@ Note that concurrent `CommitAsync` calls on the same transaction are rejected: o
 - `BeginTransactionAsync()` uses `AsyncLocal<T>` to store the current transaction
 - Exclusive transactions use a per-context semaphore
 - Each async execution context has its own transaction scope
-- The transaction is automatically cleared on `Dispose()`
+- `Dispose()` clears the transaction only for the disposing flow. A flow that captured its execution context earlier can retain the disposed transaction in its slot; reads and writes on that flow treat it as inactive.
 - A transaction must be begun, used, committed, and disposed within the same async flow; committing from another flow throws
 - Concurrent `CommitAsync` calls on the same transaction instance are rejected
 

--- a/docs/tracking-transactions.md
+++ b/docs/tracking-transactions.md
@@ -13,7 +13,7 @@ Use transactions when you need guarantees about what was actually persisted to e
 Transactions provide:
 - **Configurable commit modes**: Choose between best-effort or rollback behavior on partial failures
 - **Read-your-writes consistency**: Reading a property inside a transaction returns the pending value
-- **Notification suppression**: Change notifications are suppressed during the transaction and fired after commit
+- **Notification suppression**: Captured non-derived writes stay silent until commit replay applies them
 - **External source integration**: Changes can be written to external sources before being applied to the local model
 - **Rollback on dispose**: Uncommitted changes are discarded when the transaction is disposed
 
@@ -521,6 +521,7 @@ Note that concurrent `CommitAsync` calls on the same transaction are rejected: o
 - Exclusive transactions use a per-context semaphore
 - Each async execution context has its own transaction scope
 - `Dispose()` clears the transaction only for the disposing flow. A flow that captured its execution context earlier can retain the disposed transaction in its slot; reads and writes on that flow treat it as inactive.
+- After `Dispose()`, ambient access is ordinary raw model access even while an already-started external-writer commit completes. Such a raw write is not isolated from the commit and can be overwritten when its frozen snapshot replays.
 - A successful or terminally failed commit is inactive for property interception even before disposal. Later reads and writes use the landed model normally; retryable failures remain active.
 - While `CommitAsync()` is in progress, property access carrying that live ambient transaction is rejected unless it is synchronous model replay owned by the commit. This authorization does not extend into the external writer or child tasks.
 - A transaction must be begun, used, committed, and disposed within the same async flow; committing from another flow throws

--- a/docs/tracking-transactions.md
+++ b/docs/tracking-transactions.md
@@ -398,9 +398,11 @@ When `OnChanging/OnChanged` throws:
 
 Derived properties (marked with `[Derived]`) are handled specially:
 
-- **During capture**: Derived property recalculation notifications are skipped
-- **During read**: Derived properties return calculated value based on pending changes
-- **After commit**: Derived properties are recalculated with committed values and notifications fired
+- **Direct reads**: Getters called by application code use pending transaction values.
+- **Shared tracking**: Cached derived values, dependencies, timestamps, and notifications use values that have landed in the model.
+- **Captured writes**: Non-derived writes remain silent until commit replay applies them.
+- **Landed writes**: Derived writes are not captured and can recalculate and notify immediately while a transaction is open.
+- **Derived chains**: Derived-of-derived tracking uses the landed model view and retains flattened source dependencies.
 
 ```csharp
 [InterceptorSubject]
@@ -421,9 +423,13 @@ using (var transaction = await context.BeginTransactionAsync(TransactionFailureH
     Console.WriteLine(person.FullName); // Output: John Doe (from pending values)
 
     await transaction.CommitAsync(cancellationToken);
-    // FullName change notification is fired after commit
+    // FullName tracking is updated when the captured writes land during commit.
 }
 ```
+
+The same landed-model rule applies when tracking evaluates a getter during initial attachment, automatic recalculation, manual `RecalculateDerivedProperty()`, or a stabilization retry. It does not clear or replace the ambient transaction, so non-derived writes performed as getter side effects are still captured and direct reads resume the pending view as soon as the tracking evaluation finishes.
+
+Notification boundaries follow the evaluation nesting. A top-level derived recalculation publishes after its tracking evaluation has ended, so a synchronous subscriber reads pending values normally. If a getter causes a reentrant derived recalculation or a landed side-effect notification, that nested publication occurs while the outer getter is still being evaluated. Synchronous subscribers in that nested path read landed model values until the outer evaluation finishes.
 
 ### Capture and Commit Replay
 

--- a/docs/tracking-transactions.md
+++ b/docs/tracking-transactions.md
@@ -523,7 +523,8 @@ Note that concurrent `CommitAsync` calls on the same transaction are rejected: o
 - `Dispose()` clears the transaction only for the disposing flow. A flow that captured its execution context earlier can retain the disposed transaction in its slot; reads and writes on that flow treat it as inactive.
 - After `Dispose()`, ambient access is ordinary raw model access even while an already-started external-writer commit completes. Such a raw write is not isolated from the commit and can be overwritten when its frozen snapshot replays.
 - A successful or terminally failed commit is inactive for property interception even before disposal. Later reads and writes use the landed model normally; retryable failures remain active.
-- While `CommitAsync()` is in progress, property access carrying that live ambient transaction is rejected unless it is synchronous model replay owned by the commit. This authorization does not extend into the external writer or child tasks.
+- While a live ambient transaction is committing, property reads and writes on a flow carrying it throw `InvalidOperationException`. This includes custom writer callbacks. Getter reads are also rejected because sibling or landed-model state is outside the frozen snapshot and can make the source payload inconsistent.
+- Commit-owned synchronous local replay remains allowed, including property hooks, change handlers, and derived cascades initiated by that replay. This authorization does not extend into custom writer callbacks or child tasks.
 - A transaction must be begun, used, committed, and disposed within the same async flow; committing from another flow throws
 - Concurrent `CommitAsync` calls on the same transaction instance are rejected
 
@@ -629,7 +630,9 @@ Rollback operations can also fail. If revert fails, `SubjectTransactionException
 
 Most applications use the built-in `SourceTransactionWriter` registered by `WithSourceTransactions()` and never implement `ITransactionWriter`. A custom writer replaces stage 1 of the commit flow (registered as an `ITransactionWriter` service on the context) and is only needed when source writes require protocol-specific orchestration the built-in writer cannot provide.
 
-A custom writer must follow the in-place marking contract documented in the xml docs of `ITransactionWriter.WriteToSourcesAsync`. Moving or replacing a snapshot slot silently corrupts the local apply; not marking accepted slots is harmless but keeps the legacy double write (the apply notifications publish without a `Confirmed` origin and are pushed to the source again). While developing a writer, enable the runtime contract validation:
+Both writer callbacks execute while the caller's live ambient transaction is committing. Do not read or write subject properties from either callback, and do not suppress ambient execution-context flow to bypass this boundary. This includes getters: sibling or landed-model state is not represented by the supplied snapshot and can make source operations inconsistent with it. Construct writes from `changes` and `requirement`, and reverts from `written` and `revertState`, together with writer-owned configuration and any required subject state captured before `CommitAsync()`.
+
+A custom writer must follow the in-place marking contract documented in the XML documentation of `ITransactionWriter.WriteToSourcesAsync`. Moving or replacing a snapshot slot silently corrupts the local apply. Not marking an accepted slot is allowed, but its apply notification publishes without a `Confirmed` origin and the outbound queue pushes the committed value to the source again. While developing a writer, enable the runtime contract validation:
 
 ```csharp
 SubjectTransaction.ValidateWriterContract = true;

--- a/src/Namotion.Interceptor.Tests/OriginWriteContextTests.cs
+++ b/src/Namotion.Interceptor.Tests/OriginWriteContextTests.cs
@@ -34,6 +34,21 @@ public class OriginWriteContextTests
         }
     }
 
+    private sealed class ResolvingOriginProbe : IWriteInterceptor
+    {
+        public ChangeOriginKind? ResolvedKind { get; private set; }
+        public ChangeOriginKind? KindAfterResolution { get; private set; }
+
+        public void WriteProperty<TProperty>(
+            ref PropertyWriteContext<TProperty> context,
+            WriteInterceptionDelegate<TProperty> next)
+        {
+            ResolvedKind = context.GetFinalOrigin().Kind;
+            KindAfterResolution = context.Origin.Kind;
+            next(ref context);
+        }
+    }
+
     [Fact]
     public void WhenWriteIsSetFromSource_ThenOriginIsFromSourceBeforeAndAfterWrite()
     {
@@ -76,6 +91,31 @@ public class OriginWriteContextTests
         // Assert: attempted origin visible mid-chain, Local after finalization.
         Assert.Equal(ChangeOriginKind.FromSource, probe.KindBeforeWrite);
         Assert.Equal(ChangeOriginKind.Local, probe.KindAfterWrite);
+    }
+
+    [Fact]
+    public void WhenFinalOriginIsResolvedBeforeWrite_ThenTheAttemptedOriginRemainsAvailableToTheTerminal()
+    {
+        // Arrange
+        var probe = new ResolvingOriginProbe();
+        var context = InterceptorSubjectContext.Create();
+        context.AddService(probe);
+        var car = new Car(context);
+        var property = new PropertyReference(car, "Speed");
+
+        // Act
+        using (PendingOrigin.Set(property, ChangeOrigin.FromSource(new object()), 42))
+        {
+            car.Speed = 99;
+        }
+
+        // Assert
+        Assert.Equal(ChangeOriginKind.Local, probe.ResolvedKind);
+        Assert.Equal(ChangeOriginKind.FromSource, probe.KindAfterResolution);
+        Assert.True(property.TryGetWriteState(true, out var anyRevision, out _));
+        Assert.True(anyRevision > 0);
+        Assert.True(property.TryGetWriteState(false, out var localRevision, out _));
+        Assert.Equal(0, localRevision);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Reactive.Linq;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
+using Namotion.Interceptor.Tracking.Transactions;
 
 namespace Namotion.Interceptor.Tracking.Tests.Change;
 
@@ -462,5 +463,127 @@ public class DerivedPropertyChangeHandlerTests
         // Assert - Each derived property should fire exactly once (no duplicates)
         Assert.Single(firedEvents, e => e == "FullName");
         Assert.Single(firedEvents, e => e == "FullNameWithPrefix");
+    }
+
+    [Fact]
+    public async Task WhenTransactionIsOpenOnAnotherContext_ThenDerivedPropertiesStillRecalculate()
+    {
+        // Arrange: the written context has no transaction interceptor, so the transaction open on the
+        // other context never captures the write and no commit will replay its cascade. The ambient
+        // transaction slot is process-wide, so the handler still sees that transaction.
+        var transactionContext = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithDerivedPropertyChangeDetection()
+            .WithPropertyChangeSubscriptions();
+
+        var transactionPerson = new Person(transactionContext);
+        var person = new Person(context)
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        var changedProperties = new List<string>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(change => changedProperties.Add(change.Property.Name));
+
+        // Act
+        using (await transactionContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            transactionPerson.FirstName = "Captured";
+            person.FirstName = "Jane";
+        }
+
+        // Assert
+        Assert.Contains(nameof(Person.FirstName), changedProperties);
+        Assert.Contains(nameof(Person.FullName), changedProperties);
+        Assert.Contains(nameof(Person.FullNameWithPrefix), changedProperties);
+    }
+
+    [Fact]
+    public void WhenATransactionBecomesAmbientDuringAnUncapturedWrite_ThenTheDependentsStillRecalculate()
+    {
+        // Arrange: no transaction is ambient when the write starts, so the transaction interceptor takes its
+        // fast path and the write reaches the model. A synchronous observer then opens one, which publishes
+        // it into the ambient slot of the flow the write is running on, so by the time the cascade is
+        // decided a live transaction is bound to this context for a write nothing captured.
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+
+        var person = new Person(context) { LastName = "Doe" };
+        _ = person.FullName;
+
+        SubjectTransaction? ambientTransaction = null;
+        var changedProperties = new List<string>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(change =>
+            {
+                changedProperties.Add(change.Property.Name);
+                if (change.Property.Name == nameof(Person.FirstName) && ambientTransaction is null)
+                {
+                    ambientTransaction = context
+                        .BeginTransactionAsync(TransactionFailureHandling.BestEffort)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            });
+
+        // Act
+        try
+        {
+            person.FirstName = "Jane";
+        }
+        finally
+        {
+            // Disposal releases a process-wide active count, so leaking it here would leave every later
+            // test in the assembly believing a transaction is open.
+            ambientTransaction?.Dispose();
+        }
+
+        // Assert: the model holds the recalculated value either way, so only the announcements discriminate.
+        Assert.Contains(nameof(Person.FullName), changedProperties);
+        Assert.Contains(nameof(Person.FullNameWithPrefix), changedProperties);
+    }
+
+    [Fact]
+    public async Task WhenATransactionIsRolledBack_ThenNoDependentValueWasAnnouncedFromItsPendingState()
+    {
+        // Arrange: a derived write is not captured, so it lands during capture and cascades. The
+        // dependent's getter reads a property the transaction did capture, so recalculating now would
+        // compute from pending state and publish a value the model never holds once the commit is
+        // rolled back, with nothing left to correct it.
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+
+        var subject = new TransactionCascadeSubject(context) { Plain = "committed" };
+        _ = subject.Combined;
+
+        var announced = new List<string?>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Combined))
+            .Subscribe(change => announced.Add(change.GetNewValue<string>()));
+
+        // Act: begin, write, then dispose without committing.
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "uncommitted";
+            subject.DerivedWithSetter = "d1";
+        }
+
+        // Assert
+        Assert.Empty(announced);
+        Assert.Equal("committed|d1", subject.Combined);
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
 using Namotion.Interceptor.Tracking.Transactions;
@@ -463,6 +464,30 @@ public class DerivedPropertyChangeHandlerTests
         // Assert - Each derived property should fire exactly once (no duplicates)
         Assert.Single(firedEvents, e => e == "FullName");
         Assert.Single(firedEvents, e => e == "FullNameWithPrefix");
+    }
+
+    [Fact]
+    public void WhenAWriteIsVetoedAfterTheDerivedHandler_ThenNoWriteTimestampIsBumped()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        context.AddService<IWriteInterceptor>(new VetoingWriteInterceptor());
+
+        var person = new DerivedSetterPerson(context);
+        _ = person.NicknameWithPrefix;
+
+        var nickname = new PropertyReference(person, nameof(DerivedSetterPerson.Nickname));
+        var dependent = new PropertyReference(person, nameof(DerivedSetterPerson.NicknameWithPrefix));
+        var nicknameBefore = nickname.TryGetWriteTimestamp();
+        var dependentBefore = dependent.TryGetWriteTimestamp();
+
+        // Act
+        person.Nickname = "vetoed";
+
+        // Assert
+        Assert.Null(person.Nickname);
+        Assert.Equal(nicknameBefore, nickname.TryGetWriteTimestamp());
+        Assert.Equal(dependentBefore, dependent.TryGetWriteTimestamp());
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Reactive.Linq;
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Lifecycle;
 using Namotion.Interceptor.Tracking.Tests.Models;
 using Namotion.Interceptor.Tracking.Transactions;
 
@@ -591,33 +592,380 @@ public class DerivedPropertyChangeHandlerTests
     [Fact]
     public async Task WhenATransactionIsRolledBack_ThenNoDependentValueWasAnnouncedFromItsPendingState()
     {
-        // Arrange: a derived write is not captured, so it lands during capture and cascades. The
-        // dependent's getter reads a property the transaction did capture, so recalculating now would
-        // compute from pending state and publish a value the model never holds once the commit is
-        // rolled back, with nothing left to correct it.
+        // Arrange
         var context = InterceptorSubjectContext
             .Create()
             .WithFullPropertyTracking()
             .WithTransactions();
 
-        var subject = new TransactionCascadeSubject(context) { Plain = "committed" };
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
         _ = subject.Combined;
 
-        var announced = new List<string?>();
+        var announced = new List<SubjectPropertyChange>();
         using var subscription = context
             .GetPropertyChangeObservable(ImmediateScheduler.Instance)
             .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Combined))
-            .Subscribe(change => announced.Add(change.GetNewValue<string>()));
+            .Subscribe(announced.Add);
 
-        // Act: begin, write, then dispose without committing.
+        // Act
         using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
         {
             subject.Plain = "uncommitted";
             subject.DerivedWithSetter = "d1";
+
+            var landedChange = Assert.Single(announced);
+            Assert.Equal("committed|d1", landedChange.GetNewValue<string>());
+            Assert.DoesNotContain(announced, change => change.GetNewValue<string>() == "uncommitted|d1");
+            Assert.Equal("uncommitted|d1", subject.Combined);
         }
 
         // Assert
-        Assert.Empty(announced);
         Assert.Equal("committed|d1", subject.Combined);
+
+        subject.DerivedWithSetter = "d2";
+
+        var subsequentChange = Assert.Single(
+            announced,
+            change => change.GetNewValue<string>() == "committed|d2");
+        Assert.Equal("committed|d1", subsequentChange.GetOldValue<string>());
+    }
+
+    [Fact]
+    public async Task WhenADerivedSetterLandsWithAPendingDependency_ThenDerivedOfDerivedUsesTheModelView()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            subject.DerivedWithSetter = "d1";
+
+            // Assert
+            Assert.Contains(changes, change =>
+                change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+                change.GetNewValue<string>() == "committed|d1");
+            Assert.Contains(changes, change =>
+                change.Property.Name == nameof(TransactionCascadeSubject.CombinedAgain) &&
+                change.GetNewValue<string>() == "[committed|d1]");
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetNewValue<string>() == "pending|d1");
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.CombinedAgain) &&
+            change.GetNewValue<string>() == "[pending|d1]");
+        Assert.Equal("[pending|d1]", subject.CombinedAgain);
+    }
+
+    [Fact]
+    public async Task WhenOneDependentReadsAPendingProperty_ThenEveryDependentStillRecalculates()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.Combined;
+        _ = subject.Independent;
+
+        var independentChanges = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Independent))
+            .Subscribe(independentChanges.Add);
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            subject.DerivedWithSetter = "d1";
+
+            // Assert
+            var change = Assert.Single(independentChanges);
+            Assert.Equal("d0", change.GetOldValue<string?>());
+            Assert.Equal("d1", change.GetNewValue<string?>());
+        }
+    }
+
+    [Fact]
+    public async Task WhenACommitLandsThePendingDependency_ThenTheFinalCommittedDerivedValuesAreAnnounced()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "committed-after-commit";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetOldValue<string>() == "committed|d0" &&
+            change.GetNewValue<string>() == "committed-after-commit|d0");
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.CombinedAgain) &&
+            change.GetOldValue<string>() == "[committed|d0]" &&
+            change.GetNewValue<string>() == "[committed-after-commit|d0]");
+    }
+
+    [Fact]
+    public async Task WhenADerivedPropertyIsAttachedInsideATransaction_ThenItsCachedValueUsesTheModelView()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.Combined));
+        var lifecycleChange = new SubjectPropertyLifecycleChange((IInterceptorSubject)subject, property);
+        var handler = context.TryGetService<DerivedPropertyChangeHandler>()!;
+        handler.DetachProperty(lifecycleChange);
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            handler.AttachProperty(lifecycleChange);
+        }
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Combined))
+            .Subscribe(changes.Add);
+        subject.DerivedWithSetter = "d1";
+
+        // Assert
+        var change = Assert.Single(changes);
+        Assert.Equal("committed|d0", change.GetOldValue<string>());
+        Assert.Equal("committed|d1", change.GetNewValue<string>());
+    }
+
+    [Fact]
+    public async Task WhenDerivedEvaluationRunsInsideATransaction_ThenTheAmbientTransactionIdentityIsPreserved()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context) { Plain = "committed" };
+        SubjectTransaction? observedTransaction = null;
+        subject.ProbeEvaluator = value =>
+        {
+            observedTransaction = SubjectTransaction.Current;
+            return $"{value.Plain}|evaluated";
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Probe))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe)).RecalculateDerivedProperty();
+
+            // Assert
+            Assert.Same(transaction, observedTransaction);
+            Assert.Same(transaction, SubjectTransaction.Current);
+        }
+
+        Assert.Equal("committed|evaluated", Assert.Single(changes).GetNewValue<string>());
+    }
+
+    [Fact]
+    public async Task WhenAGetterWritesANonDerivedProperty_ThenThatSideEffectIsStillCaptured()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context) { Plain = "committed" };
+        subject.ProbeEvaluator = value =>
+        {
+            value.SideEffect = "captured-side-effect";
+            return $"{value.Plain}|evaluated";
+        };
+
+        // Act
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        subject.Plain = "pending";
+        new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe)).RecalculateDerivedProperty();
+
+        // Assert
+        Assert.Contains(transaction.GetPendingChanges(), change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.SideEffect) &&
+            change.GetNewValue<string?>() == "captured-side-effect");
+
+        string? modelSideEffect = null;
+        var flowControl = ExecutionContext.SuppressFlow();
+        Task readTask;
+        try
+        {
+            readTask = Task.Run(() => modelSideEffect = subject.SideEffect);
+        }
+        finally
+        {
+            flowControl.Undo();
+        }
+
+        await readTask;
+        Assert.Null(modelSideEffect);
+    }
+
+    [Fact]
+    public async Task WhenAGetterPublishesALandedSideEffect_ThenItsSynchronousSubscriberUsesTheModelView()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.Combined;
+
+        string? valueReadBySubscriber = null;
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Combined))
+            .Subscribe(_ => valueReadBySubscriber = subject.Plain);
+        subject.ProbeEvaluator = value =>
+        {
+            value.DerivedWithSetter = "d1";
+            return "outer";
+        };
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe)).RecalculateDerivedProperty();
+
+            // Assert
+            Assert.Equal("committed", valueReadBySubscriber);
+            Assert.Equal("pending", subject.Plain);
+        }
+    }
+
+    [Fact]
+    public async Task WhenAGetterTriggersAReentrantDerivedRecalculation_ThenTheOuterRecorderFrameAndModelViewRemainIntact()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "plain-model",
+            SideEffect = "side-model",
+            DerivedWithSetter = "d0",
+            ExternalSuffix = "before"
+        };
+        _ = subject.Combined;
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe));
+        var writeInnerValue = 0;
+        subject.ProbeEvaluator = value =>
+        {
+            var plain = value.Plain;
+            if (Interlocked.Exchange(ref writeInnerValue, 1) == 0)
+            {
+                value.DerivedWithSetter = "d1";
+            }
+            return $"{plain}|{value.SideEffect}|{value.ExternalSuffix}";
+        };
+
+        var innerSubscriberReads = new List<string?>();
+        var probeChanges = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(change =>
+            {
+                if (change.Property.Name == nameof(TransactionCascadeSubject.Combined))
+                {
+                    innerSubscriberReads.Add($"{subject.Plain}|{subject.SideEffect}");
+                }
+                else if (change.Property.Name == nameof(TransactionCascadeSubject.Probe))
+                {
+                    probeChanges.Add(change);
+                }
+            });
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "plain-pending";
+            subject.SideEffect = "side-pending";
+            subject.ExternalSuffix = "after";
+            property.RecalculateDerivedProperty();
+
+            // Assert
+            Assert.Contains("plain-model|side-model", innerSubscriberReads);
+            Assert.Equal("plain-model|side-model|after", Assert.Single(probeChanges).GetNewValue<string>());
+        }
+
+        probeChanges.Clear();
+        subject.Plain = "plain-landed";
+        Assert.Single(probeChanges);
+        probeChanges.Clear();
+        subject.SideEffect = "side-landed";
+        Assert.Single(probeChanges);
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
@@ -473,16 +473,25 @@ public class DerivedPropertyChangeHandlerTests
         var context = InterceptorSubjectContext.Create().WithFullPropertyTracking();
         context.AddService<IWriteInterceptor>(new VetoingWriteInterceptor());
 
-        var person = new DerivedSetterPerson(context);
-        _ = person.NicknameWithPrefix;
+        var initialTimestamp = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DerivedSetterPerson person;
+        using (SubjectChangeContext.WithChangedTimestamp(initialTimestamp))
+        {
+            person = new DerivedSetterPerson(context);
+            _ = person.NicknameWithPrefix;
+        }
 
         var nickname = new PropertyReference(person, nameof(DerivedSetterPerson.Nickname));
         var dependent = new PropertyReference(person, nameof(DerivedSetterPerson.NicknameWithPrefix));
         var nicknameBefore = nickname.TryGetWriteTimestamp();
         var dependentBefore = dependent.TryGetWriteTimestamp();
+        var vetoTimestamp = initialTimestamp.AddSeconds(1);
 
         // Act
-        person.Nickname = "vetoed";
+        using (SubjectChangeContext.WithChangedTimestamp(vetoTimestamp))
+        {
+            person.Nickname = "vetoed";
+        }
 
         // Assert
         Assert.Null(person.Nickname);

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
@@ -663,12 +663,20 @@ public class DerivedPropertyChangeHandlerTests
             subject.DerivedWithSetter = "d1";
 
             // Assert
-            Assert.Contains(changes, change =>
-                change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
-                change.GetNewValue<string>() == "committed|d1");
-            Assert.Contains(changes, change =>
-                change.Property.Name == nameof(TransactionCascadeSubject.CombinedAgain) &&
-                change.GetNewValue<string>() == "[committed|d1]");
+            Assert.Collection(
+                changes,
+                change =>
+                {
+                    Assert.Equal(nameof(TransactionCascadeSubject.Combined), change.Property.Name);
+                    Assert.Equal("committed|d0", change.GetOldValue<string>());
+                    Assert.Equal("committed|d1", change.GetNewValue<string>());
+                },
+                change =>
+                {
+                    Assert.Equal(nameof(TransactionCascadeSubject.CombinedAgain), change.Property.Name);
+                    Assert.Equal("[committed|d0]", change.GetOldValue<string>());
+                    Assert.Equal("[committed|d1]", change.GetNewValue<string>());
+                });
 
             await transaction.CommitAsync(CancellationToken.None);
         }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyChangeHandlerTests.cs
@@ -976,4 +976,52 @@ public class DerivedPropertyChangeHandlerTests
         subject.SideEffect = "side-landed";
         Assert.Single(probeChanges);
     }
+
+    [Fact]
+    public void WhenAReentrantDerivedGetterFinishesWithoutAnotherRead_ThenAFollowingSubjectStillTracksDerivedProperties()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking();
+        var reentrantSubject = new TransactionCascadeSubject(context)
+        {
+            Plain = "before",
+            DerivedWithSetter = "d0"
+        };
+        var triggerInnerRecalculation = 0;
+        reentrantSubject.ProbeEvaluator = subject =>
+        {
+            var result = subject.Plain;
+            if (Interlocked.Exchange(ref triggerInnerRecalculation, 1) == 0)
+            {
+                subject.DerivedWithSetter = "d1";
+            }
+
+            return result;
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(changes.Add);
+
+        // Act
+        new PropertyReference(reentrantSubject, nameof(TransactionCascadeSubject.Probe))
+            .RecalculateDerivedProperty();
+
+        var unrelatedSubject = new Person(context)
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+        changes.Clear();
+        unrelatedSubject.FirstName = "Jane";
+
+        // Assert
+        var change = Assert.Single(changes, change =>
+            change.Property.Subject == unrelatedSubject &&
+            change.Property.Name == nameof(Person.FullName));
+        Assert.Equal("John Doe", change.GetOldValue<string>());
+        Assert.Equal("Jane Doe", change.GetNewValue<string>());
+    }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationCollection.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationCollection.cs
@@ -1,0 +1,7 @@
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DerivedPropertyWriteGenerationCollection
+{
+    public const string Name = nameof(DerivedPropertyWriteGenerationCollection);
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationTests.cs
@@ -1,0 +1,43 @@
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+[Collection(DerivedPropertyWriteGenerationCollection.Name)]
+public class DerivedPropertyWriteGenerationTests
+{
+    [Fact]
+    public async Task WhenAVetoedWriteOccursDuringDependencyDiscovery_ThenTheGetterIsNotReevaluated()
+    {
+        // Arrange
+        var evaluationContext = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        using var subject = new SwitchableDerivedSubject(evaluationContext);
+        var callsBefore = subject.GetterCallCount;
+        subject.UseSecond = true;
+        subject.BlockNextEvaluation();
+
+        var vetoContext = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        vetoContext.AddService<IWriteInterceptor>(new VetoingWriteInterceptor());
+        var vetoedSubject = new Person(vetoContext);
+
+        // Act
+        var trigger = Task.Run(() => subject.First = 1);
+        try
+        {
+            Assert.True(
+                subject.EvaluationEntered.Wait(TimeSpan.FromSeconds(10)),
+                "derived getter did not start");
+            vetoedSubject.FirstName = "vetoed";
+        }
+        finally
+        {
+            subject.ContinueEvaluation.Set();
+        }
+
+        await trigger.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        Assert.Equal(callsBefore + 1, subject.GetterCallCount);
+        Assert.Null(vetoedSubject.FirstName);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationTests.cs
@@ -32,9 +32,8 @@ public class DerivedPropertyWriteGenerationTests
         finally
         {
             subject.ContinueEvaluation.Set();
+            await trigger.WaitAsync(TimeSpan.FromSeconds(10));
         }
-
-        await trigger.WaitAsync(TimeSpan.FromSeconds(10));
 
         // Assert
         Assert.Equal(callsBefore + 1, subject.GetterCallCount);

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -470,12 +470,20 @@ public class RecalculateDerivedPropertyTests
             outerProperty.RecalculateDerivedProperty();
 
             // Assert
-            Assert.Contains(changes, change =>
-                change.Property.Name == nameof(TransactionCascadeSubject.ManualCombined) &&
-                change.GetNewValue<string>() == "plain-model|after");
-            Assert.Contains(changes, change =>
-                change.Property.Name == nameof(TransactionCascadeSubject.Probe) &&
-                change.GetNewValue<string>() == "plain-model|side-model");
+            Assert.Collection(
+                changes,
+                change =>
+                {
+                    Assert.Equal(nameof(TransactionCascadeSubject.ManualCombined), change.Property.Name);
+                    Assert.Equal("plain-model|before", change.GetOldValue<string>());
+                    Assert.Equal("plain-model|after", change.GetNewValue<string>());
+                },
+                change =>
+                {
+                    Assert.Equal(nameof(TransactionCascadeSubject.Probe), change.Property.Name);
+                    Assert.Equal("plain-model", change.GetOldValue<string>());
+                    Assert.Equal("plain-model|side-model", change.GetNewValue<string>());
+                });
         }
     }
 
@@ -591,7 +599,7 @@ public class RecalculateDerivedPropertyTests
             releaseEvaluations.Set();
         }
 
-        await Task.WhenAll(firstTask, secondTask);
+        await Task.WhenAll(firstTask, secondTask).WaitAsync(TimeSpan.FromSeconds(10));
 
         // Assert
         Assert.Equal("model-1|evaluated", firstTrackedValue);

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -543,26 +543,39 @@ public class RecalculateDerivedPropertyTests
         var secondContext = InterceptorSubjectContext.Create()
             .WithFullPropertyTracking()
             .WithTransactions();
+        var ordinaryReadContext = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
         var first = new TransactionCascadeSubject(firstContext) { Plain = "model-1" };
         var second = new TransactionCascadeSubject(secondContext) { Plain = "model-2" };
+        var ordinaryReadSubject = new TransactionCascadeSubject(ordinaryReadContext) { Plain = "ordinary-model" };
         using var evaluationsEntered = new CountdownEvent(2);
         using var releaseEvaluations = new ManualResetEventSlim();
 
         first.ProbeEvaluator = value =>
         {
             evaluationsEntered.Signal();
-            releaseEvaluations.Wait();
+            if (!releaseEvaluations.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new TimeoutException("first derived evaluation was not released");
+            }
+
             return $"{value.Plain}|evaluated";
         };
         second.ProbeEvaluator = value =>
         {
             evaluationsEntered.Signal();
-            releaseEvaluations.Wait();
+            if (!releaseEvaluations.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new TimeoutException("second derived evaluation was not released");
+            }
+
             return $"{value.Plain}|evaluated";
         };
 
         string? firstTrackedValue = null;
         string? secondTrackedValue = null;
+        string? ordinaryPendingRead = null;
         using var firstSubscription = firstContext
             .GetPropertyChangeObservable(ImmediateScheduler.Instance)
             .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Probe))
@@ -593,6 +606,11 @@ public class RecalculateDerivedPropertyTests
         try
         {
             Assert.True(evaluationsEntered.Wait(TimeSpan.FromSeconds(10)), "parallel evaluations did not overlap");
+            using (await ordinaryReadContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+            {
+                ordinaryReadSubject.Plain = "ordinary-pending";
+                ordinaryPendingRead = ordinaryReadSubject.Plain;
+            }
         }
         finally
         {
@@ -604,5 +622,6 @@ public class RecalculateDerivedPropertyTests
         // Assert
         Assert.Equal("model-1|evaluated", firstTrackedValue);
         Assert.Equal("model-2|evaluated", secondTrackedValue);
+        Assert.Equal("ordinary-pending", ordinaryPendingRead);
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -2,6 +2,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
+using Namotion.Interceptor.Tracking.Transactions;
 
 namespace Namotion.Interceptor.Tracking.Tests.Change;
 
@@ -237,5 +238,363 @@ public class RecalculateDerivedPropertyTests
             var finalNotifiedValue = changes[^1].GetNewValue<double>();
             Assert.Equal((double)callCount, finalNotifiedValue);
         }
+    }
+
+    [Fact]
+    public async Task WhenManualRecalculationRunsInsideATransaction_ThenTrackingUsesTheModelView()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            ExternalSuffix = "before"
+        };
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.ManualCombined));
+        property.RecalculateDerivedProperty();
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.ManualCombined))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            subject.ExternalSuffix = "after";
+            property.RecalculateDerivedProperty();
+
+            // Assert
+            var change = Assert.Single(changes);
+            Assert.Equal("committed|before", change.GetOldValue<string>());
+            Assert.Equal("committed|after", change.GetNewValue<string>());
+            Assert.Equal("pending|after", subject.ManualCombined);
+        }
+    }
+
+    [Fact]
+    public async Task WhenAGetterThrowsInsideATransaction_ThenLaterDirectReadsStillReturnPendingValues()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context) { Plain = "committed" };
+        subject.ProbeEvaluator = _ => throw new InvalidOperationException("Probe failure.");
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe));
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            property.RecalculateDerivedProperty();
+
+            // Assert
+            Assert.Same(transaction, SubjectTransaction.Current);
+            Assert.Equal("pending", subject.Plain);
+
+            subject.ProbeEvaluator = value => $"{value.Plain}|recovered";
+            property.RecalculateDerivedProperty();
+            Assert.Equal("pending", subject.Plain);
+        }
+    }
+
+    [Fact]
+    public async Task WhenANotificationSubscriberReadsInsideATransaction_ThenItSeesPendingValues()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "committed",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.Combined;
+
+        string? valueReadBySubscriber = null;
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Combined))
+            .Subscribe(_ => valueReadBySubscriber = subject.Combined);
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            subject.DerivedWithSetter = "d1";
+
+            // Assert
+            Assert.Equal("pending|d1", valueReadBySubscriber);
+        }
+    }
+
+    [Fact]
+    public void WhenAGetterStartsATransaction_ThenItsStoredValueStillUsesTheModelView()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "initial",
+            SideEffect = "model"
+        };
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe));
+        SubjectTransaction? startedTransaction = null;
+        subject.ProbeEvaluator = value =>
+        {
+            startedTransaction ??= context
+                .BeginTransactionAsync(TransactionFailureHandling.BestEffort)
+                .GetAwaiter()
+                .GetResult();
+            value.SideEffect = "pending-from-getter";
+            return value.SideEffect;
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Probe))
+            .Subscribe(changes.Add);
+
+        // Act
+        try
+        {
+            property.RecalculateDerivedProperty();
+
+            // Assert
+            Assert.NotNull(startedTransaction);
+            Assert.Same(startedTransaction, SubjectTransaction.Current);
+            Assert.Equal("model", Assert.Single(changes).GetNewValue<string?>());
+            Assert.Equal("pending-from-getter", subject.SideEffect);
+        }
+        finally
+        {
+            startedTransaction?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WhenAGetterReplacesTheAmbientTransaction_ThenItsStoredValueUsesTheModelViewAndTheReplacementRemainsAmbient()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "initial",
+            SideEffect = "model"
+        };
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe));
+        var originalTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        SubjectTransaction? replacementTransaction = null;
+        subject.ProbeEvaluator = value =>
+        {
+            originalTransaction.Dispose();
+            replacementTransaction ??= context
+                .BeginTransactionAsync(TransactionFailureHandling.BestEffort)
+                .GetAwaiter()
+                .GetResult();
+            value.SideEffect = "pending-in-replacement";
+            return value.SideEffect;
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Probe))
+            .Subscribe(changes.Add);
+
+        // Act
+        try
+        {
+            property.RecalculateDerivedProperty();
+
+            // Assert
+            Assert.NotNull(replacementTransaction);
+            Assert.Same(replacementTransaction, SubjectTransaction.Current);
+            Assert.Equal("model", Assert.Single(changes).GetNewValue<string?>());
+            Assert.Equal("pending-in-replacement", subject.SideEffect);
+        }
+        finally
+        {
+            replacementTransaction?.Dispose();
+            originalTransaction.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WhenDerivedEvaluationsAreNested_ThenEveryGetterUsesTheModelView()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "plain-model",
+            SideEffect = "side-model",
+            ExternalSuffix = "before"
+        };
+        var innerProperty = new PropertyReference(subject, nameof(TransactionCascadeSubject.ManualCombined));
+        var outerProperty = new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe));
+        innerProperty.RecalculateDerivedProperty();
+        subject.ProbeEvaluator = value =>
+        {
+            innerProperty.RecalculateDerivedProperty();
+            return $"{value.Plain}|{value.SideEffect}";
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.ManualCombined) or
+                nameof(TransactionCascadeSubject.Probe))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "plain-pending";
+            subject.SideEffect = "side-pending";
+            subject.ExternalSuffix = "after";
+            outerProperty.RecalculateDerivedProperty();
+
+            // Assert
+            Assert.Contains(changes, change =>
+                change.Property.Name == nameof(TransactionCascadeSubject.ManualCombined) &&
+                change.GetNewValue<string>() == "plain-model|after");
+            Assert.Contains(changes, change =>
+                change.Property.Name == nameof(TransactionCascadeSubject.Probe) &&
+                change.GetNewValue<string>() == "plain-model|side-model");
+        }
+    }
+
+    [Fact]
+    public async Task WhenDerivedEvaluationCompletes_ThenItsBypassDoesNotFlowToAQueuedWorkItem()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var subject = new TransactionCascadeSubject(context) { Plain = "model" };
+        var property = new PropertyReference(subject, nameof(TransactionCascadeSubject.Probe));
+        using var evaluationCompleted = new ManualResetEventSlim();
+        using var workStarted = new ManualResetEventSlim();
+        using var workCompleted = new ManualResetEventSlim();
+        string? queuedRead = null;
+        subject.ProbeEvaluator = value =>
+        {
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                workStarted.Set();
+                evaluationCompleted.Wait();
+                queuedRead = value.Plain;
+                workCompleted.Set();
+            });
+            return value.Plain;
+        };
+
+        // Act
+        using (await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "pending";
+            try
+            {
+                property.RecalculateDerivedProperty();
+                Assert.True(workStarted.Wait(TimeSpan.FromSeconds(10)), "queued work did not start");
+            }
+            finally
+            {
+                evaluationCompleted.Set();
+            }
+
+            Assert.True(workCompleted.Wait(TimeSpan.FromSeconds(10)), "queued work did not finish");
+
+            // Assert
+            Assert.Equal("pending", queuedRead);
+        }
+    }
+
+    [Fact]
+    public async Task WhenDerivedEvaluationsRunOnParallelThreads_ThenTheirBypassesAreIsolated()
+    {
+        // Arrange
+        var firstContext = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var secondContext = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions();
+        var first = new TransactionCascadeSubject(firstContext) { Plain = "model-1" };
+        var second = new TransactionCascadeSubject(secondContext) { Plain = "model-2" };
+        using var evaluationsEntered = new CountdownEvent(2);
+        using var releaseEvaluations = new ManualResetEventSlim();
+
+        first.ProbeEvaluator = value =>
+        {
+            evaluationsEntered.Signal();
+            releaseEvaluations.Wait();
+            return $"{value.Plain}|evaluated";
+        };
+        second.ProbeEvaluator = value =>
+        {
+            evaluationsEntered.Signal();
+            releaseEvaluations.Wait();
+            return $"{value.Plain}|evaluated";
+        };
+
+        string? firstTrackedValue = null;
+        string? secondTrackedValue = null;
+        using var firstSubscription = firstContext
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Probe))
+            .Subscribe(change => firstTrackedValue = change.GetNewValue<string?>());
+        using var secondSubscription = secondContext
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name == nameof(TransactionCascadeSubject.Probe))
+            .Subscribe(change => secondTrackedValue = change.GetNewValue<string?>());
+
+        // Act
+        var firstTask = Task.Run(async () =>
+        {
+            using (await firstContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+            {
+                first.Plain = "pending-1";
+                new PropertyReference(first, nameof(TransactionCascadeSubject.Probe)).RecalculateDerivedProperty();
+            }
+        });
+        var secondTask = Task.Run(async () =>
+        {
+            using (await secondContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+            {
+                second.Plain = "pending-2";
+                new PropertyReference(second, nameof(TransactionCascadeSubject.Probe)).RecalculateDerivedProperty();
+            }
+        });
+
+        try
+        {
+            Assert.True(evaluationsEntered.Wait(TimeSpan.FromSeconds(10)), "parallel evaluations did not overlap");
+        }
+        finally
+        {
+            releaseEvaluations.Set();
+        }
+
+        await Task.WhenAll(firstTask, secondTask);
+
+        // Assert
+        Assert.Equal("model-1|evaluated", firstTrackedValue);
+        Assert.Equal("model-2|evaluated", secondTrackedValue);
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/VetoingWriteInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/VetoingWriteInterceptor.cs
@@ -1,0 +1,15 @@
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Tracking.Tests.Change;
+
+[RunsAfter(typeof(DerivedPropertyChangeHandler))]
+internal sealed class VetoingWriteInterceptor : IWriteInterceptor
+{
+    public void WriteProperty<TProperty>(
+        ref PropertyWriteContext<TProperty> context,
+        WriteInterceptionDelegate<TProperty> next)
+    {
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/DerivedSetterPerson.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/DerivedSetterPerson.cs
@@ -1,0 +1,13 @@
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+[InterceptorSubject]
+public partial class DerivedSetterPerson
+{
+    [Derived]
+    public partial string? Nickname { get; set; }
+
+    [Derived]
+    public string NicknameWithPrefix => $"Mr. {Nickname}";
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/SwitchableDerivedSubject.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/SwitchableDerivedSubject.cs
@@ -1,0 +1,45 @@
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+[InterceptorSubject]
+public partial class SwitchableDerivedSubject : IDisposable
+{
+    private int _getterCallCount;
+    private int _blockNextEvaluation;
+
+    internal ManualResetEventSlim EvaluationEntered { get; } = new(false);
+    internal ManualResetEventSlim ContinueEvaluation { get; } = new(false);
+    internal int GetterCallCount => Volatile.Read(ref _getterCallCount);
+    internal bool UseSecond { get; set; }
+
+    public partial int First { get; set; }
+    public partial int Second { get; set; }
+
+    internal void BlockNextEvaluation() => Volatile.Write(ref _blockNextEvaluation, 1);
+
+    [Derived]
+    public int Selected
+    {
+        get
+        {
+            Interlocked.Increment(ref _getterCallCount);
+            if (Interlocked.Exchange(ref _blockNextEvaluation, 0) == 1)
+            {
+                EvaluationEntered.Set();
+                if (!ContinueEvaluation.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("The test did not release the derived getter.");
+                }
+            }
+
+            return UseSecond ? Second : First;
+        }
+    }
+
+    public void Dispose()
+    {
+        EvaluationEntered.Dispose();
+        ContinueEvaluation.Dispose();
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/TransactionCascadeSubject.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/TransactionCascadeSubject.cs
@@ -7,9 +7,45 @@ public partial class TransactionCascadeSubject
 {
     public partial string? Plain { get; set; }
 
+    public partial string? SideEffect { get; set; }
+
+    public partial string? Failing { get; set; }
+
+    private bool _throwOnFailingWrite;
+
+    internal bool ThrowOnFailingWrite
+    {
+        get => Volatile.Read(ref _throwOnFailingWrite);
+        set => Volatile.Write(ref _throwOnFailingWrite, value);
+    }
+
+    partial void OnFailingChanging(ref string? newValue, ref bool cancel)
+    {
+        if (ThrowOnFailingWrite)
+        {
+            throw new InvalidOperationException("Setter failed.");
+        }
+    }
+
     [Derived]
     public partial string? DerivedWithSetter { get; set; }
 
     [Derived]
     public string Combined => $"{Plain}|{DerivedWithSetter}";
+
+    [Derived]
+    public string CombinedAgain => $"[{Combined}]";
+
+    [Derived]
+    public string? Independent => DerivedWithSetter;
+
+    internal string? ExternalSuffix { get; set; }
+
+    [Derived]
+    public string ManualCombined => $"{Plain}|{ExternalSuffix}";
+
+    internal Func<TransactionCascadeSubject, string?>? ProbeEvaluator { get; set; }
+
+    [Derived]
+    public string? Probe => ProbeEvaluator?.Invoke(this) ?? Plain;
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/TransactionCascadeSubject.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/TransactionCascadeSubject.cs
@@ -1,0 +1,15 @@
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+[InterceptorSubject]
+public partial class TransactionCascadeSubject
+{
+    public partial string? Plain { get; set; }
+
+    [Derived]
+    public partial string? DerivedWithSetter { get; set; }
+
+    [Derived]
+    public string Combined => $"{Plain}|{DerivedWithSetter}";
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -51,12 +51,12 @@ public class SubjectTransactionTests
     }
 
     [Fact]
-    public async Task WhenTheContextResolvesTwoTransactionInterceptors_ThenTheWriteIsCapturedInsteadOfThrowing()
+    public async Task WhenTheBoundTransactionInterceptorIsInheritedAndSecond_ThenTheWriteIsCapturedInsteadOfThrowing()
     {
         // Arrange: context inheritance adds another context as a fallback on attach, so a subject built on
-        // one transaction-enabled context and attached into a graph rooted on another resolves two.
-        // Requiring exactly one threw out of the property setter, which on a scheduler thread ends the
-        // process; the question being asked is only whether the transaction belongs to this context.
+        // one transaction-enabled context and attached into a graph rooted on another resolves two. The
+        // subject's own interceptor is first and the fallback's interceptor is second, so binding must scan
+        // all resolved instances by reference rather than accepting only the first one.
         var context = CreateTransactionContext();
         var fallbackContext = CreateTransactionContext();
 
@@ -64,7 +64,7 @@ public class SubjectTransactionTests
         ((IInterceptorSubject)person).Context.AddFallbackContext(fallbackContext);
 
         // Act
-        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        using (var transaction = await fallbackContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
         {
             person.FirstName = "John";
 
@@ -77,6 +77,25 @@ public class SubjectTransactionTests
         }
 
         Assert.Equal("John", person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenTransactionIsBoundToAnUnrelatedContext_ThenWriteThrows()
+    {
+        // Arrange
+        var subjectContext = CreateTransactionContext();
+        var transactionContext = CreateTransactionContext();
+        var person = new Person(subjectContext);
+
+        using var transaction = await transactionContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() => person.FirstName = "John");
+
+        // Assert
+        Assert.Contains("Transaction is bound to a different context", exception.Message);
+        Assert.Empty(transaction.GetPendingChanges());
+        Assert.Null(person.FirstName);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -1,3 +1,6 @@
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Registry;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using Namotion.Interceptor.Tracking.Change;
@@ -574,6 +577,221 @@ public class SubjectTransactionTests
 
         // Assert
         Assert.Same(transaction2, SubjectTransaction.Current);
+    }
+
+    [Fact]
+    public async Task WhenAmbientTransactionIsDisposedAndAnotherIsOpen_ThenWriteAppliesToModelAndIsNotCapturedByTheOtherTransaction()
+    {
+        // Arrange: capture the flow while a transaction is current, then dispose that transaction. The
+        // captured flow keeps pointing at the disposed transaction, which is what any thread started
+        // inside a transaction sees for its whole life (an Rx EventLoopScheduler worker, for example).
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Old" };
+
+        var disposedTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        var frozenFlow = ExecutionContext.Capture()
+            ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+        disposedTransaction.Dispose();
+
+        // The second transaction keeps the process-wide active count above zero, so the interceptor does
+        // not take its no-transaction fast path.
+        using var openTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.LastName = "Doe";
+
+        // Act
+        ExecutionContext.Run(frozenFlow, _ => person.FirstName = "New", null);
+
+        // Assert: the write went straight to the model instead of into the pooled dictionary. Read it
+        // from a flow with no ambient transaction so no pending value can mask the stored value.
+        string? modelFirstName = null;
+        await RunWithoutAsyncLocalFlowAsync(() => modelFirstName = person.FirstName);
+        Assert.Equal("New", modelFirstName);
+        Assert.DoesNotContain(openTransaction.GetPendingChanges(), change => change.Property.Name == nameof(Person.FirstName));
+
+        await openTransaction.CommitAsync(CancellationToken.None);
+        Assert.Equal("New", person.FirstName);
+        Assert.Equal("Doe", person.LastName);
+    }
+
+    [Fact]
+    public async Task WhenAmbientTransactionIsDisposedAndAnotherIsOpen_ThenReadReturnsTheModelValueInsteadOfAPendingValue()
+    {
+        // Arrange: capture the flow while a transaction is current and holds a pending value, then dispose
+        // that transaction. The captured flow keeps pointing at the disposed transaction, which is what any
+        // thread started inside a transaction sees for its whole life (an Rx EventLoopScheduler worker,
+        // for example).
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Model" };
+
+        var disposedTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        var frozenFlow = ExecutionContext.Capture()
+            ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+        person.FirstName = "PendingInDisposedTransaction";
+        disposedTransaction.Dispose();
+
+        // The second transaction keeps the process-wide active count above zero, so the interceptor does not
+        // take its no-transaction fast path. Whether the pool hands it the dictionary the first transaction
+        // returned does not matter: Dispose nulled that transaction's reference to it.
+        using var openTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.FirstName = "PendingInOpenTransaction";
+
+        // Act
+        string? readThroughDisposedTransaction = null;
+        ExecutionContext.Run(frozenFlow, _ => readThroughDisposedTransaction = person.FirstName, null);
+
+        // Assert: neither the disposed transaction's captured value nor the open transaction's pending value.
+        Assert.Equal("Model", readThroughDisposedTransaction);
+
+        // The disposed transaction holds nothing to serve, whichever transaction owns the pooled dictionary.
+        Assert.Empty(disposedTransaction.GetPendingChanges());
+        Assert.False(disposedTransaction.TryGetPendingValue<string?>(
+            new PropertyReference(person, nameof(Person.FirstName)), out _));
+
+        string? modelFirstName = null;
+        await RunWithoutAsyncLocalFlowAsync(() => modelFirstName = person.FirstName);
+        Assert.Equal("Model", modelFirstName);
+
+        // The open transaction still masks reads in its own flow.
+        Assert.Equal("PendingInOpenTransaction", person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenAmbientTransactionIsDisposedWhileAnotherThreadWrites_ThenNoExceptionEscapesTheSetterAndTheWriteLands()
+    {
+        // Arrange: a thread born inside a transaction keeps that transaction in its ambient slot for life
+        // (an Rx EventLoopScheduler worker, for example). Writing on that thread while another flow disposes
+        // the transaction races the interceptor's disposed check against the capture itself. An exception
+        // escaping the setter there is unhandled on a bare thread and terminates the process, so the write
+        // has to fall through to the model instead, exactly as if no transaction were ambient.
+        var context = CreateTransactionContext();
+        var person = new Person(context) { LastName = "Model" };
+
+        // The race is reachable within a handful of iterations; bounded so the test always terminates.
+        for (var iteration = 0; iteration < 50; iteration++)
+        {
+            var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+            var frozenFlow = ExecutionContext.Capture()
+                ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+
+            var writerStarted = new ManualResetEventSlim();
+            var disposeCompleted = false;
+            Exception? escapedException = null;
+            var valueWrittenAfterDispose = $"AfterDispose{iteration}";
+
+            var writerThread = new Thread(() => ExecutionContext.Run(frozenFlow, _ =>
+            {
+                try
+                {
+                    writerStarted.Set();
+                    var writeCount = 0;
+                    while (!Volatile.Read(ref disposeCompleted))
+                    {
+                        // Distinct values so the equality check never short-circuits the chain.
+                        person.LastName = $"Racing{writeCount++}";
+                    }
+
+                    person.LastName = valueWrittenAfterDispose;
+                }
+                catch (Exception exception)
+                {
+                    escapedException = exception;
+                }
+            }, null));
+
+            // Act
+            writerThread.Start();
+            Assert.True(writerStarted.Wait(TimeSpan.FromSeconds(10)), "writer did not start");
+            transaction.Dispose();
+            Volatile.Write(ref disposeCompleted, true);
+            Assert.True(writerThread.Join(TimeSpan.FromSeconds(10)), "writer did not stop");
+
+            // Assert
+            Assert.Null(escapedException);
+            Assert.Equal(valueWrittenAfterDispose, person.LastName);
+        }
+    }
+
+    [Fact]
+    public async Task WhenCommitIsParkedOnTheTransactionLockAndTheTransactionIsDisposed_ThenTheCommitCompletesWithoutFailing()
+    {
+        // Arrange: an optimistic commit parks acquiring the per-context transaction lock. A dispose on
+        // another flow then releases the pending-changes buffer while the commit is still parked, so the
+        // commit resumes with a null buffer. The null tolerance in StartCommitAndSnapshotChanges and
+        // FinishCommit is what keeps that from being a NullReferenceException; it is load-bearing, not
+        // defensive.
+        var context = CreateTransactionContext();
+        var person = new Person(context) { LastName = "Model" };
+
+        var lockHolder = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+
+        SubjectTransaction? parkedTransaction = null;
+        Task? parkedCommit = null;
+        var commitParked = new ManualResetEventSlim();
+
+        // Suppressed so the parked transaction does not inherit lockHolder as its ambient transaction.
+        var flowControl = ExecutionContext.SuppressFlow();
+        Task starter;
+        try
+        {
+            starter = Task.Run(async () =>
+            {
+                parkedTransaction = await context.BeginTransactionAsync(
+                    TransactionFailureHandling.BestEffort, TransactionLocking.Optimistic);
+                person.LastName = "Pending";
+
+                // CommitAsync has already parked on the lock by the time it returns its incomplete task.
+                parkedCommit = parkedTransaction.CommitAsync(CancellationToken.None).AsTask();
+                commitParked.Set();
+                await parkedCommit;
+            });
+        }
+        finally
+        {
+            flowControl.Undo();
+        }
+
+        Assert.True(commitParked.Wait(TimeSpan.FromSeconds(10)), "commit did not reach the transaction lock");
+
+        // Act
+        parkedTransaction!.Dispose();
+        lockHolder.Dispose();
+        await starter.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        Assert.True(parkedCommit!.IsCompletedSuccessfully);
+        Assert.Empty(parkedTransaction.GetPendingChanges());
+
+        string? modelLastName = null;
+        await RunWithoutAsyncLocalFlowAsync(() => modelLastName = person.LastName);
+        Assert.Equal("Model", modelLastName);
+    }
+
+    [Fact]
+    public async Task WhenSourceValueIsTransformedBeforeCapture_ThenTheCapturedOriginIsLocal()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create()
+            .WithFullPropertyTracking()
+            .WithTransactions()
+            .WithRegistry();
+        context.AddService<IWriteInterceptor>(new TransformingWriteInterceptor());
+
+        var person = new Person(context);
+        var source = new object();
+        var registeredProperty = person.TryGetRegisteredSubject()!
+            .TryGetProperty(nameof(Person.LastName))!;
+
+        // Act
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        registeredProperty.SetValueFromSource(source, null, null, "smith");
+
+        // Assert
+        var pending = Assert.Single(transaction.GetPendingChanges());
+        Assert.Equal("SMITH", pending.GetNewValue<string?>());
+        Assert.Equal(ChangeOriginKind.Local, pending.Origin.Kind);
+
+        await transaction.CommitAsync(CancellationToken.None);
+        Assert.Equal("SMITH", person.LastName);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -918,6 +918,223 @@ public class SubjectTransactionTests
         Assert.Equal("SMITH", person.LastName);
     }
 
+    [Fact]
+    public async Task WhenBestEffortPartiallyApplies_ThenDerivedAndDerivedOfDerivedTrackTheAppliedModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "original",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            subject.Plain = "applied";
+            subject.Failing = "fails";
+            subject.ThrowOnFailingWrite = true;
+            await Assert.ThrowsAsync<SubjectTransactionException>(
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
+        }
+
+        // Assert
+        Assert.Collection(
+            changes,
+            change => AssertDerivedChange(change, nameof(TransactionCascadeSubject.Combined), "original|d0", "applied|d0"),
+            change => AssertDerivedChange(change, nameof(TransactionCascadeSubject.CombinedAgain), "[original|d0]", "[applied|d0]"));
+        Assert.Equal("applied", subject.Plain);
+        Assert.Equal("applied|d0", subject.Combined);
+        Assert.Equal("[applied|d0]", subject.CombinedAgain);
+
+        changes.Clear();
+        subject.DerivedWithSetter = "d1";
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetOldValue<string>() == "applied|d0" &&
+            change.GetNewValue<string>() == "applied|d1");
+    }
+
+    [Fact]
+    public async Task WhenRollbackRevertsALocalApply_ThenDerivedAndDerivedOfDerivedReturnToTheOriginalModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "original",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.Rollback))
+        {
+            subject.Plain = "temporarily-applied";
+            subject.Failing = "fails";
+            subject.ThrowOnFailingWrite = true;
+            await Assert.ThrowsAsync<SubjectTransactionException>(
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
+        }
+
+        // Assert
+        Assert.Collection(
+            changes,
+            change => AssertDerivedChange(change, nameof(TransactionCascadeSubject.Combined), "original|d0", "temporarily-applied|d0"),
+            change => AssertDerivedChange(change, nameof(TransactionCascadeSubject.CombinedAgain), "[original|d0]", "[temporarily-applied|d0]"),
+            change => AssertDerivedChange(change, nameof(TransactionCascadeSubject.Combined), "temporarily-applied|d0", "original|d0"),
+            change => AssertDerivedChange(change, nameof(TransactionCascadeSubject.CombinedAgain), "[temporarily-applied|d0]", "[original|d0]"));
+        Assert.Equal("original", subject.Plain);
+        Assert.Equal("original|d0", subject.Combined);
+        Assert.Equal("[original|d0]", subject.CombinedAgain);
+
+        changes.Clear();
+        subject.DerivedWithSetter = "d1";
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetOldValue<string>() == "original|d0" &&
+            change.GetNewValue<string>() == "original|d1");
+    }
+
+    [Fact]
+    public async Task WhenConflictPreventsApply_ThenDerivedTrackingRemainsOnTheExternalModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "original",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(
+                   TransactionFailureHandling.BestEffort,
+                   TransactionLocking.Optimistic,
+                   conflictBehavior: TransactionConflictBehavior.FailOnConflict))
+        {
+            subject.Plain = "transaction";
+            await RunWithoutAsyncLocalFlowAsync(() => subject.Plain = "external");
+            changes.Clear();
+
+            await Assert.ThrowsAsync<SubjectTransactionConflictException>(
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
+            Assert.Empty(changes);
+        }
+
+        // Assert
+        Assert.Equal("external", subject.Plain);
+        Assert.Equal("external|d0", subject.Combined);
+        Assert.Equal("[external|d0]", subject.CombinedAgain);
+
+        subject.DerivedWithSetter = "d1";
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetOldValue<string>() == "external|d0" &&
+            change.GetNewValue<string>() == "external|d1");
+    }
+
+    [Fact]
+    public async Task WhenWriterFailurePreventsApply_ThenNoDerivedTrackingStateChanges()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        context.AddService<ITransactionWriter>(new FailingTransactionWriter());
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "original",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+
+        var changes = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(changes.Add);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.Rollback))
+        {
+            subject.Plain = "not-applied";
+            await Assert.ThrowsAsync<SubjectTransactionException>(
+                () => transaction.CommitAsync(CancellationToken.None).AsTask());
+        }
+
+        // Assert
+        Assert.Empty(changes);
+        Assert.Equal("original", subject.Plain);
+        Assert.Equal("original|d0", subject.Combined);
+        Assert.Equal("[original|d0]", subject.CombinedAgain);
+
+        subject.DerivedWithSetter = "d1";
+        Assert.Contains(changes, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetOldValue<string>() == "original|d0" &&
+            change.GetNewValue<string>() == "original|d1");
+    }
+
+    private static void AssertDerivedChange(
+        SubjectPropertyChange change,
+        string propertyName,
+        string oldValue,
+        string newValue)
+    {
+        Assert.Equal(propertyName, change.Property.Name);
+        Assert.Equal(oldValue, change.GetOldValue<string>());
+        Assert.Equal(newValue, change.GetNewValue<string>());
+    }
+
+    private sealed class FailingTransactionWriter : ITransactionWriter
+    {
+        public ValueTask<SourceWriteResult> WriteToSourcesAsync(
+            Memory<SubjectPropertyChange> changes,
+            TransactionRequirement requirement,
+            CancellationToken cancellationToken)
+        {
+            return new ValueTask<SourceWriteResult>(new SourceWriteResult(
+                Written: [],
+                Failed: changes.ToArray(),
+                Errors: [new InvalidOperationException("Writer rejected the changes.")],
+                RevertState: null));
+        }
+
+        public ValueTask<SourceRevertResult> RevertSourceWritesAsync(
+            IReadOnlyList<SubjectPropertyChange> written,
+            object? revertState,
+            CancellationToken cancellationToken)
+            => new(new SourceRevertResult([], []));
+    }
+
     /// <summary>
     /// Writes nothing to any source but marks each accepted snapshot slot with a fixed source in place,
     /// emulating a custom writer fulfilling the in-place marking contract.

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -643,6 +643,37 @@ public class SubjectTransactionTests
     }
 
     [Fact]
+    public async Task WhenAmbientTransactionIsDisposedAndAnotherIsOpen_ThenDerivedPropertiesStillRecalculate()
+    {
+        // Arrange: same frozen-flow setup as the write test above. The write reaches the model, so its
+        // derived cascade has to run with it: the disposed transaction has no commit left to replay it on,
+        // so suppressing the cascade would drop the recalculation forever.
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Old", LastName = "Doe" };
+
+        var disposedTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        var frozenFlow = ExecutionContext.Capture()
+            ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+        disposedTransaction.Dispose();
+
+        // Keeps the process-wide active count above zero, so the derived handler does not take its
+        // no-transaction fast path.
+        using var openTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+
+        var changedProperties = new List<string>();
+        context.GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(change => changedProperties.Add(change.Property.Name));
+
+        // Act
+        ExecutionContext.Run(frozenFlow, _ => person.FirstName = "New", null);
+
+        // Assert
+        Assert.Contains(nameof(Person.FirstName), changedProperties);
+        Assert.Contains(nameof(Person.FullName), changedProperties);
+        Assert.Contains(nameof(Person.FullNameWithPrefix), changedProperties);
+    }
+
+    [Fact]
     public async Task WhenAmbientTransactionIsOpen_ThenWriteIsCapturedInsteadOfAppliedToModel()
     {
         // Arrange

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -267,6 +267,109 @@ public class SubjectTransactionTests
     }
 
     [Fact]
+    public async Task WhenEmptyCommitIsTerminal_ThenLaterAccessUsesTheModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context);
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        await transaction.CommitAsync(CancellationToken.None);
+
+        // Act
+        person.FirstName = "landed-after-empty-commit";
+        string? landedValue = null;
+        await RunWithoutAsyncLocalFlowAsync(() => landedValue = person.FirstName);
+        await RunWithoutAsyncLocalFlowAsync(() => person.FirstName = "external-after-empty-commit");
+
+        // Assert
+        Assert.Equal("landed-after-empty-commit", landedValue);
+        Assert.Equal("external-after-empty-commit", person.FirstName);
+        Assert.Empty(transaction.GetPendingChanges());
+    }
+
+    [Fact]
+    public async Task WhenSuccessfulCommitIsTerminal_ThenLaterAccessUsesTheModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "model" };
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.FirstName = "committed";
+        await transaction.CommitAsync(CancellationToken.None);
+
+        // Act
+        person.LastName = "landed-after-commit";
+        string? landedValue = null;
+        await RunWithoutAsyncLocalFlowAsync(() => landedValue = person.LastName);
+        await RunWithoutAsyncLocalFlowAsync(() => person.LastName = "external-after-commit");
+
+        // Assert
+        Assert.Equal("committed", person.FirstName);
+        Assert.Equal("landed-after-commit", landedValue);
+        Assert.Equal("external-after-commit", person.LastName);
+        Assert.Empty(transaction.GetPendingChanges());
+    }
+
+    [Fact]
+    public async Task WhenCommitFailureIsTerminal_ThenLaterAccessUsesTheModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var subject = new TransactionCascadeSubject(context) { Plain = "model" };
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        subject.Plain = "applied";
+        subject.Failing = "fails";
+        subject.ThrowOnFailingWrite = true;
+        await Assert.ThrowsAsync<SubjectTransactionException>(
+            () => transaction.CommitAsync(CancellationToken.None).AsTask());
+
+        // Act
+        subject.SideEffect = "landed-after-terminal-failure";
+        string? landedValue = null;
+        await RunWithoutAsyncLocalFlowAsync(() => landedValue = subject.SideEffect);
+        await RunWithoutAsyncLocalFlowAsync(() => subject.SideEffect = "external-after-terminal-failure");
+
+        // Assert
+        Assert.Equal("applied", subject.Plain);
+        Assert.Equal("landed-after-terminal-failure", landedValue);
+        Assert.Equal("external-after-terminal-failure", subject.SideEffect);
+        Assert.Empty(transaction.GetPendingChanges());
+    }
+
+    [Fact]
+    public async Task WhenCommitFailureIsRetryable_ThenLaterWritesRemainCaptured()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "original" };
+        using var transaction = await context.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort,
+            TransactionLocking.Optimistic,
+            conflictBehavior: TransactionConflictBehavior.FailOnConflict);
+        person.FirstName = "pending";
+        await RunWithoutAsyncLocalFlowAsync(() => person.FirstName = "external");
+        await Assert.ThrowsAsync<SubjectTransactionConflictException>(
+            () => transaction.CommitAsync(CancellationToken.None).AsTask());
+
+        // Act
+        person.LastName = "captured-after-conflict";
+
+        // Assert
+        Assert.Equal("captured-after-conflict", person.LastName);
+        Assert.Contains(transaction.GetPendingChanges(),
+            change => change.Property.Name == nameof(Person.LastName));
+
+        string? modelLastName = null;
+        await RunWithoutAsyncLocalFlowAsync(() => modelLastName = person.LastName);
+        Assert.Null(modelLastName);
+
+        await RunWithoutAsyncLocalFlowAsync(() => person.FirstName = "original");
+        await transaction.CommitAsync(CancellationToken.None);
+        Assert.Equal("pending", person.FirstName);
+        Assert.Equal("captured-after-conflict", person.LastName);
+    }
+
+    [Fact]
     public async Task WhenTransactionDisposed_ThenCommitThrows()
     {
         // Arrange
@@ -948,6 +1051,175 @@ public class SubjectTransactionTests
     }
 
     [Fact]
+    public async Task WhenCommitIsBlockedInWriter_ThenCallerAccessCannotEscapeTheSnapshot()
+    {
+        // Arrange
+        var writer = new ControllableTransactionWriter();
+        var context = CreateTransactionContext();
+        context.AddService<ITransactionWriter>(writer);
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "model",
+            SideEffect = "side-model",
+            DerivedWithSetter = "d0"
+        };
+        _ = subject.CombinedAgain;
+        var sideEffectSubject = new SideEffectWritePerson(context) { Name = "before" };
+        var sideEffectBeforeCommit = sideEffectSubject.SideEffectTarget;
+
+        var derivedChanges = new List<SubjectPropertyChange>();
+        using var subscription = context
+            .GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Where(change => change.Property.Name is
+                nameof(TransactionCascadeSubject.Combined) or
+                nameof(TransactionCascadeSubject.CombinedAgain))
+            .Subscribe(derivedChanges.Add);
+
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        subject.Plain = "snapshot";
+        sideEffectSubject.Name = "committed-name";
+        var commitTask = transaction.CommitAsync(CancellationToken.None).AsTask();
+
+        try
+        {
+            Assert.True(writer.CommitStarted.Wait(TimeSpan.FromSeconds(10)), "commit did not reach the writer");
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => _ = subject.Plain);
+            Assert.Throws<InvalidOperationException>(() => subject.SideEffect = "outside-snapshot");
+            Assert.Throws<InvalidOperationException>(() => subject.DerivedWithSetter = "outside-snapshot");
+
+            var frozenChanges = transaction.GetPendingChanges();
+            Assert.Equal(2, frozenChanges.Count);
+            Assert.Contains(frozenChanges, change =>
+                change.Property.Name == nameof(TransactionCascadeSubject.Plain) &&
+                change.GetNewValue<string>() == "snapshot");
+            Assert.Contains(frozenChanges, change =>
+                change.Property.Name == nameof(SideEffectWritePerson.Name) &&
+                change.GetNewValue<string>() == "committed-name");
+
+            string? modelPlain = null;
+            string? modelSideEffect = null;
+            string? modelDerivedWithSetter = null;
+            await RunWithoutAsyncLocalFlowAsync(() =>
+            {
+                modelPlain = subject.Plain;
+                modelSideEffect = subject.SideEffect;
+                modelDerivedWithSetter = subject.DerivedWithSetter;
+            });
+            Assert.Equal("model", modelPlain);
+            Assert.Equal("side-model", modelSideEffect);
+            Assert.Equal("d0", modelDerivedWithSetter);
+        }
+        finally
+        {
+            writer.Release();
+            await commitTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+
+        Assert.Equal("snapshot", subject.Plain);
+        Assert.Equal("side-model", subject.SideEffect);
+        Assert.Equal("d0", subject.DerivedWithSetter);
+        Assert.Equal("[snapshot|d0]", subject.CombinedAgain);
+        Assert.Equal("committed-name", sideEffectSubject.Name);
+        Assert.NotEqual(sideEffectBeforeCommit, sideEffectSubject.SideEffectTarget);
+        Assert.Contains(derivedChanges, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.Combined) &&
+            change.GetNewValue<string>() == "snapshot|d0");
+        Assert.Contains(derivedChanges, change =>
+            change.Property.Name == nameof(TransactionCascadeSubject.CombinedAgain) &&
+            change.GetNewValue<string>() == "[snapshot|d0]");
+        Assert.Empty(transaction.GetPendingChanges());
+    }
+
+    [Fact]
+    public async Task WhenCommitIsBlockedInWriter_ThenForkedAmbientAccessIsRejected()
+    {
+        // Arrange
+        var writer = new ControllableTransactionWriter();
+        var context = CreateTransactionContext();
+        context.AddService<ITransactionWriter>(writer);
+        var subject = new TransactionCascadeSubject(context)
+        {
+            Plain = "model",
+            SideEffect = "side-model",
+            DerivedWithSetter = "d0"
+        };
+
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        subject.Plain = "snapshot";
+        var commitTask = transaction.CommitAsync(CancellationToken.None).AsTask();
+
+        try
+        {
+            Assert.True(writer.CommitStarted.Wait(TimeSpan.FromSeconds(10)), "commit did not reach the writer");
+
+            // Act
+            var accessTask = Task.Run(() =>
+            {
+                var readException = CaptureException(() => _ = subject.Plain);
+                var writeException = CaptureException(() => subject.SideEffect = "forked-outside-snapshot");
+                var derivedWriteException = CaptureException(
+                    () => subject.DerivedWithSetter = "forked-outside-snapshot");
+                return (readException, writeException, derivedWriteException);
+            });
+            var exceptions = await accessTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.IsType<InvalidOperationException>(exceptions.readException);
+            Assert.IsType<InvalidOperationException>(exceptions.writeException);
+            Assert.IsType<InvalidOperationException>(exceptions.derivedWriteException);
+
+            var frozenChange = Assert.Single(transaction.GetPendingChanges());
+            Assert.Equal(nameof(TransactionCascadeSubject.Plain), frozenChange.Property.Name);
+            Assert.Equal("snapshot", frozenChange.GetNewValue<string>());
+
+            string? modelPlain = null;
+            string? modelSideEffect = null;
+            string? modelDerivedWithSetter = null;
+            await RunWithoutAsyncLocalFlowAsync(() =>
+            {
+                modelPlain = subject.Plain;
+                modelSideEffect = subject.SideEffect;
+                modelDerivedWithSetter = subject.DerivedWithSetter;
+            });
+            Assert.Equal("model", modelPlain);
+            Assert.Equal("side-model", modelSideEffect);
+            Assert.Equal("d0", modelDerivedWithSetter);
+        }
+        finally
+        {
+            writer.Release();
+            await commitTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+
+        Assert.Equal("snapshot", subject.Plain);
+        Assert.Equal("side-model", subject.SideEffect);
+        Assert.Equal("d0", subject.DerivedWithSetter);
+    }
+
+    [Fact]
+    public async Task WhenWriterAccessesAmbientPropertyDuringCommit_ThenCommitReportsConcurrentAccess()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var subject = new TransactionCascadeSubject(context) { Plain = "model" };
+        context.AddService<ITransactionWriter>(new PropertyAccessingTransactionWriter(() => _ = subject.Plain));
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        subject.Plain = "pending";
+
+        // Act
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(
+            () => transaction.CommitAsync(CancellationToken.None).AsTask());
+
+        // Assert
+        var error = Assert.IsType<InvalidOperationException>(Assert.Single(exception.Errors));
+        Assert.Contains("commit is in progress", error.Message);
+        Assert.Equal("model", subject.Plain);
+        Assert.Empty(transaction.GetPendingChanges());
+    }
+
+    [Fact]
     public async Task WhenSourceValueIsTransformedBeforeCapture_ThenTheCapturedOriginIsLocal()
     {
         // Arrange
@@ -1215,6 +1487,37 @@ public class SubjectTransactionTests
             => new(new SourceRevertResult([], []));
 
         public void Release() => _release.TrySetResult();
+    }
+
+    private sealed class PropertyAccessingTransactionWriter(Action accessProperty) : ITransactionWriter
+    {
+        public ValueTask<SourceWriteResult> WriteToSourcesAsync(
+            Memory<SubjectPropertyChange> changes,
+            TransactionRequirement requirement,
+            CancellationToken cancellationToken)
+        {
+            accessProperty();
+            return new ValueTask<SourceWriteResult>(new SourceWriteResult([], [], [], RevertState: null));
+        }
+
+        public ValueTask<SourceRevertResult> RevertSourceWritesAsync(
+            IReadOnlyList<SubjectPropertyChange> written,
+            object? revertState,
+            CancellationToken cancellationToken)
+            => new(new SourceRevertResult([], []));
+    }
+
+    private static Exception? CaptureException(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -910,6 +910,44 @@ public class SubjectTransactionTests
     }
 
     [Fact]
+    public async Task WhenTransactionIsDisposedDuringCommit_ThenTryCaptureChangeReturnsFalse()
+    {
+        // Arrange
+        var writer = new ControllableTransactionWriter();
+        var context = CreateTransactionContext();
+        context.AddService<ITransactionWriter>(writer);
+        var person = new Person(context) { LastName = "Model" };
+        var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.FirstName = "Pending";
+        var commitTask = transaction.CommitAsync(CancellationToken.None).AsTask();
+        bool TryCaptureChange() => transaction.TryCaptureChange(
+            new PropertyReference(person, nameof(Person.LastName)),
+            ChangeOrigin.Local,
+            DateTimeOffset.UnixEpoch,
+            receivedTimestamp: null,
+            currentValue: "Model",
+            newValue: "AfterDispose");
+
+        try
+        {
+            Assert.True(writer.CommitStarted.Wait(TimeSpan.FromSeconds(10)), "commit did not reach the writer");
+            Assert.Throws<InvalidOperationException>(() => TryCaptureChange());
+            transaction.Dispose();
+
+            // Act
+            var captured = TryCaptureChange();
+
+            // Assert
+            Assert.False(captured);
+        }
+        finally
+        {
+            writer.Release();
+            await commitTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Fact]
     public async Task WhenSourceValueIsTransformedBeforeCapture_ThenTheCapturedOriginIsLocal()
     {
         // Arrange
@@ -1152,6 +1190,31 @@ public class SubjectTransactionTests
             object? revertState,
             CancellationToken cancellationToken)
             => new(new SourceRevertResult([], []));
+    }
+
+    private sealed class ControllableTransactionWriter : ITransactionWriter
+    {
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ManualResetEventSlim CommitStarted { get; } = new();
+
+        public async ValueTask<SourceWriteResult> WriteToSourcesAsync(
+            Memory<SubjectPropertyChange> changes,
+            TransactionRequirement requirement,
+            CancellationToken cancellationToken)
+        {
+            CommitStarted.Set();
+            await _release.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            return new SourceWriteResult([], [], [], RevertState: null);
+        }
+
+        public ValueTask<SourceRevertResult> RevertSourceWritesAsync(
+            IReadOnlyList<SubjectPropertyChange> written,
+            object? revertState,
+            CancellationToken cancellationToken)
+            => new(new SourceRevertResult([], []));
+
+        public void Release() => _release.TrySetResult();
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Connectors;
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Registry;
@@ -8,6 +9,38 @@ using Namotion.Interceptor.Tracking.Transactions;
 using Namotion.Interceptor.Tracking.Tests.Models;
 
 namespace Namotion.Interceptor.Tracking.Tests.Transactions;
+
+[InterceptorSubject]
+internal partial class DisposalCaptureGateSubject
+{
+    public partial DisposalCaptureGateValue? Value { get; set; }
+}
+
+internal sealed class DisposalCaptureGateValue(
+    string value,
+    ManualResetEventSlim? comparisonEntered = null,
+    ManualResetEventSlim? continueComparison = null) : IEquatable<DisposalCaptureGateValue>
+{
+    private readonly string _value = value;
+
+    public bool Equals(DisposalCaptureGateValue? other)
+    {
+        if (comparisonEntered is not null)
+        {
+            comparisonEntered.Set();
+            if (!continueComparison!.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new TimeoutException("The test did not release the origin comparison within 10 seconds.");
+            }
+        }
+
+        return other is not null && _value == other._value;
+    }
+
+    public override bool Equals(object? obj) => obj is DisposalCaptureGateValue other && Equals(other);
+
+    public override int GetHashCode() => _value.GetHashCode(StringComparison.Ordinal);
+}
 
 public class SubjectTransactionTests
 {
@@ -859,59 +892,62 @@ public class SubjectTransactionTests
     }
 
     [Fact]
-    public async Task WhenAmbientTransactionIsDisposedWhileAnotherThreadWrites_ThenNoExceptionEscapesTheSetterAndTheWriteLands()
+    public async Task WhenDisposeWinsAfterThePublicWritePassedItsAmbientCheck_ThenTheWriteLandsWithoutAnException()
     {
-        // Arrange: a thread born inside a transaction keeps that transaction in its ambient slot for life
-        // (an Rx EventLoopScheduler worker, for example). Writing on that thread while another flow disposes
-        // the transaction races the interceptor's disposed check against the capture itself. An exception
-        // escaping the setter there is unhandled on a bare thread and terminates the process, so the write
-        // has to fall through to the model instead, exactly as if no transaction were ambient.
+        // Arrange: final-origin resolution invokes user equality immediately before TryCaptureChange. Park
+        // there so Dispose deterministically wins after the interceptor's lock-free ambient-state check.
+        // Regression mutation: throwing instead of returning false from TryCaptureChange when disposal wins
+        // lets ObjectDisposedException escape this public write path instead of falling through to the model.
         var context = CreateTransactionContext();
-        var person = new Person(context) { LastName = "Model" };
-
-        // The race is reachable within a handful of iterations; bounded so the test always terminates.
-        for (var iteration = 0; iteration < 50; iteration++)
+        var subject = new DisposalCaptureGateSubject(context)
         {
-            var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
-            var frozenFlow = ExecutionContext.Capture()
-                ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+            Value = new DisposalCaptureGateValue("Model")
+        };
+        var property = new PropertyReference(subject, nameof(DisposalCaptureGateSubject.Value));
+        using var comparisonEntered = new ManualResetEventSlim();
+        using var continueComparison = new ManualResetEventSlim();
+        var sentValue = new DisposalCaptureGateValue("AfterDispose", comparisonEntered, continueComparison);
+        var valueWrittenAfterDispose = new DisposalCaptureGateValue("AfterDispose");
 
-            var writerStarted = new ManualResetEventSlim();
-            var disposeCompleted = false;
-            Exception? escapedException = null;
-            var valueWrittenAfterDispose = $"AfterDispose{iteration}";
-
-            var writerThread = new Thread(() => ExecutionContext.Run(frozenFlow, _ =>
+        var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        var frozenFlow = ExecutionContext.Capture()
+            ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+        Exception? escapedException = null;
+        var writerThread = new Thread(() => ExecutionContext.Run(frozenFlow, _ =>
+        {
+            try
             {
-                try
-                {
-                    writerStarted.Set();
-                    var writeCount = 0;
-                    while (!Volatile.Read(ref disposeCompleted))
-                    {
-                        // Distinct values so the equality check never short-circuits the chain.
-                        person.LastName = $"Racing{writeCount++}";
-                    }
+                property.SetValueFromOrigin(
+                    ChangeOrigin.FromSource(new object()),
+                    changedTimestamp: null,
+                    receivedTimestamp: null,
+                    value: valueWrittenAfterDispose,
+                    sentValue: sentValue);
+            }
+            catch (Exception exception)
+            {
+                escapedException = exception;
+            }
+        }, null));
 
-                    person.LastName = valueWrittenAfterDispose;
-                }
-                catch (Exception exception)
-                {
-                    escapedException = exception;
-                }
-            }, null));
-
-            // Act
+        // Act
+        try
+        {
             writerThread.Start();
-            Assert.True(writerStarted.Wait(TimeSpan.FromSeconds(10)), "writer did not start");
+            Assert.True(comparisonEntered.Wait(TimeSpan.FromSeconds(10)), "write did not reach origin comparison");
             transaction.Dispose();
-            Volatile.Write(ref disposeCompleted, true);
-            Assert.True(writerThread.Join(TimeSpan.FromSeconds(10)), "writer did not stop");
-
-            // Assert
-            Assert.Null(escapedException);
-            Assert.Equal(valueWrittenAfterDispose, person.LastName);
         }
+        finally
+        {
+            transaction.Dispose();
+            continueComparison.Set();
+            Assert.True(writerThread.Join(TimeSpan.FromSeconds(10)), "writer did not stop");
+        }
+
+        // Assert
+        Assert.Null(escapedException);
+        Assert.Same(valueWrittenAfterDispose, subject.Value);
+        Assert.Empty(transaction.GetPendingChanges());
     }
 
     [Fact]
@@ -1048,6 +1084,43 @@ public class SubjectTransactionTests
             writer.Release();
             await commitTask.WaitAsync(TimeSpan.FromSeconds(10));
         }
+    }
+
+    [Fact]
+    public async Task WhenDisposedDuringExternalWriterCommit_ThenRawWriteLandsBeforeFrozenReplayOverwritesIt()
+    {
+        // Arrange
+        var writer = new ControllableTransactionWriter();
+        var context = CreateTransactionContext();
+        context.AddService<ITransactionWriter>(writer);
+        var person = new Person(context) { FirstName = "Model" };
+        var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.FirstName = "FrozenReplay";
+        var commitTask = transaction.CommitAsync(CancellationToken.None).AsTask();
+
+        try
+        {
+            Assert.True(writer.CommitStarted.Wait(TimeSpan.FromSeconds(10)), "commit did not reach the writer");
+            transaction.Dispose();
+            Assert.Null(SubjectTransaction.Current);
+
+            // Act: disposal makes the ambient transaction inactive even though its frozen commit continues.
+            person.FirstName = "RawAfterDispose";
+
+            // Assert: observe the landed model outside any ambient transaction before replay is released.
+            string? intermediateModelValue = null;
+            await RunWithoutAsyncLocalFlowAsync(() => intermediateModelValue = person.FirstName);
+            Assert.Equal("RawAfterDispose", intermediateModelValue);
+        }
+        finally
+        {
+            transaction.Dispose();
+            writer.Release();
+            await commitTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+
+        // Assert: transaction disposal is not isolation from an already-frozen commit snapshot.
+        Assert.Equal("FrozenReplay", person.FirstName);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -51,6 +51,35 @@ public class SubjectTransactionTests
     }
 
     [Fact]
+    public async Task WhenTheContextResolvesTwoTransactionInterceptors_ThenTheWriteIsCapturedInsteadOfThrowing()
+    {
+        // Arrange: context inheritance adds another context as a fallback on attach, so a subject built on
+        // one transaction-enabled context and attached into a graph rooted on another resolves two.
+        // Requiring exactly one threw out of the property setter, which on a scheduler thread ends the
+        // process; the question being asked is only whether the transaction belongs to this context.
+        var context = CreateTransactionContext();
+        var fallbackContext = CreateTransactionContext();
+
+        var person = new Person(context);
+        ((IInterceptorSubject)person).Context.AddFallbackContext(fallbackContext);
+
+        // Act
+        using (var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+
+            // Assert: captured rather than written straight through, so the binding resolved to this
+            // context. Reading the property here would serve the pending value either way.
+            Assert.Single(transaction.GetPendingChanges(),
+                change => change.Property.Name == nameof(Person.FirstName));
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        Assert.Equal("John", person.FirstName);
+    }
+
+    [Fact]
     public async Task WhenTransactionCommitted_ThenChangesAreApplied()
     {
         // Arrange
@@ -614,6 +643,27 @@ public class SubjectTransactionTests
     }
 
     [Fact]
+    public async Task WhenAmbientTransactionIsOpen_ThenWriteIsCapturedInsteadOfAppliedToModel()
+    {
+        // Arrange
+        var context = CreateTransactionContext();
+        var person = new Person(context) { FirstName = "Old" };
+
+        // Act
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.FirstName = "New";
+
+        // Assert
+        var pendingChange = Assert.Single(transaction.GetPendingChanges());
+        Assert.Equal(nameof(Person.FirstName), pendingChange.Property.Name);
+        Assert.Equal("New", pendingChange.GetNewValue<string?>());
+
+        string? modelFirstName = null;
+        await RunWithoutAsyncLocalFlowAsync(() => modelFirstName = person.FirstName);
+        Assert.Equal("Old", modelFirstName);
+    }
+
+    [Fact]
     public async Task WhenAmbientTransactionIsDisposedAndAnotherIsOpen_ThenReadReturnsTheModelValueInsteadOfAPendingValue()
     {
         // Arrange: capture the flow while a transaction is current and holds a pending value, then dispose
@@ -708,6 +758,49 @@ public class SubjectTransactionTests
             // Assert
             Assert.Null(escapedException);
             Assert.Equal(valueWrittenAfterDispose, person.LastName);
+        }
+    }
+
+    [Fact]
+    public async Task WhenAmbientTransactionWasDisposedByAnotherFlow_ThenTheFrozenFlowCanBeginANewTransaction()
+    {
+        // Arrange: freeze a flow while a transaction is current, then dispose that transaction from the flow
+        // that owns it. Dispose clears the ambient slot only for the disposing flow, so the frozen flow keeps
+        // pointing at the disposed transaction for the rest of its life.
+        var context = CreateTransactionContext();
+        var disposedTransaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        var frozenFlow = ExecutionContext.Capture()
+            ?? throw new InvalidOperationException("Execution context flow must not be suppressed in this test.");
+        disposedTransaction.Dispose();
+
+        // Act
+        SubjectTransaction? newTransaction = null;
+        try
+        {
+            Exception? failure = null;
+            ExecutionContext.Run(frozenFlow, _ =>
+            {
+                Assert.Same(disposedTransaction, SubjectTransaction.Current);
+                try
+                {
+                    newTransaction = context
+                        .BeginTransactionAsync(TransactionFailureHandling.BestEffort)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+                catch (Exception exception)
+                {
+                    failure = exception;
+                }
+            }, null);
+
+            // Assert
+            Assert.Null(failure);
+            Assert.NotNull(newTransaction);
+        }
+        finally
+        {
+            newTransaction?.Dispose();
         }
     }
 

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/TransformingWriteInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/TransformingWriteInterceptor.cs
@@ -1,0 +1,21 @@
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Tracking.Transactions;
+
+namespace Namotion.Interceptor.Tracking.Tests.Transactions;
+
+[RunsBefore(typeof(SubjectTransactionInterceptor))]
+internal sealed class TransformingWriteInterceptor : IWriteInterceptor
+{
+    public void WriteProperty<TProperty>(
+        ref PropertyWriteContext<TProperty> context,
+        WriteInterceptionDelegate<TProperty> next)
+    {
+        if (context.NewValue is string text)
+        {
+            context.NewValue = (TProperty)(object)text.ToUpperInvariant();
+        }
+
+        next(ref context);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -166,7 +166,8 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         {
             // Suppress cascading recalculations during transaction capture (replayed on commit).
             if (SubjectTransaction.HasActiveTransaction &&
-                SubjectTransaction.Current is { IsCommitting: false })
+                SubjectTransaction.Current is { IsCommitting: false } ambientTransaction &&
+                AnyDependentReadsPendingValue(ambientTransaction, usedByProperties))
             {
                 return;
             }
@@ -177,6 +178,30 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             var storageTimestamp = rawTimestamp > 0 ? rawTimestamp : 0L;
             RecalculateDependents(usedByProperties, context.Property, storageTimestamp, rawTimestamp);
         }
+    }
+
+    private static bool AnyDependentReadsPendingValue(
+        SubjectTransaction transaction,
+        ReadOnlySpan<PropertyReference> usedByProperties)
+    {
+        for (var index = 0; index < usedByProperties.Length; index++)
+        {
+            var dependentData = usedByProperties[index].TryGetDerivedPropertyData();
+            if (dependentData is null)
+            {
+                continue;
+            }
+
+            lock (dependentData)
+            {
+                if (transaction.ContainsAnyPendingValue(dependentData.RequiredPropertiesSpan))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Tracking.Lifecycle;
-using Namotion.Interceptor.Tracking.Transactions;
 
 namespace Namotion.Interceptor.Tracking.Change;
 
@@ -34,6 +33,12 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
 
     [ThreadStatic]
     private static DerivedPropertyRecorder? _recorder;
+
+    internal static bool IsRecordingDerivedProperty
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _recorder?.IsRecording == true;
+    }
 
     // Global counter incremented on every write (Interlocked.Increment, full fence).
     // Paired with Volatile.Read in AttachProperty/RecalculateDerivedProperty to detect
@@ -169,44 +174,12 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         var usedByProperties = data.GetUsedByProperties();
         if (usedByProperties.Length > 0)
         {
-            // Suppress cascading recalculations during transaction capture (replayed on commit).
-            if (SubjectTransaction.HasActiveTransaction &&
-                SubjectTransaction.Current is { IsCommitting: false } ambientTransaction &&
-                AnyDependentReadsPendingValue(ambientTransaction, usedByProperties))
-            {
-                return;
-            }
-
             // Thread the trigger's resolved timestamp into each dependent's context, skipping a
             // scope push. storageTimestamp=0 under a null scope preserves the never-written sentinel.
             var rawTimestamp = context.WriteTimestampRaw;
             var storageTimestamp = rawTimestamp > 0 ? rawTimestamp : 0L;
             RecalculateDependents(usedByProperties, context.Property, storageTimestamp, rawTimestamp);
         }
-    }
-
-    private static bool AnyDependentReadsPendingValue(
-        SubjectTransaction transaction,
-        ReadOnlySpan<PropertyReference> usedByProperties)
-    {
-        for (var index = 0; index < usedByProperties.Length; index++)
-        {
-            var dependentData = usedByProperties[index].TryGetDerivedPropertyData();
-            if (dependentData is null)
-            {
-                continue;
-            }
-
-            lock (dependentData)
-            {
-                if (transaction.ContainsAnyPendingValue(dependentData.RequiredPropertiesSpan))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -409,12 +382,15 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         DerivedPropertyData data, in PropertyReference property, bool callerHoldsLock)
     {
         var generationBefore = Volatile.Read(ref _writeGeneration);
+        var ownsActiveRecording = false;
 
         try
         {
             StartRecordingTouchedProperties(property);
+            ownsActiveRecording = true;
             var result = property.Metadata.GetValue?.Invoke(property.Subject);
             var recordedDeps = _recorder!.FinishRecording();
+            ownsActiveRecording = false;
 
             bool dependenciesChanged;
             if (callerHoldsLock)
@@ -444,8 +420,10 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
             for (var iteration = 0; iteration < MaxStabilizationIterations; iteration++)
             {
                 StartRecordingTouchedProperties(property);
+                ownsActiveRecording = true;
                 result = property.Metadata.GetValue?.Invoke(property.Subject);
                 recordedDeps = _recorder.FinishRecording();
+                ownsActiveRecording = false;
 
                 if (callerHoldsLock)
                 {
@@ -480,7 +458,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         }
         finally
         {
-            DiscardActiveRecording();
+            DiscardActiveRecording(ownsActiveRecording);
         }
     }
 
@@ -495,14 +473,14 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
     /// No-op on the happy path (recording already finished and cleared).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void DiscardActiveRecording()
+    private static void DiscardActiveRecording(bool ownsActiveRecording)
     {
         if (_recorder is null)
         {
             return;
         }
 
-        if (_recorder.IsRecording)
+        if (ownsActiveRecording)
         {
             _recorder.FinishRecording();
         }

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -75,7 +75,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                 }
                 catch (Exception)
                 {
-                    // Getter threw — value will be computed on the next dependency write.
+                    // Getter threw. The value will be computed on the next dependency write.
                 }
             }
         }
@@ -239,7 +239,6 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
 
         object? oldValue;
 
-        // Phase 1: Acquire recalculation ownership (brief lock).
         var data = derivedProperty.GetDerivedPropertyData();
         lock (data)
         {
@@ -261,7 +260,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
         // Outer loop handles the post-notification RecalculationNeeded check without recursion,
         // preventing stack overflow under sustained concurrent writes.
         // The try-finally at this level ensures IsRecalculating is always cleared on exit.
-        // Crucially, IsRecalculating stays true during NotifyDerivedPropertyChanged — this
+        // Crucially, IsRecalculating stays true during NotifyDerivedPropertyChanged. This
         // serializes notification delivery with recalculation, preventing a stale notification
         // from being delivered after a newer one (TOCTOU race between guard checks and delivery).
         try
@@ -271,10 +270,8 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                 object? newValue;
                 long sequence;
 
-                // Inner loop: re-evaluates when the state changes during evaluation.
                 while (true)
                 {
-                    // Phase 2: Evaluate getter OUTSIDE lock(data).
                     // This prevents deadlock: getter side effects can safely acquire
                     // lock(_attachedSubjects) in LifecycleInterceptor without lock ordering inversion.
                     try
@@ -283,11 +280,10 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                     }
                     catch (Exception)
                     {
-                        // Getter threw — keep LastKnownValue, concurrent writer's cascade will retry.
+                        // Getter threw. Keep LastKnownValue; a concurrent writer's cascade will retry.
                         return;
                     }
 
-                    // Phase 3: Commit result under lock.
                     lock (data)
                     {
                         if (!data.IsAttached)
@@ -310,12 +306,10 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                     }
                 }
 
-                // Deliver notification while IsRecalculating is still true.
                 // Any concurrent writes during delivery set RecalculationNeeded=true and bail out,
                 // so no new recalculation (or notification) can start until delivery completes.
                 NotifyDerivedPropertyChanged(ref derivedProperty, data, sequence, newValue, oldValue, rawTimestamp);
 
-                // Handle recalculations that arrived during evaluation or notification delivery.
                 // Uses a loop (not recursion) to prevent stack overflow under sustained concurrent writes.
                 lock (data)
                 {
@@ -325,12 +319,10 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                     }
 
                     data.RecalculationNeeded = false;
-                    // IsRecalculating stays true for next iteration
                     oldValue = data.LastKnownValue;
                 }
             }
 
-            // Safety: if the outer loop exhausted MaxStabilizationIterations, log a warning.
             Trace.TraceWarning(
                 $"DerivedPropertyChangeHandler: MaxStabilizationIterations ({MaxStabilizationIterations}) exhausted for " +
                 $"'{derivedProperty.Metadata.Name}' on {derivedProperty.Subject.GetType().Name}. " +
@@ -448,7 +440,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                 return result;
             }
 
-            // Concurrent write detected while dependencies changed — stabilize.
+            // Concurrent write detected while dependencies changed. Stabilize.
             for (var iteration = 0; iteration < MaxStabilizationIterations; iteration++)
             {
                 StartRecordingTouchedProperties(property);

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -212,6 +212,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
 
         object? oldValue;
 
+        // Phase 1: Acquire recalculation ownership (brief lock).
         var data = derivedProperty.GetDerivedPropertyData();
         lock (data)
         {
@@ -245,6 +246,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
 
                 while (true)
                 {
+                    // Phase 2: Evaluate getter OUTSIDE lock(data).
                     // This prevents deadlock: getter side effects can safely acquire
                     // lock(_attachedSubjects) in LifecycleInterceptor without lock ordering inversion.
                     try
@@ -257,6 +259,7 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
                         return;
                     }
 
+                    // Phase 3: Commit result under lock.
                     lock (data)
                     {
                         if (!data.IsAttached)

--- a/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/DerivedPropertyChangeHandler.cs
@@ -142,7 +142,12 @@ public class DerivedPropertyChangeHandler : IReadInterceptor, IWriteInterceptor,
     {
         next(ref context);
 
-        // Signal write before TryGet so writes to not-yet-tracked properties are also detected.
+        if (!context.IsWritten)
+        {
+            return;
+        }
+
+        // Signal landed writes before TryGet so writes to not-yet-tracked properties are also detected.
         Interlocked.Increment(ref _writeGeneration);
 
         var data = context.Property.TryGetDerivedPropertyData();

--- a/src/Namotion.Interceptor.Tracking/Transactions/ITransactionWriter.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/ITransactionWriter.cs
@@ -7,6 +7,13 @@ namespace Namotion.Interceptor.Tracking.Transactions;
 /// Implement this interface and register it with <see cref="IInterceptorSubjectContext"/>
 /// to enable external source writes during transaction commit.
 /// </summary>
+/// <remarks>
+/// The transaction invokes both callbacks while its live ambient transaction is committing. Subject
+/// property reads and writes on a flow carrying that transaction throw <see cref="InvalidOperationException"/>.
+/// Commit-owned synchronous local replay remains allowed, including property hooks, change handlers,
+/// and derived cascades initiated by that replay. This authorization does not extend into these callbacks.
+/// Disposed and terminal transactions are inactive and use normal property access semantics.
+/// </remarks>
 public interface ITransactionWriter
 {
     /// <summary>
@@ -16,14 +23,21 @@ public interface ITransactionWriter
     /// requirement, since only the writer knows the source mappings.
     /// </summary>
     /// <remarks>
+    /// Do not read or write subject properties from this callback, and do not suppress ambient
+    /// execution-context flow to bypass the committing access boundary. This includes getters: sibling
+    /// or landed-model state is outside the frozen snapshot and can make a source payload inconsistent.
+    /// Construct source operations from <paramref name="changes"/>, <paramref name="requirement"/>, and
+    /// writer-owned configuration, and any required subject state captured before
+    /// <see cref="SubjectTransaction.CommitAsync"/>.
+    ///
     /// Report failures via <see cref="SourceWriteResult"/>, never throw: a throw returns neither the
     /// written set nor the revert state, so the transaction fails terminally with nothing reverted.
     /// After (and only after) a source accepts a change, replace that slot in <paramref name="changes"/>
     /// with the same change marked by the accepting source (<see cref="SubjectPropertyChange.WithOrigin"/>),
     /// so the commit's local apply and revert notifications are recognized as echoes by that source's
     /// outbound queue. Change only the slot's <see cref="SubjectPropertyChange.Origin"/>, never move a
-    /// change to a different slot, and leave failed slots untouched. Not marking at all is harmless but
-    /// keeps the legacy double write (the queue re-pushes each committed value).
+    /// change to a different slot, and leave failed slots untouched. Not marking at all is allowed, but
+    /// the queue then re-pushes each committed value.
     /// <paramref name="changes"/> is a pooled buffer owned by the commit: do not retain or mutate it after
     /// the returned task completes. Parallel per-source writers must touch only their own source's slots.
     /// Enable <see cref="SubjectTransaction.ValidateWriterContract"/> while developing an implementation.
@@ -45,6 +59,11 @@ public interface ITransactionWriter
     /// values back to each source.
     /// </summary>
     /// <remarks>
+    /// Do not read or write subject properties from this callback, and do not suppress ambient
+    /// execution-context flow to bypass the committing access boundary. Construct inverse source
+    /// operations from <paramref name="written"/>, <paramref name="revertState"/>, writer-owned
+    /// configuration, and any required subject state captured before <see cref="SubjectTransaction.CommitAsync"/>.
+    ///
     /// Implementations must report revert failures via <see cref="SourceRevertResult"/> rather than
     /// throwing. A throw is treated as if every requested revert failed and the commit fails terminally.
     /// </remarks>

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -223,7 +223,6 @@ public sealed class SubjectTransaction : IDisposable
         _commitTimeout = commitTimeout;
         _lockReleaser = lockReleaser;
 
-        // Increment in constructor ensures counter is always paired with Dispose
         Interlocked.Increment(ref _activeTransactionCount);
     }
 
@@ -250,7 +249,7 @@ public sealed class SubjectTransaction : IDisposable
         TimeSpan commitTimeout,
         CancellationToken cancellationToken)
     {
-        // Check for nested transactions BEFORE acquiring lock (prevents deadlock)
+        // Check before acquiring the context lock so an attempted nested exclusive transaction cannot deadlock.
         if (CurrentTransaction.Value is { IsDisposed: false })
         {
             throw new InvalidOperationException("Nested transactions are not supported.");
@@ -262,16 +261,13 @@ public sealed class SubjectTransaction : IDisposable
 
         IDisposable? transactionLock = null;
 
-        // For Exclusive locking, acquire the lock now
-        // For Optimistic locking, skip the lock - we'll acquire it during commit only
         if (locking == TransactionLocking.Exclusive)
         {
             transactionLock = await interceptor.AcquireTransactionLockAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        // Don't set CurrentTransaction.Value here because it won't flow to caller's context
-        // The caller (extension method) will call SetCurrent after awaiting this
-        // Counter increment is in constructor to ensure it's always paired with Dispose
+        // An AsyncLocal assignment here would not flow back through this async method's await;
+        // the caller assigns the transaction in its own execution context.
         return new SubjectTransaction(
             context,
             interceptor,
@@ -605,11 +601,9 @@ public sealed class SubjectTransaction : IDisposable
         OrderedDictionary<PropertyReference, SubjectPropertyChange>? pendingChangesToReturn = null;
         lock (_pendingChangesLock)
         {
-            // Clear under the lock so a concurrent Dispose observes the in-flight commit consistently: while
-            // _isCommitting is true Dispose skips returning the pooled buffer (this commit owns it) and defers
-            // the exclusive-lock release to us. Reading the flag here makes that release exactly-once
-            // (whichever of Dispose/EndCommit observes the other). The ArrayPool buffer below is owned solely
-            // by this commit and is always returned here.
+            // Clear under the lock so Dispose observes the in-flight commit consistently. A disposing caller
+            // defers exclusive-lock release while this commit owns it. If it also owns the pending dictionary,
+            // detach it here and return it after the lock so ownership transfers exactly once.
             _isCommitting = false;
             releaseDeferredLock = _disposeRequestedDuringCommit;
             if (releaseDeferredLock)
@@ -632,12 +626,9 @@ public sealed class SubjectTransaction : IDisposable
             ArrayPool<SubjectPropertyChange>.Shared.Return(rentedArray, clearArray: true);
         }
 
-        // Release the optimistic lock BEFORE resetting _commitStarted so a retry cannot start
-        // before the optimistic lock is actually free.
+        // Release the optimistic lock before allowing a retry to start.
         commitLock?.Dispose();
 
-        // Release the exclusive lock deferred by a concurrent Dispose, now that the commit has fully finished
-        // (so no other transaction on this context could interleave with its apply pass).
         if (releaseDeferredLock)
         {
             _lockReleaser?.Dispose();
@@ -645,10 +636,6 @@ public sealed class SubjectTransaction : IDisposable
 
         if (!_isCommitted)
         {
-            // Reset so CommitAsync can be retried, but only for failures before anything moved
-            // (conflict detected, optimistic lock not acquired, commit timeout). All later failures,
-            // including converted writer throws, run through FinishCommit first, which marks the
-            // transaction committed and skips this branch, so they are terminal.
             Volatile.Write(ref _commitStarted, 0);
         }
     }
@@ -672,8 +659,6 @@ public sealed class SubjectTransaction : IDisposable
 
     private ValueTask<IDisposable?> AcquireOptimisticLockIfNeededAsync(CancellationToken cancellationToken)
     {
-        // Sync fast path for the default (Exclusive) locking mode: lock was already
-        // acquired in BeginTransactionAsync, so commit needs no lock here.
         if (Locking != TransactionLocking.Optimistic)
         {
             return default;
@@ -690,16 +675,12 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
-            // Rent the ArrayPool buffer BEFORE setting _isCommitting so an OOM in Rent leaves the
-            // transaction reusable (the flag is never set, no cleanup is owed).
+            // Rent before setting _isCommitting so an allocation failure leaves the transaction reusable.
             var pendingChanges = _pendingChanges;
             var changeCount = pendingChanges?.Count ?? 0;
             var rentedArray = ArrayPool<SubjectPropertyChange>.Shared.Rent(changeCount);
 
-            // Set _isCommitting inside the lock to prevent concurrent writes from being
-            // captured into _pendingChanges between the copy and the flag update (TOCTOU).
-            // Once set, EndCommit (run only in the caller's finally) is responsible for clearing it
-            // and returning the rented buffer.
+            // Set this while holding the lock so no write can be captured between snapshot and commit.
             _isCommitting = true;
 
             var index = 0;
@@ -754,6 +735,7 @@ public sealed class SubjectTransaction : IDisposable
     /// </summary>
     public void Dispose()
     {
+        // Publish disposal before taking the lock so a waiting capture observes it and continues normally.
         if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
         {
             Interlocked.Decrement(ref _activeTransactionCount);
@@ -770,6 +752,7 @@ public sealed class SubjectTransaction : IDisposable
                 }
                 else
                 {
+                    // Detach while locked; return the pooled dictionary after releasing the lock.
                     pendingChangesToReturn = _pendingChanges;
                     _pendingChanges = null;
                 }
@@ -782,10 +765,6 @@ public sealed class SubjectTransaction : IDisposable
                 CurrentTransaction.Value = null;
             }
 
-            // A commit in flight (reachable only by misuse: disposing without awaiting CommitAsync) still owns
-            // the pooled buffer and the exclusive lock, so skip both here: returning the buffer would corrupt
-            // another transaction's pending changes, and releasing the lock would drop mutual exclusion mid-apply.
-            // EndCommit returns the deferred buffer and releases the deferred lock once the commit completes.
             if (!committing)
             {
                 if (pendingChangesToReturn is not null)

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -34,7 +34,7 @@ public sealed class SubjectTransaction : IDisposable
     private static readonly ObjectPool<OrderedDictionary<PropertyReference, SubjectPropertyChange>> PendingChangesPool
         = new(() => new OrderedDictionary<PropertyReference, SubjectPropertyChange>(PropertyReference.Comparer));
 
-    private readonly OrderedDictionary<PropertyReference, SubjectPropertyChange> _pendingChanges = PendingChangesPool.Rent();
+    private OrderedDictionary<PropertyReference, SubjectPropertyChange>? _pendingChanges = PendingChangesPool.Rent();
     private readonly Lock _pendingChangesLock = new();
 
     private volatile bool _isCommitting;
@@ -74,6 +74,11 @@ public sealed class SubjectTransaction : IDisposable
     internal bool IsCommitting => _isCommitting;
 
     /// <summary>
+    /// Gets a value indicating whether the transaction has been disposed.
+    /// </summary>
+    internal bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+    /// <summary>
     /// Gets the interceptor this transaction is bound to (for cross-context validation).
     /// </summary>
     internal SubjectTransactionInterceptor Interceptor { get; }
@@ -85,7 +90,7 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
-            return _pendingChanges.Values.ToList();
+            return _pendingChanges?.Values.ToList() ?? [];
         }
     }
 
@@ -97,6 +102,12 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
+            if (Volatile.Read(ref _isDisposed) != 0 || _pendingChanges is null)
+            {
+                value = default!;
+                return false;
+            }
+
             ThrowIfCommittingConcurrently();
 
             if (_pendingChanges.TryGetValue(property, out var change))
@@ -113,10 +124,11 @@ public sealed class SubjectTransaction : IDisposable
     /// <summary>
     /// Atomically captures a property change into the pending dictionary.
     /// First write preserves <paramref name="currentValue"/> as old value for conflict detection;
-    /// subsequent writes preserve the original old value (last write wins).
+    /// subsequent writes preserve the original old value (last write wins). Returns false when
+    /// disposal wins the race, allowing the caller to continue the normal write chain.
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown if a concurrent commit is in progress (TOCTOU race).</exception>
-    internal void CaptureChange<TProperty>(
+    internal bool TryCaptureChange<TProperty>(
         PropertyReference property,
         ChangeOrigin origin,
         DateTimeOffset changedTimestamp,
@@ -128,14 +140,21 @@ public sealed class SubjectTransaction : IDisposable
         {
             ThrowIfCommittingConcurrently();
 
-            var isFirstWrite = !_pendingChanges.TryGetValue(property, out var existingChange);
-            _pendingChanges[property] = SubjectPropertyChange.Create(
+            if (Volatile.Read(ref _isDisposed) != 0)
+            {
+                return false;
+            }
+
+            var pendingChanges = _pendingChanges!;
+            var isFirstWrite = !pendingChanges.TryGetValue(property, out var existingChange);
+            pendingChanges[property] = SubjectPropertyChange.Create(
                 property,
                 origin: origin,
                 changedTimestamp: changedTimestamp,
                 receivedTimestamp: receivedTimestamp,
                 isFirstWrite ? currentValue : existingChange.GetOldValue<TProperty>(),
                 newValue);
+            return true;
         }
     }
 
@@ -271,7 +290,7 @@ public sealed class SubjectTransaction : IDisposable
 
         lock (_pendingChangesLock)
         {
-            if (_pendingChanges.Count == 0)
+            if (_pendingChanges is null || _pendingChanges.Count == 0)
             {
                 _isCommitted = true;
                 return default;
@@ -549,7 +568,7 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
-            _pendingChanges.Clear();
+            _pendingChanges?.Clear();
         }
 
         _isCommitted = true;
@@ -562,6 +581,7 @@ public sealed class SubjectTransaction : IDisposable
     private void EndCommit(SubjectPropertyChange[]? rentedArray, IDisposable? commitLock)
     {
         bool releaseDeferredLock;
+        OrderedDictionary<PropertyReference, SubjectPropertyChange>? pendingChangesToReturn = null;
         lock (_pendingChangesLock)
         {
             // Clear under the lock so a concurrent Dispose observes the in-flight commit consistently: while
@@ -571,6 +591,16 @@ public sealed class SubjectTransaction : IDisposable
             // by this commit and is always returned here.
             _isCommitting = false;
             releaseDeferredLock = _disposeRequestedDuringCommit;
+            if (releaseDeferredLock)
+            {
+                pendingChangesToReturn = _pendingChanges;
+                _pendingChanges = null;
+            }
+        }
+
+        if (pendingChangesToReturn is not null)
+        {
+            PendingChangesPool.Return(pendingChangesToReturn);
         }
 
         if (rentedArray != null)
@@ -641,7 +671,8 @@ public sealed class SubjectTransaction : IDisposable
         {
             // Rent the ArrayPool buffer BEFORE setting _isCommitting so an OOM in Rent leaves the
             // transaction reusable (the flag is never set, no cleanup is owed).
-            var changeCount = _pendingChanges.Count;
+            var pendingChanges = _pendingChanges;
+            var changeCount = pendingChanges?.Count ?? 0;
             var rentedArray = ArrayPool<SubjectPropertyChange>.Shared.Rent(changeCount);
 
             // Set _isCommitting inside the lock to prevent concurrent writes from being
@@ -651,9 +682,12 @@ public sealed class SubjectTransaction : IDisposable
             _isCommitting = true;
 
             var index = 0;
-            foreach (var change in _pendingChanges.Values)
+            if (pendingChanges is not null)
             {
-                rentedArray[index++] = change;
+                foreach (var change in pendingChanges.Values)
+                {
+                    rentedArray[index++] = change;
+                }
             }
 
             return (rentedArray, rentedArray.AsMemory(0, changeCount));
@@ -704,13 +738,19 @@ public sealed class SubjectTransaction : IDisposable
             Interlocked.Decrement(ref _activeTransactionCount);
 
             bool committing;
+            OrderedDictionary<PropertyReference, SubjectPropertyChange>? pendingChangesToReturn = null;
             lock (_pendingChangesLock)
             {
-                _pendingChanges.Clear();
+                _pendingChanges?.Clear();
                 committing = _isCommitting;
                 if (committing)
                 {
                     _disposeRequestedDuringCommit = true;
+                }
+                else
+                {
+                    pendingChangesToReturn = _pendingChanges;
+                    _pendingChanges = null;
                 }
             }
 
@@ -724,10 +764,13 @@ public sealed class SubjectTransaction : IDisposable
             // A commit in flight (reachable only by misuse: disposing without awaiting CommitAsync) still owns
             // the pooled buffer and the exclusive lock, so skip both here: returning the buffer would corrupt
             // another transaction's pending changes, and releasing the lock would drop mutual exclusion mid-apply.
-            // EndCommit releases the deferred lock once the commit completes; the buffer is left unpooled (GC'd).
+            // EndCommit returns the deferred buffer and releases the deferred lock once the commit completes.
             if (!committing)
             {
-                PendingChangesPool.Return(_pendingChanges);
+                if (pendingChangesToReturn is not null)
+                {
+                    PendingChangesPool.Return(pendingChangesToReturn);
+                }
                 _lockReleaser?.Dispose(); // May be null for Optimistic transactions
             }
         }

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -121,6 +121,27 @@ public sealed class SubjectTransaction : IDisposable
         }
     }
 
+    internal bool ContainsAnyPendingValue(ReadOnlySpan<PropertyReference> properties)
+    {
+        lock (_pendingChangesLock)
+        {
+            if (Volatile.Read(ref _isDisposed) != 0 || _pendingChanges is null)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < properties.Length; index++)
+            {
+                if (_pendingChanges.ContainsKey(properties[index]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
     /// <summary>
     /// Atomically captures a property change into the pending dictionary.
     /// First write preserves <paramref name="currentValue"/> as old value for conflict detection;

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -121,27 +121,6 @@ public sealed class SubjectTransaction : IDisposable
         }
     }
 
-    internal bool ContainsAnyPendingValue(ReadOnlySpan<PropertyReference> properties)
-    {
-        lock (_pendingChangesLock)
-        {
-            if (Volatile.Read(ref _isDisposed) != 0 || _pendingChanges is null)
-            {
-                return false;
-            }
-
-            for (var index = 0; index < properties.Length; index++)
-            {
-                if (_pendingChanges.ContainsKey(properties[index]))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-    }
-
     /// <summary>
     /// Atomically captures a property change into the pending dictionary.
     /// First write preserves <paramref name="currentValue"/> as old value for conflict detection;

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -230,7 +230,7 @@ public sealed class SubjectTransaction : IDisposable
         CancellationToken cancellationToken)
     {
         // Check for nested transactions BEFORE acquiring lock (prevents deadlock)
-        if (CurrentTransaction.Value != null)
+        if (CurrentTransaction.Value is { IsDisposed: false })
         {
             throw new InvalidOperationException("Nested transactions are not supported.");
         }

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -13,6 +13,9 @@ public sealed class SubjectTransaction : IDisposable
     private static readonly AsyncLocal<SubjectTransaction?> CurrentTransaction = new();
     private static int _activeTransactionCount;
 
+    [ThreadStatic]
+    private static SubjectTransaction? _commitModelAccessTransaction;
+
     /// <summary>
     /// Gets a value indicating whether any transaction is currently active across all contexts.
     /// This is a fast-path check using a volatile read; it may briefly return true after
@@ -74,9 +77,19 @@ public sealed class SubjectTransaction : IDisposable
     internal bool IsCommitting => _isCommitting;
 
     /// <summary>
+    /// Gets a value indicating whether the transaction has reached a terminal committed state.
+    /// </summary>
+    internal bool IsCommitted => _isCommitted;
+
+    /// <summary>
     /// Gets a value indicating whether the transaction has been disposed.
     /// </summary>
     internal bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+    /// <summary>
+    /// Gets a value indicating whether this thread is synchronously replaying this transaction's model work.
+    /// </summary>
+    internal bool IsCommitModelAccessAuthorized => ReferenceEquals(_commitModelAccessTransaction, this);
 
     /// <summary>
     /// Gets the interceptor this transaction is bound to (for cross-context validation).
@@ -102,7 +115,7 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
-            if (Volatile.Read(ref _isDisposed) != 0 || _pendingChanges is null)
+            if (Volatile.Read(ref _isDisposed) != 0 || _isCommitted || _pendingChanges is null)
             {
                 value = default!;
                 return false;
@@ -138,7 +151,7 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
-            if (Volatile.Read(ref _isDisposed) != 0)
+            if (Volatile.Read(ref _isDisposed) != 0 || _isCommitted || _pendingChanges is null)
             {
                 return false;
             }
@@ -155,6 +168,25 @@ public sealed class SubjectTransaction : IDisposable
                 isFirstWrite ? currentValue : existingChange.GetOldValue<TProperty>(),
                 newValue);
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Rechecks an interceptor's lock-free state observation. Returns true when the transaction became
+    /// inactive, throws while a live commit still owns the model, and otherwise returns false so the caller
+    /// can continue the live non-committing path.
+    /// </summary>
+    internal bool IsInactiveUnderLockOrThrowIfCommitting()
+    {
+        lock (_pendingChangesLock)
+        {
+            if (Volatile.Read(ref _isDisposed) != 0 || _isCommitted || _pendingChanges is null)
+            {
+                return true;
+            }
+
+            ThrowIfCommittingConcurrently();
+            return false;
         }
     }
 
@@ -340,21 +372,24 @@ public sealed class SubjectTransaction : IDisposable
             var (rented, changes) = StartCommitAndSnapshotChanges();
             rentedArray = rented;
 
-            ThrowIfConflictsDetected(changes.Span);
-
-            var (applied, applyFailed, applyErrors) = SubjectPropertyChangeOperations.ApplyLocalChanges(changes.Span, exclude: null);
-
             SubjectTransactionException? failure = null;
-            if (applyFailed.Count > 0)
+            using (EnterCommitModelAccess())
             {
-                if (_failureHandling == TransactionFailureHandling.Rollback)
+                ThrowIfConflictsDetected(changes.Span);
+
+                var (applied, applyFailed, applyErrors) = SubjectPropertyChangeOperations.ApplyLocalChanges(changes.Span, exclude: null);
+
+                if (applyFailed.Count > 0)
                 {
-                    var (revertFailed, revertErrors) = SubjectPropertyChangeOperations.RevertLocalChanges(applied);
-                    failure = CreateFailureException([], SubjectPropertyChangeOperations.Concat(applyFailed, revertFailed), SubjectPropertyChangeOperations.Concat(applyErrors, revertErrors));
-                }
-                else
-                {
-                    failure = CreateFailureException(applied, applyFailed, applyErrors);
+                    if (_failureHandling == TransactionFailureHandling.Rollback)
+                    {
+                        var (revertFailed, revertErrors) = SubjectPropertyChangeOperations.RevertLocalChanges(applied);
+                        failure = CreateFailureException([], SubjectPropertyChangeOperations.Concat(applyFailed, revertFailed), SubjectPropertyChangeOperations.Concat(applyErrors, revertErrors));
+                    }
+                    else
+                    {
+                        failure = CreateFailureException(applied, applyFailed, applyErrors);
+                    }
                 }
             }
 
@@ -384,7 +419,10 @@ public sealed class SubjectTransaction : IDisposable
             var (rented, changes) = StartCommitAndSnapshotChanges();
             rentedArray = rented;
 
-            ThrowIfConflictsDetected(changes.Span);
+            using (EnterCommitModelAccess())
+            {
+                ThrowIfConflictsDetected(changes.Span);
+            }
 
             using var timeoutCts = CreateCommitTimeoutCts();
             var commitToken = timeoutCts?.Token ?? CancellationToken.None;
@@ -458,14 +496,25 @@ public sealed class SubjectTransaction : IDisposable
         // Apply the whole snapshot except the source-write failures in a single pass. With no source
         // failure, this is the entire snapshot, and ApplyAllChanges returns an empty Successful set.
         var exclude = failedSource.Count == 0 ? null : failedSource;
-        var (applied, applyFailed, applyErrors) = SubjectPropertyChangeOperations.ApplyLocalChanges(changes.Span, exclude);
+        IReadOnlyList<SubjectPropertyChange> applied;
+        IReadOnlyList<SubjectPropertyChange> applyFailed;
+        IReadOnlyList<Exception> applyErrors;
+        IReadOnlyList<SubjectPropertyChange> revertFailed = [];
+        IReadOnlyList<Exception> revertErrors = [];
+        using (EnterCommitModelAccess())
+        {
+            (applied, applyFailed, applyErrors) = SubjectPropertyChangeOperations.ApplyLocalChanges(changes.Span, exclude);
+            if (applyFailed.Count > 0 && _failureHandling == TransactionFailureHandling.Rollback)
+            {
+                (revertFailed, revertErrors) = SubjectPropertyChangeOperations.RevertLocalChanges(applied);
+            }
+        }
 
         if (applyFailed.Count > 0)
         {
             if (_failureHandling == TransactionFailureHandling.Rollback)
             {
                 // All-or-nothing: revert local applies, then the source writes.
-                var (revertFailed, revertErrors) = SubjectPropertyChangeOperations.RevertLocalChanges(applied);
                 var sourceRevert = await RevertSourceWritesSafelyAsync(writer, written, revertState, cancellationToken).ConfigureAwait(false);
                 // The no-source local changes were applied then reverted; under all-or-nothing they did not
                 // commit, so report them as failed too (consistent with the source-write-failure branch and
@@ -565,9 +614,8 @@ public sealed class SubjectTransaction : IDisposable
         lock (_pendingChangesLock)
         {
             _pendingChanges?.Clear();
+            _isCommitted = true;
         }
-
-        _isCommitted = true;
     }
 
     /// <summary>
@@ -694,6 +742,28 @@ public sealed class SubjectTransaction : IDisposable
         return _commitTimeout == Timeout.InfiniteTimeSpan
             ? null
             : new CancellationTokenSource(_commitTimeout);
+    }
+
+    private CommitModelAccessScope EnterCommitModelAccess() => new(this);
+
+    /// <summary>
+    /// Grants model access only to synchronous commit-owned work on this thread. The previous identity is
+    /// restored for nested/reentrant use. Callers must dispose the scope before awaiting external code.
+    /// </summary>
+    private readonly struct CommitModelAccessScope : IDisposable
+    {
+        private readonly SubjectTransaction? _previousTransaction;
+
+        public CommitModelAccessScope(SubjectTransaction transaction)
+        {
+            _previousTransaction = _commitModelAccessTransaction;
+            _commitModelAccessTransaction = transaction;
+        }
+
+        public void Dispose()
+        {
+            _commitModelAccessTransaction = _previousTransaction;
+        }
     }
 
     private SubjectTransactionException CreateFailureException(

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -138,12 +138,12 @@ public sealed class SubjectTransaction : IDisposable
     {
         lock (_pendingChangesLock)
         {
-            ThrowIfCommittingConcurrently();
-
             if (Volatile.Read(ref _isDisposed) != 0)
             {
                 return false;
             }
+
+            ThrowIfCommittingConcurrently();
 
             var pendingChanges = _pendingChanges!;
             var isFirstWrite = !pendingChanges.TryGetValue(property, out var existingChange);
@@ -581,8 +581,9 @@ public sealed class SubjectTransaction : IDisposable
         lock (_pendingChangesLock)
         {
             // Clear under the lock so Dispose observes the in-flight commit consistently. A disposing caller
-            // defers exclusive-lock release while this commit owns it. If it also owns the pending dictionary,
-            // detach it here and return it after the lock so ownership transfers exactly once.
+            // defers exclusive-lock release until commit completion so another transaction cannot interleave
+            // with the apply pass. If it also owns the pending dictionary, detach it here and return it after
+            // the lock so ownership transfers exactly once.
             _isCommitting = false;
             releaseDeferredLock = _disposeRequestedDuringCommit;
             if (releaseDeferredLock)
@@ -615,6 +616,7 @@ public sealed class SubjectTransaction : IDisposable
 
         if (!_isCommitted)
         {
+            // Only failures that escape before FinishCommit are retryable; later failures are terminal.
             Volatile.Write(ref _commitStarted, 0);
         }
     }

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -36,7 +36,7 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         }
 
         var transaction = SubjectTransaction.Current;
-        if (transaction is { IsCommitting: false } &&
+        if (transaction is { IsCommitting: false, IsDisposed: false } &&
             transaction.TryGetPendingValue<TProperty>(context.Property, out var pendingValue))
         {
             return pendingValue;
@@ -57,7 +57,7 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         }
 
         var transaction = SubjectTransaction.Current;
-        if (transaction is { IsCommitting: false } && !context.Property.Metadata.IsDerived)
+        if (transaction is { IsCommitting: false, IsDisposed: false } && !context.Property.Metadata.IsDerived)
         {
             // Validate context binding
             var subjectInterceptor = context.Property.Subject.Context.TryGetService<SubjectTransactionInterceptor>();
@@ -67,25 +67,23 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
                     $"Cannot modify property '{context.Property.Metadata.Name}': Transaction is bound to a different context.");
             }
 
-            // Capture is a terminal outcome for the chain: the downstream write (and its origin
-            // finalization) never runs. Finalize here so a stamped origin whose captured value was
-            // transformed (e.g. an OnChanging clamp) demotes to Local, matching what the terminal
-            // write would have produced. Otherwise the stale FromSource survives commit replay and
-            // the corrected value is echo-suppressed, leaving the source diverged.
-            context.FinalizeOrigin();
+            var resolvedOrigin = context.GetFinalOrigin();
+            var changedTimestamp = context.WriteTimestampForPublishing;
+            var receivedTimestamp = SubjectChangeContext.Current.ReceivedTimestamp;
 
-            transaction.CaptureChange(
-                context.Property,
-                context.Origin,
-                context.WriteTimestampForPublishing,
-                SubjectChangeContext.Current.ReceivedTimestamp,
-                context.CurrentValue,
-                context.NewValue);
-
-            return; // Captured, interceptor chain stops here
+            if (transaction.TryCaptureChange(
+                    context.Property,
+                    resolvedOrigin,
+                    changedTimestamp,
+                    receivedTimestamp,
+                    context.CurrentValue,
+                    context.NewValue))
+            {
+                return;
+            }
         }
 
-        next(ref context); // No transaction, derived, or committing: Normal flow
+        next(ref context); // No transaction, disposed, derived, committing, or failed capture: Normal flow
     }
 
     private sealed class LockReleaser(SemaphoreSlim semaphore) : IDisposable

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -36,9 +36,32 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         }
 
         var transaction = SubjectTransaction.Current;
-        if (transaction is { IsCommitting: false, IsDisposed: false } &&
-            !DerivedPropertyChangeHandler.IsRecordingDerivedProperty &&
-            transaction.TryGetPendingValue<TProperty>(context.Property, out var pendingValue))
+        if (transaction is null || transaction.IsDisposed || transaction.IsCommitted)
+        {
+            return next(ref context);
+        }
+
+        if (transaction.IsCommitting)
+        {
+            if (transaction.IsCommitModelAccessAuthorized)
+            {
+                return next(ref context);
+            }
+
+            if (transaction.IsInactiveUnderLockOrThrowIfCommitting())
+            {
+                return next(ref context);
+            }
+        }
+
+        // Recorder-active reads are the landed-model view. This access linearizes at the non-committing
+        // observation above; do not hold the transaction lock while a user getter executes.
+        if (DerivedPropertyChangeHandler.IsRecordingDerivedProperty)
+        {
+            return next(ref context);
+        }
+
+        if (transaction.TryGetPendingValue<TProperty>(context.Property, out var pendingValue))
         {
             return pendingValue;
         }
@@ -57,35 +80,61 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         }
 
         var transaction = SubjectTransaction.Current;
-        if (transaction is { IsCommitting: false, IsDisposed: false } && !context.Property.Metadata.IsDerived)
+        if (transaction is null || transaction.IsDisposed || transaction.IsCommitted)
         {
-            var subjectInterceptors = context.Property.Subject.Context
-                .GetServices<SubjectTransactionInterceptor>();
-            var isBoundToThisContext = subjectInterceptors.Length == 1
-                ? ReferenceEquals(subjectInterceptors[0], transaction.Interceptor)
-                : ContainsByReference(subjectInterceptors, transaction.Interceptor);
+            next(ref context);
+            return;
+        }
 
-            if (!isBoundToThisContext)
+        if (transaction.IsCommitting)
+        {
+            if (transaction.IsCommitModelAccessAuthorized)
             {
-                throw new InvalidOperationException(
-                    $"Cannot modify property '{context.Property.Metadata.Name}': Transaction is bound to a different context.");
-            }
-
-            // Origin comparison can run user equality code, so resolve it before taking the transaction lock.
-            var resolvedOrigin = context.GetFinalOrigin();
-            var changedTimestamp = context.WriteTimestampForPublishing;
-            var receivedTimestamp = SubjectChangeContext.Current.ReceivedTimestamp;
-
-            if (transaction.TryCaptureChange(
-                    context.Property,
-                    resolvedOrigin,
-                    changedTimestamp,
-                    receivedTimestamp,
-                    context.CurrentValue,
-                    context.NewValue))
-            {
+                next(ref context);
                 return;
             }
+
+            if (transaction.IsInactiveUnderLockOrThrowIfCommitting())
+            {
+                next(ref context);
+                return;
+            }
+        }
+
+        // Settable-derived writes are immediate and outside the transaction. This access linearizes at the
+        // non-committing observation above; do not hold the transaction lock while a user setter executes.
+        if (context.Property.Metadata.IsDerived)
+        {
+            next(ref context);
+            return;
+        }
+
+        var subjectInterceptors = context.Property.Subject.Context
+            .GetServices<SubjectTransactionInterceptor>();
+        var isBoundToThisContext = subjectInterceptors.Length == 1
+            ? ReferenceEquals(subjectInterceptors[0], transaction.Interceptor)
+            : ContainsByReference(subjectInterceptors, transaction.Interceptor);
+
+        if (!isBoundToThisContext)
+        {
+            throw new InvalidOperationException(
+                $"Cannot modify property '{context.Property.Metadata.Name}': Transaction is bound to a different context.");
+        }
+
+        // Origin comparison can run user equality code, so resolve it before taking the transaction lock.
+        var resolvedOrigin = context.GetFinalOrigin();
+        var changedTimestamp = context.WriteTimestampForPublishing;
+        var receivedTimestamp = SubjectChangeContext.Current.ReceivedTimestamp;
+
+        if (transaction.TryCaptureChange(
+                context.Property,
+                resolvedOrigin,
+                changedTimestamp,
+                receivedTimestamp,
+                context.CurrentValue,
+                context.NewValue))
+        {
+            return;
         }
 
         next(ref context);

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Interceptors;
@@ -58,9 +59,11 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         var transaction = SubjectTransaction.Current;
         if (transaction is { IsCommitting: false, IsDisposed: false } && !context.Property.Metadata.IsDerived)
         {
-            var isBoundToThisContext = context.Property.Subject.Context
-                .GetServices<SubjectTransactionInterceptor>()
-                .Contains(transaction.Interceptor);
+            var subjectInterceptors = context.Property.Subject.Context
+                .GetServices<SubjectTransactionInterceptor>();
+            var isBoundToThisContext = subjectInterceptors.Length == 1
+                ? ReferenceEquals(subjectInterceptors[0], transaction.Interceptor)
+                : ContainsByReference(subjectInterceptors, transaction.Interceptor);
 
             if (!isBoundToThisContext)
             {
@@ -86,6 +89,22 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         }
 
         next(ref context);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ContainsByReference(
+        ImmutableArray<SubjectTransactionInterceptor> interceptors,
+        SubjectTransactionInterceptor target)
+    {
+        for (var index = 0; index < interceptors.Length; index++)
+        {
+            if (ReferenceEquals(interceptors[index], target))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private sealed class LockReleaser(SemaphoreSlim semaphore) : IDisposable

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -29,7 +29,6 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public TProperty ReadProperty<TProperty>(ref PropertyReadContext<TProperty> context, ReadInterceptionDelegate<TProperty> next)
     {
-        // Fast path: Skip transaction check when no transaction is active (avoids AsyncLocal read)
         if (!SubjectTransaction.HasActiveTransaction)
         {
             return next(ref context);
@@ -49,7 +48,6 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next)
     {
-        // Fast path: Skip transaction check when no transaction is active (avoids AsyncLocal read)
         if (!SubjectTransaction.HasActiveTransaction)
         {
             next(ref context);
@@ -59,7 +57,6 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         var transaction = SubjectTransaction.Current;
         if (transaction is { IsCommitting: false, IsDisposed: false } && !context.Property.Metadata.IsDerived)
         {
-            // Validate context binding
             var isBoundToThisContext = context.Property.Subject.Context
                 .GetServices<SubjectTransactionInterceptor>()
                 .Contains(transaction.Interceptor);
@@ -70,6 +67,7 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
                     $"Cannot modify property '{context.Property.Metadata.Name}': Transaction is bound to a different context.");
             }
 
+            // Origin comparison can run user equality code, so resolve it before taking the transaction lock.
             var resolvedOrigin = context.GetFinalOrigin();
             var changedTimestamp = context.WriteTimestampForPublishing;
             var receivedTimestamp = SubjectChangeContext.Current.ReceivedTimestamp;
@@ -86,7 +84,7 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
             }
         }
 
-        next(ref context); // No transaction, disposed, derived, committing, or failed capture: Normal flow
+        next(ref context);
     }
 
     private sealed class LockReleaser(SemaphoreSlim semaphore) : IDisposable

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -36,6 +36,7 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
 
         var transaction = SubjectTransaction.Current;
         if (transaction is { IsCommitting: false, IsDisposed: false } &&
+            !DerivedPropertyChangeHandler.IsRecordingDerivedProperty &&
             transaction.TryGetPendingValue<TProperty>(context.Property, out var pendingValue))
         {
             return pendingValue;

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -60,8 +60,11 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         if (transaction is { IsCommitting: false, IsDisposed: false } && !context.Property.Metadata.IsDerived)
         {
             // Validate context binding
-            var subjectInterceptor = context.Property.Subject.Context.TryGetService<SubjectTransactionInterceptor>();
-            if (subjectInterceptor != transaction.Interceptor)
+            var isBoundToThisContext = context.Property.Subject.Context
+                .GetServices<SubjectTransactionInterceptor>()
+                .Contains(transaction.Interceptor);
+
+            if (!isBoundToThisContext)
             {
                 throw new InvalidOperationException(
                     $"Cannot modify property '{context.Property.Metadata.Name}': Transaction is bound to a different context.");

--- a/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
@@ -14,9 +14,9 @@ public interface IWriteInterceptor
     /// values are boxed through non-generic paths (e.g., <c>SetPropertyValueWithInterception</c>).
     /// Use <c>context.Property.Metadata.Type</c> for the actual declared property type.</typeparam>
     /// <param name="context">The write context containing the property reference and values.</param>
-    /// <param name="next">The next interceptor in the chain to call. Always forward the context you
-    /// received; a freshly constructed context loses the per-call state the chain threads through it
-    /// (including the terminal write operation).</param>
+    /// <param name="next">The next interceptor in the chain to call. Always forward the received context by
+    /// reference. Copying it loses per-call changes, including <see cref="PropertyWriteContext{TProperty}.IsWritten"/>,
+    /// and a freshly constructed context also loses the terminal write operation.</param>
     void WriteProperty<TProperty>(ref PropertyWriteContext<TProperty> context, WriteInterceptionDelegate<TProperty> next);
 }
 

--- a/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
@@ -261,17 +261,12 @@ public struct PropertyWriteContext<TProperty>
             : NewValue;
     }
 
-    /// <summary>
-    /// Finalizes <see cref="Origin"/> at the terminal write (right after <see cref="IsWritten"/>
-    /// becomes true). A stamped origin survives only when the stored value is exactly the value the
-    /// source sent; otherwise the value was computed locally and the origin becomes Local.
-    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void FinalizeOrigin()
+    internal ChangeOrigin GetFinalOrigin()
     {
         if (_attempted.Origin.Kind == ChangeOriginKind.Local)
         {
-            return;
+            return default;
         }
 
         // A derived property's stored value is recomputed by its getter, never literally the sent value,
@@ -279,8 +274,7 @@ public struct PropertyWriteContext<TProperty>
         // here (this executes under the subject's SyncRoot).
         if (Property.Metadata.IsDerived)
         {
-            _attempted = default;
-            return;
+            return default;
         }
 
         // Survive only when the sent value was faithfully stored. The 'is TProperty' pattern unboxes
@@ -294,7 +288,18 @@ public struct PropertyWriteContext<TProperty>
                 ? NewValue is null
                 : SentValueEqualsAfterUnbox(_attempted.SentValue, NewValue);
 
-        if (!survives)
+        return survives ? _attempted.Origin : default;
+    }
+
+    /// <summary>
+    /// Finalizes <see cref="Origin"/> at the terminal write (right after <see cref="IsWritten"/>
+    /// becomes true). A stamped origin survives only when the stored value is exactly the value the
+    /// source sent; otherwise the value was computed locally and the origin becomes Local.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void FinalizeOrigin()
+    {
+        if (GetFinalOrigin().Kind == ChangeOriginKind.Local)
         {
             _attempted = default;
         }


### PR DESCRIPTION
## Summary

- Make transaction capture, commit, terminal completion, and disposal ownership atomic, including stale ambient transaction handling.
- Reject access carrying a live ambient transaction while a commit owns the frozen snapshot, while allowing only synchronous commit-owned model replay.
- Preserve direct transaction read-your-writes while ensuring derived tracking observes landed model values after rollback, failure, transformation, and reentrant evaluation.
- Scope cascade suppression to writes that actually landed, so vetoed writes and unrelated writes retain the correct behavior.
- Keep multiple and inherited transaction interceptor registrations correct while optimizing the common singleton context-binding path.

## Contract

- Direct reads inside a live transaction return pending values.
- After terminal commit completion, the still-ambient transaction is inactive: reads see the model and writes land normally instead of entering a dead buffer.
- Property access carrying a live ambient transaction during an in-progress commit throws. Synchronous conflict detection, apply, revert, hooks, and derived cascades owned by that commit remain valid.
- Disposal makes the ambient transaction inactive immediately. Ordinary raw writes may therefore interleave with an already-started external-writer commit and may later be overwritten by its frozen replay.
- Derived tracking and shared derived values are calculated from landed model state.
- Commit publishes and cascades changes in deterministic landed order.
- Nested and concurrent derived evaluation uses invocation-owned, thread-local recording state.
- Settable-derived writes retain their current immediate, non-transactional behavior; #471 tracks the separate design decision.
- No public API is added or removed.

## Behavior change for transaction writers

Misuse of a live transaction during commit now fails loudly. While `CommitAsync()` is in progress, reading or writing a property on a flow carrying that live transaction throws `InvalidOperationException`. Previously, such writes could bypass the frozen transaction snapshot and land directly in the model. Synchronous model replay owned by the commit, including property hooks, change handlers, and derived cascades, remains authorized.

Custom `ITransactionWriter` implementations must construct source operations from the supplied change snapshot, writer-owned configuration, and any required subject state captured before `CommitAsync()`. They must not read or write subject properties from `WriteToSourcesAsync` or `RevertSourceWritesAsync`; even a getter reads landed sibling state outside the frozen snapshot and can make the source payload inconsistent.

## Verification

- `dotnet build src/Namotion.Interceptor.slnx --no-restore`
  - Passed with 0 warnings and 0 errors.
- `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration" --no-build --no-restore`
  - Passed: 3,103 tests, 0 failed, 0 skipped, including 474 tracking tests.
- Targeted transaction, terminal-state, frozen-snapshot access, rollback, veto, nested derived, derived-of-derived, reentrancy, disposal boundary, multi-context, and mutation-sensitivity tests pass.
- Independent correctness and concurrency reviews found no blocking defect. Final minor feedback was incorporated with deterministic public-path coverage and documentation corrections.
- Detailed cross-revision benchmark evidence and controls are recorded in [the review comment](https://github.com/RicoSuter/Namotion.Interceptor/pull/468#issuecomment-5306973304). Reported allocations were unchanged, and timing deltas stayed within the measured control noise.

## Scope

This PR contains only the transaction and derived-tracking correctness foundation. Scheduled property subscriptions follow in #469, stacked on this branch.

The concrete reproduction from #465 is fixed here; that issue remains closed as superseded by #467.

Fixes #467
Addresses #466
Follow-up: #471
