### PR TITLE
Enforce unique context authorities

### DIFF
--- a/docs/design/context-cardinality.md
+++ b/docs/design/context-cardinality.md
@@ -1,0 +1,26 @@
+# Context service cardinality
+
+Some services represent one authority for a resolved context cone. Such a service implements
+`IUniqueContextService<TContract>`, where `TContract` identifies the constrained authority.
+
+For each authority contract, zero or one distinct instance is valid. The same object reached
+through several context paths is valid. Two different objects are invalid even when `Equals`
+reports equality. One object may implement several authority contracts.
+
+The initial unique authorities are `ILifecycleInterceptor`, `ISubjectRegistry`, and
+`SubjectTransactionInterceptor`. Ordered extension collections such as `ILifecycleHandler` and
+`IPropertyLifecycleHandler` remain multi-service.
+
+Validation runs while services are resolved and examines every reachable raw service, not only the
+requested service type. Consequently an unrelated query can expose a conflicting authority.
+`TryGetService<T>()` may throw; its `Try` prefix describes the no-result case only.
+
+Successful validation is cached on immutable context state. Service or fallback mutation publishes
+a new state without the marker and invalidates upstream caches. Invalid topology may therefore
+exist after mutation until its next resolution.
+
+Configure and compose one shared application context for the ordinary object graph. When several
+contexts intentionally expose non-unique services, compose them before configuring the consuming
+context so idempotent helpers reuse reachable authorities. Independently configured contexts that
+contribute different lifecycle, registry, or transaction authorities cannot share one resolved
+cone.

--- a/docs/interceptor.md
+++ b/docs/interceptor.md
@@ -46,6 +46,14 @@ var registry = context.TryGetService<SubjectRegistry>();
 
 Services are cached after first resolution. The cache is invalidated when services or fallback contexts change.
 
+### Unique authorities
+
+Some context services are singular authorities, determined by reference identity. Validation covers
+unrelated services in the complete fallback cone, so `TryGetService<T>()` can throw for
+singular-service ambiguity, delegation cycles, or unique authority conflicts. One shared context
+remains the recommended setup for the common case. See [Context service cardinality](design/context-cardinality.md)
+for the full contract.
+
 ## Fallback Contexts
 
 Contexts can be linked in a hierarchy where child contexts inherit services from parent contexts:

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/ContextConfigurationCompositionTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/ContextConfigurationCompositionTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Namotion.Interceptor;
+using Namotion.Interceptor.Interceptors;
+
+namespace HomeBlaze.Services.Tests;
+
+public class ContextConfigurationCompositionTests
+{
+    [Fact]
+    public void WhenPathResolverContextsAreConfiguredBeforeComposition_ThenResolutionThrows()
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        AddRootManager(parent);
+        AddRootManager(child);
+        parent.WithPathResolver();
+        child.WithPathResolver();
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(ILifecycleInterceptor).FullName!, exception.Message);
+    }
+
+    private static void AddRootManager(IInterceptorSubjectContext context)
+    {
+        var typeProvider = new TypeProvider();
+        var typeRegistry = new SubjectTypeRegistry(typeProvider);
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var serializer = new ConfigurableSubjectSerializer(typeProvider, serviceProvider);
+        _ = new RootManager(typeRegistry, serializer, context);
+    }
+}

--- a/src/Namotion.Interceptor.Connectors.Tests/ContextConfigurationCompositionTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/ContextConfigurationCompositionTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.DependencyInjection;
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Tracking.Transactions;
+
+namespace Namotion.Interceptor.Connectors.Tests;
+
+public class ContextConfigurationCompositionTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WhenSourceMonitoringContextsAreConfiguredBeforeComposition_ThenResolutionThrows(
+        bool useHostedOverload)
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        ConfigureSourceMonitoring(parent, useHostedOverload);
+        ConfigureSourceMonitoring(child, useHostedOverload);
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(ILifecycleInterceptor).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void WhenSourceTransactionContextsAreConfiguredBeforeComposition_ThenResolutionThrows()
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create().WithSourceTransactions();
+        var child = InterceptorSubjectContext.Create().WithSourceTransactions();
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(SubjectTransactionInterceptor).FullName!, exception.Message);
+    }
+
+    private static void ConfigureSourceMonitoring(
+        IInterceptorSubjectContext context,
+        bool useHostedOverload)
+    {
+        if (useHostedOverload)
+        {
+            context.WithSourceMonitoring(new ServiceCollection());
+        }
+        else
+        {
+            context.WithSourceMonitoring();
+        }
+    }
+}

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
@@ -352,8 +352,13 @@ public class SourceMonitorTests
     public void WhenTwoMonitorsAreReachable_ThenGetSourceMonitorThrows()
     {
         // Arrange
-        var parent = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithLifecycle().WithSourceMonitoring();
-        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithFullPropertyTracking().WithSourceMonitoring();
+        child.WithSourceMonitoring();
         child.AddFallbackContext(parent);
 
         // Act & Assert

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceWaitResultTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceWaitResultTests.cs
@@ -327,11 +327,13 @@ public class SourceWaitResultTests
         // with every reachable monitor, making the aggregation idempotent rather than tested.
         // Varying which monitor carries the failure rules out folding to one fixed constituent, and
         // varying which settles last rules out first-to-complete and last-to-complete winning.
-        var parent = InterceptorSubjectContext.Create()
-            .WithFullPropertyTracking()
-            .WithLifecycle()
-            .WithSourceMonitoring();
-        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithFullPropertyTracking().WithSourceMonitoring();
+        child.WithSourceMonitoring();
         child.AddFallbackContext(parent);
 
         var parentMonitor = parent.GetSourceMonitor();
@@ -380,11 +382,13 @@ public class SourceWaitResultTests
         // the transient satisfaction below has been withdrawn, and it would block forever. Which
         // monitor comes first in the aggregation is an implementation detail, so both placements run:
         // whichever order holds, one of them puts the transient source second and would hang.
-        var parent = InterceptorSubjectContext.Create()
-            .WithFullPropertyTracking()
-            .WithLifecycle()
-            .WithSourceMonitoring();
-        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithFullPropertyTracking().WithSourceMonitoring();
+        child.WithSourceMonitoring();
         child.AddFallbackContext(parent);
 
         var parentMonitor = parent.GetSourceMonitor();

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceWaitTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceWaitTests.cs
@@ -242,11 +242,13 @@ public class SourceWaitTests
     public void WhenTwoMonitorsAreReachable_ThenCompleteSourceRegistrationSignalsAll()
     {
         // Arrange
-        var parent = InterceptorSubjectContext.Create()
-            .WithFullPropertyTracking()
-            .WithLifecycle()
-            .WithSourceMonitoring();
-        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithFullPropertyTracking().WithSourceMonitoring();
+        child.WithSourceMonitoring();
         child.AddFallbackContext(parent);
 
         var parentMonitor = parent.GetSourceMonitor();
@@ -264,11 +266,13 @@ public class SourceWaitTests
     public void WhenDeferWaitCompletionIsCalledWithTwoMonitors_ThenBothHoldsAreReleased()
     {
         // Arrange
-        var parent = InterceptorSubjectContext.Create()
-            .WithFullPropertyTracking()
-            .WithLifecycle()
-            .WithSourceMonitoring();
-        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithFullPropertyTracking().WithSourceMonitoring();
+        child.WithSourceMonitoring();
         child.AddFallbackContext(parent);
 
         var parentMonitor = parent.GetSourceMonitor();
@@ -782,11 +786,13 @@ public class SourceWaitTests
     public void WhenOneMonitorsReleaseThrows_ThenTheOtherMonitorIsStillReleased()
     {
         // Arrange
-        var parent = InterceptorSubjectContext.Create()
-            .WithFullPropertyTracking()
-            .WithLifecycle()
-            .WithSourceMonitoring();
-        var child = InterceptorSubjectContext.Create().WithSourceMonitoring();
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithFullPropertyTracking().WithSourceMonitoring();
+        child.WithSourceMonitoring();
         child.AddFallbackContext(parent);
 
         var parentMonitor = parent.GetSourceMonitor();
@@ -897,4 +903,3 @@ internal sealed class PoisonAnchor(IInterceptorSubjectContext context) : IInterc
     public void AddProperties(params IEnumerable<SubjectPropertyMetadata> properties) =>
         throw new NotSupportedException();
 }
-

--- a/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.WhenInterceptingDynamicSubject_ThenTheyAreCalled.verified.txt
+++ b/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.WhenInterceptingDynamicSubject_ThenTheyAreCalled.verified.txt
@@ -1,6 +1,5 @@
 ﻿[
-  a: Attached,
-  b: Attached,
+  lifecycle: Attached,
   a: Before write Speed,
   b: Before write Speed,
   b: After write Speed,
@@ -17,6 +16,5 @@
   b: Before read Temperature,
   b: After read Temperature,
   a: After read Temperature,
-  a: Detached,
-  b: Detached
+  lifecycle: Detached
 ]

--- a/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.cs
+++ b/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.cs
@@ -72,7 +72,8 @@ public class DynamicSubjectTests
         var context = InterceptorSubjectContext
             .Create()
             .WithService(() => new TestInterceptor("a", logs), _ => false)
-            .WithService(() => new TestInterceptor("b", logs), _ => false);
+            .WithService(() => new TestInterceptor("b", logs), _ => false)
+            .WithService(() => new TestLifecycleInterceptor(logs, "a", "b"), _ => false);
 
         var subject = DynamicSubjectFactory.CreateDynamicSubject(typeof(IMotor), typeof(ISensor));
         subject.Context.AddFallbackContext(context);
@@ -133,7 +134,7 @@ public class DynamicSubjectTests
         Assert.Equal(["Speed", "Temperature"], propertyNames);
     }
 
-    public class TestInterceptor : IReadInterceptor, IWriteInterceptor, ILifecycleInterceptor
+    public class TestInterceptor : IReadInterceptor, IWriteInterceptor
     {
         private readonly string _name;
         private readonly List<string> _logs;
@@ -160,14 +161,33 @@ public class DynamicSubjectTests
             _logs.Add($"{_name}: After write {context.Property.Name}");
         }
 
+    }
+
+    public class TestLifecycleInterceptor : ILifecycleInterceptor
+    {
+        private readonly List<string> _logs;
+        private readonly string[] _names;
+
+        public TestLifecycleInterceptor(List<string> logs, params string[] names)
+        {
+            _logs = logs;
+            _names = names;
+        }
+
         public void AttachSubjectToContext(IInterceptorSubject subject)
         {
-            _logs.Add($"{_name}: Attached");
+            foreach (var name in _names)
+            {
+                _logs.Add($"{name}: Attached");
+            }
         }
 
         public void DetachSubjectFromContext(IInterceptorSubject subject)
         {
-            _logs.Add($"{_name}: Detached");
+            foreach (var name in _names)
+            {
+                _logs.Add($"{name}: Detached");
+            }
         }
     }
 }

--- a/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.cs
+++ b/src/Namotion.Interceptor.Dynamic.Tests/DynamicSubjectTests.cs
@@ -73,7 +73,7 @@ public class DynamicSubjectTests
             .Create()
             .WithService(() => new TestInterceptor("a", logs), _ => false)
             .WithService(() => new TestInterceptor("b", logs), _ => false)
-            .WithService(() => new TestLifecycleInterceptor(logs, "a", "b"), _ => false);
+            .WithService(() => new TestLifecycleInterceptor("lifecycle", logs), _ => false);
 
         var subject = DynamicSubjectFactory.CreateDynamicSubject(typeof(IMotor), typeof(ISensor));
         subject.Context.AddFallbackContext(context);
@@ -166,28 +166,22 @@ public class DynamicSubjectTests
     public class TestLifecycleInterceptor : ILifecycleInterceptor
     {
         private readonly List<string> _logs;
-        private readonly string[] _names;
+        private readonly string _name;
 
-        public TestLifecycleInterceptor(List<string> logs, params string[] names)
+        public TestLifecycleInterceptor(string name, List<string> logs)
         {
             _logs = logs;
-            _names = names;
+            _name = name;
         }
 
         public void AttachSubjectToContext(IInterceptorSubject subject)
         {
-            foreach (var name in _names)
-            {
-                _logs.Add($"{name}: Attached");
-            }
+            _logs.Add($"{_name}: Attached");
         }
 
         public void DetachSubjectFromContext(IInterceptorSubject subject)
         {
-            foreach (var name in _names)
-            {
-                _logs.Add($"{name}: Detached");
-            }
+            _logs.Add($"{_name}: Detached");
         }
     }
 }

--- a/src/Namotion.Interceptor.Hosting.Tests/ContextConfigurationCompositionTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/ContextConfigurationCompositionTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+using Namotion.Interceptor.Interceptors;
+
+namespace Namotion.Interceptor.Hosting.Tests;
+
+public class ContextConfigurationCompositionTests
+{
+    [Fact]
+    public void WhenHostedServiceContextsAreConfiguredBeforeComposition_ThenResolutionThrows()
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create()
+            .WithHostedServices(new ServiceCollection());
+        var child = InterceptorSubjectContext.Create()
+            .WithHostedServices(new ServiceCollection());
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(ILifecycleInterceptor).FullName!, exception.Message);
+    }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/ContextConfigurationCompositionTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/ContextConfigurationCompositionTests.cs
@@ -8,6 +8,28 @@ namespace Namotion.Interceptor.Registry.Tests;
 public class ContextConfigurationCompositionTests
 {
     [Fact]
+    public void WhenRegistryIsConfiguredAfterCompositionWithCustomAuthorities_ThenItReusesBothAuthorities()
+    {
+        // Arrange
+        var registry = new CustomSubjectRegistry();
+        var lifecycle = new CustomLifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        parent.AddService<ISubjectRegistry>(registry);
+        parent.AddService<ILifecycleInterceptor>(lifecycle);
+        var child = InterceptorSubjectContext.Create();
+        child.AddFallbackContext(parent);
+
+        // Act
+        child.WithRegistry();
+
+        // Assert
+        Assert.Same(registry, child.GetService<ISubjectRegistry>());
+        Assert.Single(child.GetServices<ISubjectRegistry>());
+        Assert.Same(lifecycle, child.GetService<ILifecycleInterceptor>());
+        Assert.Single(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
     public void WhenRegistryContextsShareRegistryBeforeComposition_ThenLifecycleResolutionThrows()
     {
         // Arrange
@@ -47,5 +69,27 @@ public class ContextConfigurationCompositionTests
 
         // Assert
         Assert.Contains(typeof(ISubjectRegistry).FullName!, exception.Message);
+    }
+
+    private sealed class CustomSubjectRegistry : ISubjectRegistry
+    {
+        public IReadOnlyDictionary<IInterceptorSubject, RegisteredSubject> KnownSubjects { get; } =
+            new Dictionary<IInterceptorSubject, RegisteredSubject>();
+
+        public RegisteredSubject? TryGetRegisteredSubject(IInterceptorSubject subject)
+        {
+            return null;
+        }
+    }
+
+    private sealed class CustomLifecycleInterceptor : ILifecycleInterceptor
+    {
+        public void AttachSubjectToContext(IInterceptorSubject subject)
+        {
+        }
+
+        public void DetachSubjectFromContext(IInterceptorSubject subject)
+        {
+        }
     }
 }

--- a/src/Namotion.Interceptor.Registry.Tests/ContextConfigurationCompositionTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/ContextConfigurationCompositionTests.cs
@@ -1,0 +1,51 @@
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Registry.Abstractions;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Lifecycle;
+
+namespace Namotion.Interceptor.Registry.Tests;
+
+public class ContextConfigurationCompositionTests
+{
+    [Fact]
+    public void WhenRegistryContextsShareRegistryBeforeComposition_ThenLifecycleResolutionThrows()
+    {
+        // Arrange
+        var registry = new SubjectRegistry();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(registry);
+        child.AddService(registry);
+        parent.WithRegistry();
+        child.WithRegistry();
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(ILifecycleInterceptor).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void WhenRegistryContextsShareLifecycleBeforeComposition_ThenRegistryResolutionThrows()
+    {
+        // Arrange
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        child.AddService(lifecycle);
+        parent.WithRegistry();
+        child.WithRegistry();
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(ISubjectRegistry).FullName!, exception.Message);
+    }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Registry.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -12,7 +12,7 @@ namespace Namotion.Interceptor.Registry.Abstractions
     {
         void InitializeProperty(Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty property);
     }
-    public interface ISubjectRegistry
+    public interface ISubjectRegistry : Namotion.Interceptor.IUniqueContextService<Namotion.Interceptor.Registry.Abstractions.ISubjectRegistry>
     {
         System.Collections.Generic.IReadOnlyDictionary<Namotion.Interceptor.IInterceptorSubject, Namotion.Interceptor.Registry.Abstractions.RegisteredSubject> KnownSubjects { get; }
         Namotion.Interceptor.Registry.Abstractions.RegisteredSubject? TryGetRegisteredSubject(Namotion.Interceptor.IInterceptorSubject subject);
@@ -107,7 +107,7 @@ namespace Namotion.Interceptor.Registry
     [Namotion.Interceptor.Attributes.RunsBefore(new System.Type[] {
             typeof(Namotion.Interceptor.Tracking.Parent.ParentTrackingHandler),
             typeof(Namotion.Interceptor.Tracking.Lifecycle.ContextInheritanceHandler)})]
-    public class SubjectRegistry : Namotion.Interceptor.Registry.Abstractions.ISubjectIdRegistry, Namotion.Interceptor.Registry.Abstractions.ISubjectRegistry, Namotion.Interceptor.Tracking.Lifecycle.ILifecycleHandler, Namotion.Interceptor.Tracking.Lifecycle.IPropertyLifecycleHandler
+    public class SubjectRegistry : Namotion.Interceptor.IUniqueContextService<Namotion.Interceptor.Registry.Abstractions.ISubjectRegistry>, Namotion.Interceptor.Registry.Abstractions.ISubjectIdRegistry, Namotion.Interceptor.Registry.Abstractions.ISubjectRegistry, Namotion.Interceptor.Tracking.Lifecycle.ILifecycleHandler, Namotion.Interceptor.Tracking.Lifecycle.IPropertyLifecycleHandler
     {
         public SubjectRegistry() { }
         public System.Collections.Generic.IReadOnlyDictionary<Namotion.Interceptor.IInterceptorSubject, Namotion.Interceptor.Registry.Abstractions.RegisteredSubject> KnownSubjects { get; }

--- a/src/Namotion.Interceptor.Registry/Abstractions/ISubjectRegistry.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/ISubjectRegistry.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A registry which tracks subjects and their child subjects, property attributes and additional metadata.
 /// </summary>
-public interface ISubjectRegistry
+public interface ISubjectRegistry : IUniqueContextService<ISubjectRegistry>
 {
     /// <summary>
     /// Gets all known registered subjects.

--- a/src/Namotion.Interceptor.Registry/InterceptorSubjectContextExtensions.cs
+++ b/src/Namotion.Interceptor.Registry/InterceptorSubjectContextExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Namotion.Interceptor.Tracking;
 
+using Namotion.Interceptor.Registry.Abstractions;
+
 namespace Namotion.Interceptor.Registry;
 
 public static class InterceptorSubjectContextExtensions
@@ -12,7 +14,7 @@ public static class InterceptorSubjectContextExtensions
     public static IInterceptorSubjectContext WithRegistry(this IInterceptorSubjectContext context)
     {
         context
-            .TryAddService(() => new SubjectRegistry(), _ => true);
+            .TryAddService<ISubjectRegistry>(() => new SubjectRegistry(), _ => true);
 
         return context
             .WithContextInheritance();

--- a/src/Namotion.Interceptor.Tests/Context/UniqueContextServiceTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/UniqueContextServiceTests.cs
@@ -165,7 +165,26 @@ public class UniqueContextServiceTests
     }
 
     [Fact]
-    public async Task WhenFailedValidationRacesWithRemovingTheConflict_ThenTheRepairedStateSucceeds()
+    public void WhenAValidatedRootSeesAReachableDescendantGainAConflictingAuthority_ThenTheNextQueryThrows()
+    {
+        // Arrange
+        var descendant = InterceptorSubjectContext.Create();
+        descendant.AddService(new UniqueAlpha("first"));
+        var root = InterceptorSubjectContext.Create();
+        root.AddFallbackContext(descendant);
+        _ = root.GetServices<object>();
+
+        // Act
+        descendant.AddService(new UniqueAlpha("second"));
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => root.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(IUniqueAlpha).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public async Task WhenOldConflictingStateIsValidatedWhileRemovalPublishesARepairedState_ThenOnlyTheRepairedStateSucceeds()
     {
         // Arrange
         var first = InterceptorSubjectContext.Create();

--- a/src/Namotion.Interceptor.Tests/Context/UniqueContextServiceTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/UniqueContextServiceTests.cs
@@ -171,6 +171,8 @@ public class UniqueContextServiceTests
         var descendant = InterceptorSubjectContext.Create();
         descendant.AddService(new UniqueAlpha("first"));
         var root = InterceptorSubjectContext.Create();
+        // Keep validation on the root's own state so this detects removal of upstream-state invalidation.
+        root.AddService("root");
         root.AddFallbackContext(descendant);
         _ = root.GetServices<object>();
 

--- a/src/Namotion.Interceptor.Tests/Context/UniqueContextServiceTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/UniqueContextServiceTests.cs
@@ -1,0 +1,244 @@
+using System.Reflection;
+
+using static Namotion.Interceptor.Tests.Context.ContextStateReflection;
+
+namespace Namotion.Interceptor.Tests.Context;
+
+public class UniqueContextServiceTests
+{
+    private static readonly MethodInfo GetServicesFromStateMethod = typeof(InterceptorSubjectContext)
+        .GetMethod("GetServicesFromState", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException(
+            "InterceptorSubjectContext.GetServicesFromState was renamed, the context tests need updating.");
+
+    [Fact]
+    public void WhenNoUniqueServicesAreReachable_ThenOrderedServicesResolveNormally()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create();
+        context.AddService("first");
+        context.AddService("second");
+
+        // Act
+        var services = context.GetServices<string>();
+
+        // Assert
+        Assert.Equal(["first", "second"], services.ToArray());
+    }
+
+    [Fact]
+    public void WhenOneUniqueServiceIsReachable_ThenItResolvesNormally()
+    {
+        // Arrange
+        var service = new UniqueAlpha("only");
+        var context = InterceptorSubjectContext.Create();
+        context.AddService(service);
+
+        // Act
+        var services = context.GetServices<UniqueAlpha>();
+
+        // Assert
+        Assert.Same(service, Assert.Single(services));
+    }
+
+    [Fact]
+    public void WhenTwoDistinctUniqueServicesAreReachable_ThenAnUnrelatedQueryThrows()
+    {
+        // Arrange
+        var first = InterceptorSubjectContext.Create();
+        first.AddService(new UniqueAlpha("first"));
+        var second = InterceptorSubjectContext.Create();
+        second.AddService(new UniqueAlpha("second"));
+        var root = InterceptorSubjectContext.Create();
+        root.AddFallbackContext(first);
+        root.AddFallbackContext(second);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => root.GetServices<string>());
+
+        // Assert
+        Assert.Contains(typeof(IUniqueAlpha).FullName!, exception.Message);
+        Assert.Contains(typeof(UniqueAlpha).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void WhenDistinctUniqueServicesCompareEqual_ThenReferenceIdentityStillConflicts()
+    {
+        // Arrange
+        var first = new UniqueAlpha("first");
+        var second = new UniqueAlpha("second");
+        var root = InterceptorSubjectContext.Create();
+        root.AddService(first);
+        root.AddService(second);
+
+        // Act
+        var areEqual = first.Equals(second);
+        var exception = Record.Exception(() => root.GetServices<UniqueAlpha>());
+
+        // Assert
+        Assert.True(areEqual);
+        Assert.IsType<InvalidOperationException>(exception);
+    }
+
+    [Fact]
+    public void WhenAnUnrelatedUniqueAuthorityConflicts_ThenTryGetServiceThrows()
+    {
+        // Arrange
+        var root = InterceptorSubjectContext.Create();
+        root.AddService(new UniqueAlpha("first"));
+        root.AddService(new UniqueAlpha("second"));
+        root.AddService("unrelated");
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => root.TryGetService<string>());
+
+        // Assert
+        Assert.Contains(typeof(IUniqueAlpha).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void WhenTheSameUniqueInstanceIsReachedThroughADiamond_ThenItResolvesOnce()
+    {
+        // Arrange
+        var sharedService = new UniqueAlpha("shared");
+        var shared = InterceptorSubjectContext.Create();
+        shared.AddService(sharedService);
+        var left = InterceptorSubjectContext.Create();
+        left.AddFallbackContext(shared);
+        var right = InterceptorSubjectContext.Create();
+        right.AddFallbackContext(shared);
+        var root = InterceptorSubjectContext.Create();
+        root.AddFallbackContext(left);
+        root.AddFallbackContext(right);
+
+        // Act
+        var services = root.GetServices<UniqueAlpha>();
+
+        // Assert
+        Assert.Single(services);
+        Assert.Same(sharedService, services[0]);
+    }
+
+    [Fact]
+    public void WhenOneServiceImplementsTwoUniqueContracts_ThenBothContractsAreConstrained()
+    {
+        // Arrange
+        var alphaRoot = InterceptorSubjectContext.Create();
+        alphaRoot.AddService(new UniqueAlphaAndBeta());
+        alphaRoot.AddService(new UniqueAlpha("alpha"));
+
+        var betaRoot = InterceptorSubjectContext.Create();
+        betaRoot.AddService(new UniqueAlphaAndBeta());
+        betaRoot.AddService(new UniqueBeta());
+
+        // Act
+        var alphaException = Assert.Throws<InvalidOperationException>(
+            () => alphaRoot.GetServices<object>());
+        var betaException = Assert.Throws<InvalidOperationException>(
+            () => betaRoot.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(IUniqueAlpha).FullName!, alphaException.Message);
+        Assert.Contains(typeof(IUniqueBeta).FullName!, betaException.Message);
+    }
+
+    [Fact]
+    public void WhenAValidatedTopologyGainsAConflictingService_ThenTheNextQueryThrows()
+    {
+        // Arrange
+        var root = InterceptorSubjectContext.Create();
+        root.AddService(new UniqueAlpha("first"));
+        _ = root.GetServices<object>();
+
+        var conflicting = InterceptorSubjectContext.Create();
+        conflicting.AddService(new UniqueAlpha("second"));
+
+        // Act
+        root.AddFallbackContext(conflicting);
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => root.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(IUniqueAlpha).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public async Task WhenFailedValidationRacesWithRemovingTheConflict_ThenTheRepairedStateSucceeds()
+    {
+        // Arrange
+        var first = InterceptorSubjectContext.Create();
+        first.AddService(new UniqueAlpha("first"));
+        var conflicting = InterceptorSubjectContext.Create();
+        conflicting.AddService(new UniqueAlpha("second"));
+        var root = InterceptorSubjectContext.Create();
+        root.AddFallbackContext(first);
+        root.AddFallbackContext(conflicting);
+
+        var conflictingState = GetState(root);
+        using var start = new Barrier(2);
+        Exception? validationException = null;
+        object? repairedState = null;
+
+        var failedValidation = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            validationException = Assert.Throws<TargetInvocationException>(
+                () => GetServicesFromStateMethod
+                    .MakeGenericMethod(typeof(string))
+                    .Invoke(root, [conflictingState]));
+        }, TaskCreationOptions.LongRunning);
+
+        var repair = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            Assert.True(root.RemoveFallbackContext(conflicting));
+            repairedState = GetState(root);
+            _ = GetServicesFromStateMethod
+                .MakeGenericMethod(typeof(string))
+                .Invoke(root, [repairedState]);
+        }, TaskCreationOptions.LongRunning);
+
+        // Act
+        await Task.WhenAll(failedValidation, repair).WaitAsync(TimeSpan.FromSeconds(15));
+        var services = GetServicesFromStateMethod
+            .MakeGenericMethod(typeof(UniqueAlpha))
+            .Invoke(root, [repairedState!]);
+
+        // Assert
+        var exception = Assert.IsType<InvalidOperationException>(validationException!.InnerException);
+        Assert.Contains(typeof(IUniqueAlpha).FullName!, exception.Message);
+        Assert.NotSame(conflictingState, repairedState);
+        var service = Assert.IsType<System.Collections.Immutable.ImmutableArray<UniqueAlpha>>(services);
+        Assert.Single(service);
+    }
+
+    private interface IUniqueAlpha
+    {
+    }
+
+    private interface IUniqueBeta
+    {
+    }
+
+    private sealed class UniqueAlpha(string name) :
+        IUniqueContextService<IUniqueAlpha>
+    {
+        public override bool Equals(object? obj) => obj is UniqueAlpha;
+
+        public override int GetHashCode() => 0;
+
+        public override string ToString() => name;
+    }
+
+    private sealed class UniqueBeta : IUniqueContextService<IUniqueBeta>
+    {
+    }
+
+    private sealed class UniqueAlphaAndBeta :
+        IUniqueContextService<IUniqueAlpha>,
+        IUniqueContextService<IUniqueBeta>
+    {
+    }
+}

--- a/src/Namotion.Interceptor.Tests/InterceptorTests.WhenAddingAndRemovingContext_ThenInterceptorsAreCalledInTheRightOrder.verified.txt
+++ b/src/Namotion.Interceptor.Tests/InterceptorTests.WhenAddingAndRemovingContext_ThenInterceptorsAreCalledInTheRightOrder.verified.txt
@@ -1,6 +1,4 @@
 ﻿[
-  a: Attached,
-  b: Attached,
-  a: Detached,
-  b: Detached
+  lifecycle: Attached,
+  lifecycle: Detached
 ]

--- a/src/Namotion.Interceptor.Tests/InterceptorTests.cs
+++ b/src/Namotion.Interceptor.Tests/InterceptorTests.cs
@@ -93,8 +93,7 @@ public class InterceptorTests
         
         var context = InterceptorSubjectContext
             .Create()
-            .WithService(() => new TestLifecycleInterceptor("a", logs), _ => false)
-            .WithService(() => new TestLifecycleInterceptor("b", logs), _ => false);
+            .WithService(() => new TestLifecycleInterceptor(logs, "a", "b"), _ => false);
         
         // Act
         var car = new Car(context);
@@ -106,23 +105,29 @@ public class InterceptorTests
 
     public class TestLifecycleInterceptor : ILifecycleInterceptor
     {
-        private readonly string _name;
+        private readonly string[] _names;
         private readonly List<string> _logs;
 
-        public TestLifecycleInterceptor(string name, List<string> logs)
+        public TestLifecycleInterceptor(List<string> logs, params string[] names)
         {
-            _name = name;
+            _names = names;
             _logs = logs;
         }
 
         public void AttachSubjectToContext(IInterceptorSubject subject)
         {
-            _logs.Add($"{_name}: Attached");
+            foreach (var name in _names)
+            {
+                _logs.Add($"{name}: Attached");
+            }
         }
 
         public void DetachSubjectFromContext(IInterceptorSubject subject)
         {
-            _logs.Add($"{_name}: Detached");
+            foreach (var name in _names)
+            {
+                _logs.Add($"{name}: Detached");
+            }
         }
     }
     

--- a/src/Namotion.Interceptor.Tests/InterceptorTests.cs
+++ b/src/Namotion.Interceptor.Tests/InterceptorTests.cs
@@ -93,7 +93,7 @@ public class InterceptorTests
         
         var context = InterceptorSubjectContext
             .Create()
-            .WithService(() => new TestLifecycleInterceptor(logs, "a", "b"), _ => false);
+            .WithService(() => new TestLifecycleInterceptor("lifecycle", logs), _ => false);
         
         // Act
         var car = new Car(context);
@@ -105,29 +105,23 @@ public class InterceptorTests
 
     public class TestLifecycleInterceptor : ILifecycleInterceptor
     {
-        private readonly string[] _names;
+        private readonly string _name;
         private readonly List<string> _logs;
 
-        public TestLifecycleInterceptor(List<string> logs, params string[] names)
+        public TestLifecycleInterceptor(string name, List<string> logs)
         {
-            _names = names;
+            _name = name;
             _logs = logs;
         }
 
         public void AttachSubjectToContext(IInterceptorSubject subject)
         {
-            foreach (var name in _names)
-            {
-                _logs.Add($"{name}: Attached");
-            }
+            _logs.Add($"{_name}: Attached");
         }
 
         public void DetachSubjectFromContext(IInterceptorSubject subject)
         {
-            foreach (var name in _names)
-            {
-                _logs.Add($"{name}: Detached");
-            }
+            _logs.Add($"{_name}: Detached");
         }
     }
     

--- a/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -79,6 +79,7 @@ namespace Namotion.Interceptor
     {
         void RaisePropertyChanged(string propertyName);
     }
+    public interface IUniqueContextService<TContract> { }
     public class InterceptorSubjectContext : Namotion.Interceptor.IInterceptorSubjectContext
     {
         public virtual bool AddFallbackContext(Namotion.Interceptor.IInterceptorSubjectContext context) { }

--- a/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -180,7 +180,7 @@ namespace Namotion.Interceptor.Interceptors
         object? InvokeMethod(string methodName, object?[] parameters, System.Func<Namotion.Interceptor.IInterceptorSubject, object?[], object?> invokeMethod);
         bool SetPropertyValue<TProperty>(string propertyName, TProperty newValue, TProperty currentValue, System.Action<Namotion.Interceptor.IInterceptorSubject, TProperty> writeValue);
     }
-    public interface ILifecycleInterceptor
+    public interface ILifecycleInterceptor : Namotion.Interceptor.IUniqueContextService<Namotion.Interceptor.Interceptors.ILifecycleInterceptor>
     {
         void AttachSubjectToContext(Namotion.Interceptor.IInterceptorSubject subject);
         void DetachSubjectFromContext(Namotion.Interceptor.IInterceptorSubject subject);

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs
@@ -137,7 +137,8 @@ public class PerPropertySubscriptionLifecycleTests
         // the target-side [RunsAfter] ordering (PropertyChangeInterceptor after SubjectTransactionInterceptor):
         // staged writes stay silent during capture and replay once at commit. The aggregated counterpart is
         // WhenAggregatedWithSingleTransactionContext...; only the symmetric aggregation (both contexts
-        // .WithTransactions()) is inexpressible, because capture's TryGetService<SubjectTransactionInterceptor>
+        // .WithTransactions()) is inexpressible only when both contexts independently configure
+        // transaction authorities, because capture's TryGetService<SubjectTransactionInterceptor>
         // throws when two aggregated contexts each contribute one.
         var context = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithTransactions();
         var person = new Person(context);
@@ -163,9 +164,9 @@ public class PerPropertySubscriptionLifecycleTests
     [Fact]
     public async Task WhenAggregatedWithSingleTransactionContext_ThenStagedWritesStaySilentAndDeliverOnceAtCommit()
     {
-        // Arrange: an ASYMMETRIC aggregation. A symmetric one (both contexts .WithTransactions()) cannot be
-        // expressed because capture resolves the interceptor via TryGetService, which throws when two
-        // aggregated contexts each contribute a SubjectTransactionInterceptor. Here only the parent fallback
+        // Arrange: an ASYMMETRIC aggregation. An aggregation where both contexts independently configure
+        // transactions cannot be expressed because capture resolves the interceptor via TryGetService, which
+        // throws when two aggregated contexts each contribute a SubjectTransactionInterceptor. Here only the parent fallback
         // adds transactions, so SubjectTransactionInterceptor resolves to exactly one instance while
         // PropertyChangeInterceptor aggregates to two (one per context). This pins the target-side
         // [RunsAfter] ordering across aggregated change interceptors: neither aggregated instance leaks a

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs
@@ -2,6 +2,7 @@ using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Lifecycle;
 using Namotion.Interceptor.Tracking.Transactions;
 using Namotion.Interceptor.Tracking.Tests.Models;
 
@@ -109,9 +110,14 @@ public class PerPropertySubscriptionLifecycleTests
     [Fact]
     public void WhenTwoAggregatedInterceptors_ThenListenerDeliversExactlyOnce()
     {
-        // Arrange: a subject whose context aggregates two full-tracking contexts.
-        var parent = InterceptorSubjectContext.Create().WithFullPropertyTracking();
-        var childCtx = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        // Arrange: a subject whose context aggregates two property-change interceptors under one lifecycle.
+        var lifecycle = new LifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        var childCtx = InterceptorSubjectContext.Create();
+        parent.AddService(lifecycle);
+        childCtx.AddService(lifecycle);
+        parent.WithFullPropertyTracking();
+        childCtx.WithFullPropertyTracking();
         childCtx.AddFallbackContext(parent);
         var person = new Person(childCtx);
         var hits = 0;
@@ -164,8 +170,13 @@ public class PerPropertySubscriptionLifecycleTests
         // PropertyChangeInterceptor aggregates to two (one per context). This pins the target-side
         // [RunsAfter] ordering across aggregated change interceptors: neither aggregated instance leaks a
         // staged write to a per-property listener during capture, and commit replay delivers exactly once.
-        var child = InterceptorSubjectContext.Create().WithFullPropertyTracking();
-        var parent = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithTransactions();
+        var lifecycle = new LifecycleInterceptor();
+        var child = InterceptorSubjectContext.Create();
+        var parent = InterceptorSubjectContext.Create();
+        child.AddService(lifecycle);
+        parent.AddService(lifecycle);
+        child.WithFullPropertyTracking();
+        parent.WithFullPropertyTracking().WithTransactions();
         child.AddFallbackContext(parent);
         var person = new Person(child);
         var hits = 0;
@@ -448,10 +459,15 @@ public class PerPropertySubscriptionLifecycleTests
     [Fact]
     public void WhenAggregatedContextsAssignSubject_ThenNewChildIsAttachedAtCallbackTime()
     {
-        // Arrange: the ordering edge must bind to every LifecycleInterceptor instance, not just
-        // one, when a context aggregates a fallback context that also registers tracking.
-        var parentContext = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithRegistry();
-        var childContext = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        // Arrange: the ordering edge must bind the aggregated change interceptors to the shared
+        // lifecycle authority when a fallback context also registers tracking.
+        var lifecycle = new LifecycleInterceptor();
+        var parentContext = InterceptorSubjectContext.Create();
+        var childContext = InterceptorSubjectContext.Create();
+        parentContext.AddService(lifecycle);
+        childContext.AddService(lifecycle);
+        parentContext.WithFullPropertyTracking().WithRegistry();
+        childContext.WithFullPropertyTracking();
         childContext.AddFallbackContext(parentContext);
         var root = new Person(childContext);
         var child = new Person();

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/WritePipelineOrderTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/WritePipelineOrderTests.cs
@@ -57,10 +57,15 @@ public class WritePipelineOrderTests
     [Fact]
     public void WhenContextsAreAggregated_ThenEveryChangeInterceptorPrecedesEveryLifecycleInterceptor()
     {
-        // Arrange: each context contributes its own instances, so the ordering edges must bind to
-        // every instance of the referenced type rather than just one.
-        var parentContext = InterceptorSubjectContext.Create().WithFullPropertyTracking();
-        var childContext = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+        // Arrange: each context contributes its own non-unique interceptors under one shared
+        // lifecycle authority, so ordering edges must bind across the complete resolved cone.
+        var lifecycle = new LifecycleInterceptor();
+        var parentContext = InterceptorSubjectContext.Create();
+        var childContext = InterceptorSubjectContext.Create();
+        parentContext.AddService(lifecycle);
+        childContext.AddService(lifecycle);
+        parentContext.WithFullPropertyTracking();
+        childContext.WithFullPropertyTracking();
         childContext.AddFallbackContext(parentContext);
 
         // Act
@@ -77,7 +82,6 @@ public class WritePipelineOrderTests
                 typeof(DerivedPropertyChangeHandler),
                 typeof(PropertyChangeInterceptor),
                 typeof(PropertyChangeInterceptor),
-                typeof(LifecycleInterceptor),
                 typeof(LifecycleInterceptor)
             ],
             chain);

--- a/src/Namotion.Interceptor.Tracking.Tests/Lifecycle/ContextConfigurationCompositionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Lifecycle/ContextConfigurationCompositionTests.cs
@@ -1,0 +1,143 @@
+using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Tracking.Lifecycle;
+using Namotion.Interceptor.Tracking.Parent;
+using Namotion.Interceptor.Tracking.Transactions;
+using Namotion.Interceptor.Validation;
+
+namespace Namotion.Interceptor.Tracking.Tests.Lifecycle;
+
+public class ContextConfigurationCompositionTests
+{
+    public enum LifecycleConfiguration
+    {
+        Lifecycle,
+        DerivedPropertyChangeDetection,
+        ContextInheritance,
+        Parents,
+        FullPropertyTracking
+    }
+
+    public enum NonUniqueConfiguration
+    {
+        EqualityCheck,
+        ReadPropertyRecorder,
+        PropertyChangeSubscriptions,
+        PropertyValidation,
+        DataAnnotationValidation
+    }
+
+    [Theory]
+    [InlineData(LifecycleConfiguration.Lifecycle)]
+    [InlineData(LifecycleConfiguration.DerivedPropertyChangeDetection)]
+    [InlineData(LifecycleConfiguration.ContextInheritance)]
+    [InlineData(LifecycleConfiguration.Parents)]
+    [InlineData(LifecycleConfiguration.FullPropertyTracking)]
+    public void WhenLifecycleEstablishingContextsAreConfiguredBeforeComposition_ThenResolutionThrows(
+        LifecycleConfiguration configuration)
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        Configure(parent, configuration);
+        Configure(child, configuration);
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(ILifecycleInterceptor).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public void WhenContextsAreComposedBeforeLifecycleConfiguration_ThenTheyShareOneAuthority()
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create().WithLifecycle();
+        var child = InterceptorSubjectContext.Create();
+        child.AddFallbackContext(parent);
+
+        // Act
+        child.WithParents();
+
+        // Assert
+        Assert.Same(
+            parent.GetService<ILifecycleInterceptor>(),
+            child.GetService<ILifecycleInterceptor>());
+        Assert.Single(child.GetServices<ILifecycleInterceptor>());
+        Assert.Single(child.GetServices<ParentTrackingHandler>());
+    }
+
+    [Fact]
+    public void WhenTransactionContextsAreConfiguredBeforeComposition_ThenResolutionThrows()
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create().WithTransactions();
+        var child = InterceptorSubjectContext.Create().WithTransactions();
+        child.AddFallbackContext(parent);
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => child.GetServices<object>());
+
+        // Assert
+        Assert.Contains(typeof(SubjectTransactionInterceptor).FullName!, exception.Message);
+    }
+
+    [Theory]
+    [InlineData(NonUniqueConfiguration.EqualityCheck, 2)]
+    [InlineData(NonUniqueConfiguration.ReadPropertyRecorder, 2)]
+    [InlineData(NonUniqueConfiguration.PropertyChangeSubscriptions, 2)]
+    [InlineData(NonUniqueConfiguration.PropertyValidation, 2)]
+    [InlineData(NonUniqueConfiguration.DataAnnotationValidation, 4)]
+    public void WhenNonUniqueServiceContextsAreConfiguredBeforeComposition_ThenAllServicesResolve(
+        NonUniqueConfiguration configuration,
+        int expectedServiceCount)
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create();
+        var child = InterceptorSubjectContext.Create();
+        Configure(parent, configuration);
+        Configure(child, configuration);
+        child.AddFallbackContext(parent);
+
+        // Act
+        var services = child.GetServices<object>();
+
+        // Assert
+        Assert.Equal(expectedServiceCount, services.Length);
+    }
+
+    private static void Configure(
+        IInterceptorSubjectContext context,
+        LifecycleConfiguration configuration)
+    {
+        _ = configuration switch
+        {
+            LifecycleConfiguration.Lifecycle => context.WithLifecycle(),
+            LifecycleConfiguration.DerivedPropertyChangeDetection =>
+                context.WithDerivedPropertyChangeDetection(),
+            LifecycleConfiguration.ContextInheritance => context.WithContextInheritance(),
+            LifecycleConfiguration.Parents => context.WithParents(),
+            LifecycleConfiguration.FullPropertyTracking => context.WithFullPropertyTracking(),
+            _ => throw new ArgumentOutOfRangeException(nameof(configuration))
+        };
+    }
+
+    private static void Configure(
+        IInterceptorSubjectContext context,
+        NonUniqueConfiguration configuration)
+    {
+        _ = configuration switch
+        {
+            NonUniqueConfiguration.EqualityCheck => context.WithEqualityCheck(),
+            NonUniqueConfiguration.ReadPropertyRecorder => context.WithReadPropertyRecorder(),
+            NonUniqueConfiguration.PropertyChangeSubscriptions =>
+                context.WithPropertyChangeSubscriptions(),
+            NonUniqueConfiguration.PropertyValidation => context.WithPropertyValidation(),
+            NonUniqueConfiguration.DataAnnotationValidation => context.WithDataAnnotationValidation(),
+            _ => throw new ArgumentOutOfRangeException(nameof(configuration))
+        };
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Lifecycle/ContextConfigurationCompositionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Lifecycle/ContextConfigurationCompositionTests.cs
@@ -1,6 +1,7 @@
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Tracking.Lifecycle;
 using Namotion.Interceptor.Tracking.Parent;
+using Namotion.Interceptor.Tracking.Tests.Models;
 using Namotion.Interceptor.Tracking.Transactions;
 using Namotion.Interceptor.Validation;
 
@@ -70,6 +71,24 @@ public class ContextConfigurationCompositionTests
     }
 
     [Fact]
+    public void WhenLifecycleIsConfiguredAfterCompositionWithACustomAuthority_ThenItReusesThatAuthority()
+    {
+        // Arrange
+        var lifecycle = new CustomLifecycleInterceptor();
+        var parent = InterceptorSubjectContext.Create();
+        parent.AddService<ILifecycleInterceptor>(lifecycle);
+        var child = InterceptorSubjectContext.Create();
+        child.AddFallbackContext(parent);
+
+        // Act
+        child.WithLifecycle();
+
+        // Assert
+        Assert.Same(lifecycle, child.GetService<ILifecycleInterceptor>());
+        Assert.Single(child.GetServices<ILifecycleInterceptor>());
+    }
+
+    [Fact]
     public void WhenTransactionContextsAreConfiguredBeforeComposition_ThenResolutionThrows()
     {
         // Arrange
@@ -83,6 +102,34 @@ public class ContextConfigurationCompositionTests
 
         // Assert
         Assert.Contains(typeof(SubjectTransactionInterceptor).FullName!, exception.Message);
+    }
+
+    [Fact]
+    public async Task WhenTransactionsAreConfiguredAfterComposition_ThenTheyReuseTheCoordinatorAndCommit()
+    {
+        // Arrange
+        var parent = InterceptorSubjectContext.Create().WithTransactions();
+        var child = InterceptorSubjectContext.Create();
+        child.AddFallbackContext(parent);
+        child.WithTransactions();
+        var person = new Person(child);
+
+        // Act
+        using (var transaction = await child.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            person.FirstName = "John";
+
+            // Assert
+            Assert.Same(
+                parent.GetService<SubjectTransactionInterceptor>(),
+                child.GetService<SubjectTransactionInterceptor>());
+            Assert.Single(transaction.GetPendingChanges());
+
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        Assert.Equal("John", person.FirstName);
     }
 
     [Theory]
@@ -139,5 +186,16 @@ public class ContextConfigurationCompositionTests
             NonUniqueConfiguration.DataAnnotationValidation => context.WithDataAnnotationValidation(),
             _ => throw new ArgumentOutOfRangeException(nameof(configuration))
         };
+    }
+
+    private sealed class CustomLifecycleInterceptor : ILifecycleInterceptor
+    {
+        public void AttachSubjectToContext(IInterceptorSubject subject)
+        {
+        }
+
+        public void DetachSubjectFromContext(IInterceptorSubject subject)
+        {
+        }
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -84,32 +84,27 @@ public class SubjectTransactionTests
     }
 
     [Fact]
-    public async Task WhenTheBoundTransactionInterceptorIsInheritedAndSecond_ThenTheWriteIsCapturedInsteadOfThrowing()
+    public async Task WhenTwoTransactionInterceptorsResolveForAWrite_ThenItFailsBeforeTheSetterRuns()
     {
-        // Arrange: context inheritance adds another context as a fallback on attach, so a subject built on
-        // one transaction-enabled context and attached into a graph rooted on another resolves two. The
-        // subject's own interceptor is first and the fallback's interceptor is second, so binding must scan
-        // all resolved instances by reference rather than accepting only the first one.
-        var context = CreateTransactionContext();
-        var fallbackContext = CreateTransactionContext();
+        // Arrange
+        var subjectContext = InterceptorSubjectContext.Create().WithTransactions();
+        var transactionContext = InterceptorSubjectContext.Create().WithTransactions();
+        var person = new Person(subjectContext);
+        ((IInterceptorSubject)person).Context.AddFallbackContext(transactionContext);
 
-        var person = new Person(context);
-        ((IInterceptorSubject)person).Context.AddFallbackContext(fallbackContext);
+        using var transaction = await transactionContext.BeginTransactionAsync(
+            TransactionFailureHandling.BestEffort);
 
         // Act
-        using (var transaction = await fallbackContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
-        {
-            person.FirstName = "John";
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => person.FirstName = "John");
 
-            // Assert: captured rather than written straight through, so the binding resolved to this
-            // context. Reading the property here would serve the pending value either way.
-            Assert.Single(transaction.GetPendingChanges(),
-                change => change.Property.Name == nameof(Person.FirstName));
+        ((IInterceptorSubject)person).Context.RemoveFallbackContext(transactionContext);
 
-            await transaction.CommitAsync(CancellationToken.None);
-        }
-
-        Assert.Equal("John", person.FirstName);
+        // Assert
+        Assert.Contains(typeof(SubjectTransactionInterceptor).FullName!, exception.Message);
+        Assert.Empty(transaction.GetPendingChanges());
+        Assert.Null(person.FirstName);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -165,7 +165,7 @@ namespace Namotion.Interceptor.Tracking.Lifecycle
         void DetachProperty(Namotion.Interceptor.Tracking.Lifecycle.SubjectPropertyLifecycleChange change);
         void RefreshCollectionProperty(Namotion.Interceptor.PropertyReference property, object? value);
     }
-    public class LifecycleInterceptor : Namotion.Interceptor.Interceptors.ILifecycleInterceptor, Namotion.Interceptor.Interceptors.IWriteInterceptor
+    public class LifecycleInterceptor : Namotion.Interceptor.IUniqueContextService<Namotion.Interceptor.Interceptors.ILifecycleInterceptor>, Namotion.Interceptor.Interceptors.ILifecycleInterceptor, Namotion.Interceptor.Interceptors.IWriteInterceptor
     {
         public LifecycleInterceptor() { }
         public event System.Action<Namotion.Interceptor.Tracking.Lifecycle.SubjectLifecycleChange>? SubjectAttached;
@@ -297,7 +297,7 @@ namespace Namotion.Interceptor.Tracking.Transactions
     }
     [Namotion.Interceptor.Attributes.RunsBefore(new System.Type[] {
             typeof(Namotion.Interceptor.Tracking.Change.DerivedPropertyChangeHandler)})]
-    public sealed class SubjectTransactionInterceptor : Namotion.Interceptor.Interceptors.IReadInterceptor, Namotion.Interceptor.Interceptors.IWriteInterceptor
+    public sealed class SubjectTransactionInterceptor : Namotion.Interceptor.IUniqueContextService<Namotion.Interceptor.Tracking.Transactions.SubjectTransactionInterceptor>, Namotion.Interceptor.Interceptors.IReadInterceptor, Namotion.Interceptor.Interceptors.IWriteInterceptor
     {
         public SubjectTransactionInterceptor() { }
         public TProperty ReadProperty<TProperty>(ref Namotion.Interceptor.Interceptors.PropertyReadContext<TProperty> context, Namotion.Interceptor.Interceptors.ReadInterceptionDelegate<TProperty> next) { }

--- a/src/Namotion.Interceptor.Tracking/InterceptorSubjectContextExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/InterceptorSubjectContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Lifecycle;
 using Namotion.Interceptor.Tracking.Parent;
@@ -159,8 +160,8 @@ public static class InterceptorSubjectContextExtensions
     /// <returns>The collection.</returns>
     public static IInterceptorSubjectContext WithLifecycle(this IInterceptorSubjectContext context)
     {
-        return context
-            .WithService(() => new LifecycleInterceptor());
+        context.TryAddService<ILifecycleInterceptor>(() => new LifecycleInterceptor(), _ => true);
+        return context;
     }
     
     /// <summary>

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransactionInterceptor.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Interceptors;
@@ -12,7 +11,10 @@ namespace Namotion.Interceptor.Tracking.Transactions;
 /// Also manages the per-context transaction lock for serialized transactions.
 /// </summary>
 [RunsBefore(typeof(DerivedPropertyChangeHandler))]
-public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInterceptor
+public sealed class SubjectTransactionInterceptor :
+    IReadInterceptor,
+    IWriteInterceptor,
+    IUniqueContextService<SubjectTransactionInterceptor>
 {
     private readonly SemaphoreSlim _exclusiveTransactionLock = new(1, 1);
 
@@ -109,13 +111,10 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
             return;
         }
 
-        var subjectInterceptors = context.Property.Subject.Context
-            .GetServices<SubjectTransactionInterceptor>();
-        var isBoundToThisContext = subjectInterceptors.Length == 1
-            ? ReferenceEquals(subjectInterceptors[0], transaction.Interceptor)
-            : ContainsByReference(subjectInterceptors, transaction.Interceptor);
+        var subjectInterceptor = context.Property.Subject.Context
+            .TryGetService<SubjectTransactionInterceptor>();
 
-        if (!isBoundToThisContext)
+        if (!ReferenceEquals(subjectInterceptor, transaction.Interceptor))
         {
             throw new InvalidOperationException(
                 $"Cannot modify property '{context.Property.Metadata.Name}': Transaction is bound to a different context.");
@@ -138,22 +137,6 @@ public sealed class SubjectTransactionInterceptor : IReadInterceptor, IWriteInte
         }
 
         next(ref context);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static bool ContainsByReference(
-        ImmutableArray<SubjectTransactionInterceptor> interceptors,
-        SubjectTransactionInterceptor target)
-    {
-        for (var index = 0; index < interceptors.Length; index++)
-        {
-            if (ReferenceEquals(interceptors[index], target))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private sealed class LockReleaser(SemaphoreSlim semaphore) : IDisposable

--- a/src/Namotion.Interceptor/IInterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/IInterceptorSubjectContext.cs
@@ -39,8 +39,15 @@ public interface IInterceptorSubjectContext
     /// <summary>
     /// Retrieves a service of the specified type, or null if not registered.
     /// </summary>
+    /// <remarks>
+    /// The <c>Try</c> prefix describes the zero-service result only; it is not a no-throw guarantee.
+    /// </remarks>
     /// <typeparam name="TInterface">The type of service to retrieve.</typeparam>
     /// <returns>The service instance, or null if not found.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The requested singular service has several matches, the delegation chain is cyclic, or an
+    /// unrelated unique authority in the resolved context cone has several distinct instances.
+    /// </exception>
     TInterface? TryGetService<TInterface>();
 
     /// <summary>
@@ -56,7 +63,10 @@ public interface IInterceptorSubjectContext
     /// </remarks>
     /// <typeparam name="TInterface">The type of services to retrieve.</typeparam>
     /// <returns>An immutable array of all matching services.</returns>
-    /// <exception cref="InvalidOperationException">The fallback contexts form a delegation cycle.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The delegation chain is cyclic, or a unique authority in the resolved context cone has
+    /// several distinct instances, including an authority unrelated to <typeparamref name="TInterface"/>.
+    /// </exception>
     ImmutableArray<TInterface> GetServices<TInterface>();
 
     /// <summary>

--- a/src/Namotion.Interceptor/IUniqueContextService.cs
+++ b/src/Namotion.Interceptor/IUniqueContextService.cs
@@ -1,0 +1,10 @@
+namespace Namotion.Interceptor;
+
+/// <summary>
+/// Marks a service as an authority for <typeparamref name="TContract"/>. A resolved context chain
+/// may contain at most one distinct instance implementing that authority contract.
+/// </summary>
+/// <typeparam name="TContract">The authority contract whose cardinality is constrained.</typeparam>
+public interface IUniqueContextService<TContract>
+{
+}

--- a/src/Namotion.Interceptor/IUniqueContextService.cs
+++ b/src/Namotion.Interceptor/IUniqueContextService.cs
@@ -1,7 +1,7 @@
 namespace Namotion.Interceptor;
 
 /// <summary>
-/// Marks a service as an authority for <typeparamref name="TContract"/>. A resolved context chain
+/// Marks a service as an authority for <typeparamref name="TContract"/>. A resolved context cone
 /// may contain at most one distinct instance implementing that authority contract.
 /// </summary>
 /// <typeparam name="TContract">The authority contract whose cardinality is constrained.</typeparam>

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -60,6 +60,16 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     private static HashSet<InterceptorSubjectContext>? _serviceQueryVisited;
 
     [ThreadStatic]
+    private static HashSet<InterceptorSubjectContext>? _uniqueServiceValidationVisited;
+
+    [ThreadStatic]
+    private static List<(InterceptorSubjectContext Context, ContextState State)>?
+        _uniqueServiceValidationPending;
+
+    [ThreadStatic]
+    private static Dictionary<Type, object>? _uniqueServiceValidationAuthorities;
+
+    [ThreadStatic]
     private static HashSet<InterceptorSubjectContext>? _delegationCycleVisited;
 
     [ThreadStatic]
@@ -551,6 +561,8 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
             return ImmutableArray<TInterface>.Empty;
         }
 
+        ValidateUniqueContextServices(state);
+
         var serviceCache = state.GetServiceCache();
         if (serviceCache.TryGetValue(typeof(TInterface), out var cachedServices))
         {
@@ -561,6 +573,104 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
         // The two-argument GetOrAdd canonicalizes racing computations without a closure allocation.
         return (ImmutableArray<TInterface>)serviceCache.GetOrAdd(typeof(TInterface), services);
+    }
+
+    private void ValidateUniqueContextServices(ContextState state)
+    {
+        if (state.AreUniqueContextServicesValidated)
+        {
+            return;
+        }
+
+        var visited = _uniqueServiceValidationVisited ??= [];
+        var pending = _uniqueServiceValidationPending ??= [];
+        var authorities = _uniqueServiceValidationAuthorities ??= [];
+        pending.Add((this, state));
+
+        try
+        {
+            while (pending.Count > 0)
+            {
+                var lastIndex = pending.Count - 1;
+                var entry = pending[lastIndex];
+                pending.RemoveAt(lastIndex);
+                if (!visited.Add(entry.Context))
+                {
+                    continue;
+                }
+
+                foreach (var service in entry.State.Services)
+                {
+                    if (service is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var contract in UniqueContextServiceMetadata.GetContracts(service.GetType()))
+                    {
+                        if (authorities.TryGetValue(contract, out var existing))
+                        {
+                            if (!ReferenceEquals(existing, service))
+                            {
+                                throw new InvalidOperationException(
+                                    $"Context service contract '{contract.FullName}' must resolve to at most one distinct " +
+                                    $"instance, but '{existing.GetType().FullName}' and " +
+                                    $"'{service.GetType().FullName}' were found.");
+                            }
+                        }
+                        else
+                        {
+                            authorities.Add(contract, service);
+                        }
+                    }
+                }
+
+                for (var index = entry.State.FallbackContexts.Length - 1; index >= 0; index--)
+                {
+                    var fallback = entry.State.FallbackContexts[index];
+                    pending.Add((fallback, Volatile.Read(ref fallback._state)));
+                }
+            }
+
+            state.MarkUniqueContextServicesValidated();
+        }
+        finally
+        {
+            ReleaseUniqueServiceValidationBuffers(visited, pending, authorities);
+        }
+    }
+
+    private static void ReleaseUniqueServiceValidationBuffers(
+        HashSet<InterceptorSubjectContext> visited,
+        List<(InterceptorSubjectContext Context, ContextState State)> pending,
+        Dictionary<Type, object> authorities)
+    {
+        if (visited.Count > MaximumRetainedTraversalSize)
+        {
+            _uniqueServiceValidationVisited = null;
+        }
+        else
+        {
+            visited.Clear();
+        }
+
+        if (pending.Capacity > MaximumRetainedTraversalSize)
+        {
+            _uniqueServiceValidationPending = null;
+        }
+        else
+        {
+            pending.Clear();
+        }
+
+        if (authorities.Count > MaximumRetainedTraversalSize)
+        {
+            _uniqueServiceValidationAuthorities = null;
+        }
+        else
+        {
+            authorities.Clear();
+        }
     }
 
     private ImmutableArray<TInterface> ComputeServices<TInterface>(ContextState state)
@@ -959,6 +1069,8 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         private Delegate?[]? _readFunctions;
         private Delegate?[]? _writeFunctions;
 
+        private int _areUniqueContextServicesValidated;
+
         // The context this state's chain ends on, or CyclicDelegationMarker when it runs in a
         // circle. Null until first walked. A context and never a state: a context's state is
         // replaced whenever anything below it changes, so a cached state would serve an abandoned
@@ -973,6 +1085,12 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         }
 
         internal bool IsEmpty => Services.IsEmpty && FallbackContexts.IsEmpty;
+
+        internal bool AreUniqueContextServicesValidated =>
+            Volatile.Read(ref _areUniqueContextServicesValidated) != 0;
+
+        internal void MarkUniqueContextServicesValidated() =>
+            Volatile.Write(ref _areUniqueContextServicesValidated, 1);
 
         internal InterceptorSubjectContext? ResolvedTerminal
         {

--- a/src/Namotion.Interceptor/InterceptorSubjectContextExtensions.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContextExtensions.cs
@@ -41,7 +41,11 @@ public static class InterceptorSubjectContextExtensions
     /// <typeparam name="TService">The type of service to retrieve.</typeparam>
     /// <param name="context">The subject context.</param>
     /// <returns>The service instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the service is not registered.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The service is not registered, the requested singular service has several matches, the
+    /// delegation chain is cyclic, or an unrelated unique authority in the resolved context cone
+    /// has several distinct instances.
+    /// </exception>
     public static TService GetService<TService>(this IInterceptorSubjectContext context)
     {
         return context.TryGetService<TService>()

--- a/src/Namotion.Interceptor/Interceptors/ILifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/ILifecycleInterceptor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Namotion.Interceptor.Interceptors;
 
-public interface ILifecycleInterceptor
+public interface ILifecycleInterceptor : IUniqueContextService<ILifecycleInterceptor>
 {
     /// <summary>
     /// Called when the specified subject begins to be intercepted by this interceptor.

--- a/src/Namotion.Interceptor/UniqueContextServiceMetadata.cs
+++ b/src/Namotion.Interceptor/UniqueContextServiceMetadata.cs
@@ -1,0 +1,21 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+namespace Namotion.Interceptor;
+
+internal static class UniqueContextServiceMetadata
+{
+    private static readonly ConcurrentDictionary<Type, ImmutableArray<Type>> Cache = new();
+
+    internal static ImmutableArray<Type> GetContracts(Type serviceType)
+    {
+        return Cache.GetOrAdd(serviceType, static type => type
+            .GetInterfaces()
+            .Where(@interface =>
+                @interface.IsGenericType &&
+                @interface.GetGenericTypeDefinition() == typeof(IUniqueContextService<>))
+            .Select(@interface => @interface.GetGenericArguments()[0])
+            .Distinct()
+            .ToImmutableArray());
+    }
+}


### PR DESCRIPTION
## Summary

- Add a marker contract for services that may resolve to at most one distinct authority instance.
- Validate every unique authority in a resolved context cone by reference identity and cache successful validation on immutable context state.
- Apply the contract to lifecycle, registry, and transaction authorities and align built-in helper compositions.

## Breaking change

Composing independently configured contexts that expose distinct lifecycle, registry, or transaction authorities now throws when services are resolved. Reaching the same authority instance through several paths remains valid, and the ordinary one-shared-context application model is unchanged.

`TryGetService<T>()` is not a no-throw API. It can throw for singular-service ambiguity, delegation cycles, or a conflicting unique authority elsewhere in the resolved cone.

## Verification

- Full non-integration solution suite passed.
- Core, Tracking, Registry, Hosting, Connectors, and HomeBlaze service tests passed.
- Public API snapshots passed without unaccepted output.

## Performance

The agreed resolver and registry benchmark comparison is delegated to the maintainer's external machine. No performance conclusion is recorded yet.

Resolves #466 when merged.
