### PR TITLE
Add internal effective ownership route state

### DIFF
--- a/docs/design/context-resolution.md
+++ b/docs/design/context-resolution.md
@@ -1,0 +1,72 @@
+# Context Resolution
+
+Namotion.Interceptor contexts resolve interceptors and coordination services through an immutable,
+copy-on-write state. This document defines the internal relationship types, traversal order, and
+cache invalidation rules used by Core. The ownership route is an internal foundation in the first
+pull request and receives its production lifecycle owner in the following attachment pull request.
+
+## Concepts and terms
+
+- **Local services:** Services registered directly on the context being queried.
+- **Fallback composition:** Public service composition created by `AddFallbackContext`. Existing
+  lifecycle side effects remain until the attachment pull request separates them.
+- **Ownership route:** One internal resolution relationship used later by explicit attachment or an
+  active parent branch.
+- **Ownership domain:** The plain configured context whose reference identity names one lifecycle
+  domain.
+- **Using context:** A context whose resolution depends on another context and must be invalidated
+  when that dependency changes.
+
+## Contract at a glance
+
+- A query pins one immutable state and takes no context mutation lock.
+- Resolution visits local services, public fallbacks in insertion order, then one ownership route.
+- Ordering attributes override route order only where they declare a dependency.
+- Repeated contexts and service instances are returned once according to the existing visited and
+  distinct rules.
+- Services, fallbacks, the ownership route, delegation, and caches belong to one published state.
+- A route change compares the exact previous descriptor instance before it publishes.
+- Reverse dependency registration remains while either a fallback or ownership route uses a target.
+- Topology changes publish a cache-free state and invalidate every upstream using context.
+- Traversal and invalidation are iterative and terminate on cyclic graphs.
+
+## Immutable state and publication
+
+Route-free contexts use the existing `ContextState`. A context with an ownership route uses a
+derived state containing one immutable route descriptor. The descriptor contains the target and
+ownership-domain references and also serves as the transition generation token.
+
+Mutators serialize on one context's mutation lock, build the complete replacement state, register a
+new reverse dependency before publication, publish once, conditionally remove the old reverse
+dependency, and invalidate upstream contexts after releasing the mutation lock. Queries continue to
+use one volatile state read.
+
+## Resolution and delegation
+
+The service walk is depth-first. Each entered context contributes local services, then each public
+fallback, then its ownership route. The existing visited set cuts cycles and gives the earliest
+route to a repeated context precedence.
+
+An empty context delegates directly when it has one distinct target: one fallback, one ownership
+route, or both relationships to the same target. Different fallback and ownership targets require
+the normal service walk. A pure delegation cycle raises the existing delegation-cycle exception.
+
+## Reverse dependencies and invalidation
+
+`_usedByContexts` represents whether a source depends on a target, not how many relationship kinds
+connect them. Removing a fallback must retain the reverse entry while an ownership route still uses
+the target. Clearing a route must retain it while a fallback still uses the target.
+
+Registration occurs before publication so the reverse set is always a superset of the true using
+set. Conditional removal occurs after publication. An extra entry can cause a harmless invalidation;
+a missing entry can preserve a stale compiled chain and is forbidden.
+
+## Performance
+
+Route-free contexts keep the existing base state layout. Cached service queries and steady-state
+intercepted reads, writes, and invocations do not inspect an ownership descriptor. A route attempt
+allocates its descriptor before the exact comparison; only a successful route publication uses the
+derived routed state.
+
+Timing comparisons on a development machine are diagnostic. Final performance acceptance uses the
+stable benchmark machine and compares the exact pull request head with its exact base commit.

--- a/docs/superpowers/plans/2026-08-17-effective-ownership-route-state.md
+++ b/docs/superpowers/plans/2026-08-17-effective-ownership-route-state.md
@@ -1,0 +1,1210 @@
+# Effective Ownership-Route State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a permanent internal ownership-route relationship to Core context state without changing public or production behavior.
+
+**Architecture:** Store an immutable target and ownership-domain descriptor only in a derived routed context state, leaving route-free state layout unchanged. Publish route changes with the existing context mutation lock, traverse the route after public fallbacks, and maintain the reverse dependency as the union of both relationship kinds.
+
+**Tech Stack:** C# 13, .NET Standard 2.0 Core library, xUnit, immutable copy-on-write context state, PublicApiGenerator and Verify.
+
+## Global Constraints
+
+- Work in `/Users/ricosuter/Projects/GitHub/Namotion.Interceptor/.claude/worktrees/single-context-stack-roadmap` on `design/single-context-stack-roadmap`.
+- The pull request base is exact `master` commit `868a4d109d53b24805c9ee180efbf5029ee12c1a`.
+- Follow `AGENTS.md`: correctness first, then allocations and CPU, then style.
+- Use strict TDD. No production code is written before the covering tests are observed failing for the missing ownership-route capability.
+- Tests use `When<Condition>_Then<ExpectedBehavior>` names and explicit `// Arrange`, `// Act`, and `// Assert` sections.
+- Deterministic concurrency uses `Barrier`, `ManualResetEventSlim`, or `AsyncTestHelpers.WaitUntilAsync`; never `Task.Delay` or `Thread.Sleep`.
+- Add no public type or member. The Core Public API snapshot must remain byte-for-byte unchanged.
+- Do not change `IInterceptorSubjectContext`, `InterceptorExecutor`, source generation, Tracking, Registry, Hosting, connectors, OPC UA, or HomeBlaze.
+- Existing fallback lifecycle behavior remains unchanged because no production path installs an ownership route in this pull request.
+- Route-free `InterceptorSubjectContext` and base `ContextState` instance fields and object sizes remain unchanged.
+- Steady-state intercepted reads, writes, method invocations, delegation, and cached service resolution add no route lookup and no allocation.
+- The internal service order is local services, public fallbacks in insertion order, then the ownership route. Ordering attributes still override otherwise unconstrained route order.
+- Reverse using-context registration is the union of public fallback and ownership-route relationships to one target.
+- A stale operation can change a route only when its exact expected descriptor instance is still current.
+- Use no em dash in documentation, comments, commit messages, or pull request text.
+- Local benchmark timings are diagnostic only. Do static hot-path and allocation analysis locally, then ask the maintainer before handing the exact comparison to the stable benchmark machine.
+- A nonzero build, test, or pack exit is not a passing gate. Record an infrastructure timeout accurately and obtain a clean successful run before the pull request is finalized.
+
+---
+
+## File Map
+
+- Modify `src/Namotion.Interceptor/InterceptorSubjectContext.cs`: route descriptor, routed immutable state, exact route transition, traversal order, delegation, and reverse invalidation ownership.
+- Create `src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs`: deterministic route behavior, ABA, invalidation, cycle, and concurrency contracts.
+- Modify `src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs`: extend the recursive differential oracle with one ownership route per node.
+- Modify `src/Namotion.Interceptor.Tests/Context/ContextDeepGraphTests.cs`: prove route traversal and invalidation remain iterative at graph depth.
+- Create `docs/design/context-resolution.md`: permanent internal context-resolution terms, order, publication, and invalidation rules.
+
+Before Task 1 is dispatched, the controller commits this plan together with the approved spec and
+roadmap, then verifies `git status --short` is empty. The implementation task therefore begins from
+a clean, recoverable planning commit.
+
+## Task 1: Implement the Internal Ownership Route Test-First
+
+**Files:**
+- Modify: `src/Namotion.Interceptor/InterceptorSubjectContext.cs`
+- Create: `src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs`
+- Modify: `src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs`
+- Modify: `src/Namotion.Interceptor.Tests/Context/ContextDeepGraphTests.cs`
+
+**Interfaces:**
+- Consumes: existing `InterceptorSubjectContext` immutable state, `_mutationLock`, `_usedByContexts`, delegation cache, service-walk visited set, and invalidation worklist.
+- Produces: nested internal `InterceptorSubjectContext.ContextOwnershipRoute` and `InterceptorSubjectContext.TryChangeOwnershipRoute(ContextOwnershipRoute? expected, ContextOwnershipRoute? replacement)` for PR 2.
+
+- [ ] **Step 1: Create the deterministic ownership-route tests**
+
+Create `ContextOwnershipRouteTests.cs` with the following real-behavior tests. The exact descriptor identity is exercised through transition results and resolved services, not through reflection or a mock.
+
+```csharp
+using Namotion.Interceptor.Testing;
+
+using static Namotion.Interceptor.Tests.Context.ContextStateReflection;
+
+namespace Namotion.Interceptor.Tests.Context;
+
+public class ContextOwnershipRouteTests
+{
+    [Fact]
+    public void WhenOwnershipRouteIsInstalled_ThenServicesResolveAfterFallbacks()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var routeTarget = InterceptorSubjectContext.Create();
+        routeTarget.AddService<IRouteService>(new RouteService("route"));
+
+        var fallback = InterceptorSubjectContext.Create();
+        fallback.AddService<IRouteService>(new RouteService("fallback"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        context.AddFallbackContext(fallback);
+
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(routeTarget, ownershipDomain);
+
+        // Act
+        var installed = context.TryChangeOwnershipRoute(null, route);
+        var names = context.GetServices<IRouteService>().Select(service => service.Name).ToArray();
+
+        // Assert
+        Assert.True(installed);
+        Assert.Equal(["local", "fallback", "route"], names);
+    }
+
+    [Fact]
+    public void WhenFallbackAndOwnershipRouteShareTarget_ThenTargetServicesResolveOnce()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        var service = new RouteService("target");
+        target.AddService<IRouteService>(service);
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddFallbackContext(target);
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+
+        // Act
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        var services = context.GetServices<IRouteService>();
+
+        // Assert
+        Assert.Single(services);
+        Assert.Same(service, services[0]);
+    }
+
+    [Fact]
+    public void WhenOldDescriptorClearsSameTargetGeneration_ThenNewGenerationRemains()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target"));
+        var context = InterceptorSubjectContext.Create();
+
+        var first = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        var second = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, first));
+        Assert.True(context.TryChangeOwnershipRoute(first, second));
+
+        // Act
+        var staleClear = context.TryChangeOwnershipRoute(first, null);
+
+        // Assert
+        Assert.False(staleClear);
+        Assert.Single(context.GetServices<IRouteService>());
+        Assert.True(context.TryChangeOwnershipRoute(second, null));
+        Assert.Empty(context.GetServices<IRouteService>());
+    }
+
+    [Fact]
+    public void WhenServicesAreAddedReentrantlyAfterRouteInstall_ThenRouteSurvivesEveryStatePublication()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("route"));
+
+        var context = InterceptorSubjectContext.Create();
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+
+        // Act
+        var added = context.TryAddService<IRouteService>(
+            () =>
+            {
+                context.AddService<IRouteService>(new RouteService("reentrant"));
+                return new RouteService("added");
+            },
+            _ => false);
+
+        var names = context.GetServices<IRouteService>().Select(service => service.Name).ToArray();
+
+        // Assert
+        Assert.True(added);
+        Assert.Equal(["reentrant", "added", "route"], names);
+    }
+
+    [Fact]
+    public void WhenRouteTargetMutatesAfterResolution_ThenInvalidatedStateRetainsRoute()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target-1"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        // Act
+        target.AddService<IRouteService>(new RouteService("target-2"));
+
+        // Assert
+        Assert.Equal(3, context.GetServices<IRouteService>().Length);
+    }
+
+    [Fact]
+    public void WhenRouteTransfersToDifferentTarget_ThenReverseDependenciesFollowPublishedRelationships()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var targetA = InterceptorSubjectContext.Create();
+        var targetB = InterceptorSubjectContext.Create();
+        targetA.AddService<IRouteService>(new RouteService("a-1"));
+        targetB.AddService<IRouteService>(new RouteService("b-1"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        var routeA = new InterceptorSubjectContext.ContextOwnershipRoute(targetA, ownershipDomain);
+        var routeB = new InterceptorSubjectContext.ContextOwnershipRoute(targetB, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, routeA));
+        Assert.True(context.AddFallbackContext(targetA));
+        Assert.Equal(["local", "a-1"],
+            context.GetServices<IRouteService>().Select(service => service.Name).ToArray());
+
+        // Act: transfer the route away from A while the fallback still depends on A.
+        Assert.True(context.TryChangeOwnershipRoute(routeA, routeB));
+
+        // Assert
+        Assert.Equal(["local", "a-1", "b-1"],
+            context.GetServices<IRouteService>().Select(service => service.Name).ToArray());
+
+        var stateWithA = GetState(context);
+        targetA.AddService<IRouteService>(new RouteService("a-2"));
+
+        // Assert
+        Assert.NotSame(stateWithA, GetState(context));
+        Assert.Equal(4, context.GetServices<IRouteService>().Length);
+
+        // Act: removing the fallback ends the final relationship to A.
+        Assert.True(context.RemoveFallbackContext(targetA));
+        Assert.Equal(["local", "b-1"],
+            context.GetServices<IRouteService>().Select(service => service.Name).ToArray());
+
+        var stateWithoutA = GetState(context);
+        targetA.AddService<IRouteService>(new RouteService("a-3"));
+
+        // Assert
+        Assert.Same(stateWithoutA, GetState(context));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        var stateWithB = GetState(context);
+        targetB.AddService<IRouteService>(new RouteService("b-2"));
+        Assert.NotSame(stateWithB, GetState(context));
+        Assert.Equal(3, context.GetServices<IRouteService>().Length);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WhenFallbackAndRouteShareTarget_ThenRemovingOneKeepsInvalidationThroughTheOther(
+        bool removeFallbackFirst)
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target-1"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        context.AddFallbackContext(target);
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        // Act
+        if (removeFallbackFirst)
+        {
+            Assert.True(context.RemoveFallbackContext(target));
+        }
+        else
+        {
+            Assert.True(context.TryChangeOwnershipRoute(route, null));
+        }
+
+        target.AddService<IRouteService>(new RouteService("target-2"));
+
+        // Assert
+        Assert.Equal(3, context.GetServices<IRouteService>().Length);
+
+        // Act
+        if (removeFallbackFirst)
+        {
+            Assert.True(context.TryChangeOwnershipRoute(route, null));
+        }
+        else
+        {
+            Assert.True(context.RemoveFallbackContext(target));
+        }
+
+        Assert.Single(context.GetServices<IRouteService>());
+        var stateAfterFinalRemoval = GetState(context);
+        target.AddService<IRouteService>(new RouteService("target-3"));
+
+        // Assert
+        Assert.Same(stateAfterFinalRemoval, GetState(context));
+        Assert.Single(context.GetServices<IRouteService>());
+    }
+
+    [Fact]
+    public void WhenOwnershipRoutesFormDelegationCycle_ThenResolutionThrows()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var contextA = InterceptorSubjectContext.Create();
+        var contextB = InterceptorSubjectContext.Create();
+        var routeA = new InterceptorSubjectContext.ContextOwnershipRoute(contextB, ownershipDomain);
+        var routeB = new InterceptorSubjectContext.ContextOwnershipRoute(contextA, ownershipDomain);
+        Assert.True(contextA.TryChangeOwnershipRoute(null, routeA));
+        Assert.True(contextB.TryChangeOwnershipRoute(null, routeB));
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => contextA.GetServices<IRouteService>());
+
+        // Assert
+        Assert.Contains("delegation cycle", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WhenTwoThreadsInstallFirstRoute_ThenExactlyOneDescriptorWins()
+    {
+        const int attempts = 500;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            // Arrange
+            var ownershipDomain = InterceptorSubjectContext.Create();
+            var firstTarget = InterceptorSubjectContext.Create();
+            var secondTarget = InterceptorSubjectContext.Create();
+            var firstService = new RouteService("first");
+            var secondService = new RouteService("second");
+            firstTarget.AddService<IRouteService>(firstService);
+            secondTarget.AddService<IRouteService>(secondService);
+
+            var context = InterceptorSubjectContext.Create();
+            var firstRoute = new InterceptorSubjectContext.ContextOwnershipRoute(firstTarget, ownershipDomain);
+            var secondRoute = new InterceptorSubjectContext.ContextOwnershipRoute(secondTarget, ownershipDomain);
+            using var start = new Barrier(2);
+            var results = new bool[2];
+
+            var installers = new[]
+            {
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[0] = context.TryChangeOwnershipRoute(null, firstRoute);
+                }, TaskCreationOptions.LongRunning),
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[1] = context.TryChangeOwnershipRoute(null, secondRoute);
+                }, TaskCreationOptions.LongRunning)
+            };
+
+            // Act
+            await AsyncTestHelpers.WaitUntilAsync(
+                () => installers.All(installer => installer.IsCompleted),
+                message: $"Concurrent ownership-route installation did not complete on attempt {attempt}");
+            await Task.WhenAll(installers);
+
+            // Assert
+            Assert.NotEqual(results[0], results[1]);
+            var service = Assert.Single(context.GetServices<IRouteService>());
+            Assert.Same(results[0] ? firstService : secondService, service);
+        }
+    }
+
+    [Fact]
+    public async Task WhenTwoThreadsTransferSameRoute_ThenExactlyOneReplacementWins()
+    {
+        const int attempts = 500;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            // Arrange
+            var ownershipDomain = InterceptorSubjectContext.Create();
+            var initialTarget = InterceptorSubjectContext.Create();
+            var firstTarget = InterceptorSubjectContext.Create();
+            var secondTarget = InterceptorSubjectContext.Create();
+            var firstService = new RouteService("first");
+            var secondService = new RouteService("second");
+            firstTarget.AddService<IRouteService>(firstService);
+            secondTarget.AddService<IRouteService>(secondService);
+
+            var context = InterceptorSubjectContext.Create();
+            var initialRoute = new InterceptorSubjectContext.ContextOwnershipRoute(initialTarget, ownershipDomain);
+            var firstRoute = new InterceptorSubjectContext.ContextOwnershipRoute(firstTarget, ownershipDomain);
+            var secondRoute = new InterceptorSubjectContext.ContextOwnershipRoute(secondTarget, ownershipDomain);
+            Assert.True(context.TryChangeOwnershipRoute(null, initialRoute));
+
+            using var start = new Barrier(2);
+            var results = new bool[2];
+            var transfers = new[]
+            {
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[0] = context.TryChangeOwnershipRoute(initialRoute, firstRoute);
+                }, TaskCreationOptions.LongRunning),
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[1] = context.TryChangeOwnershipRoute(initialRoute, secondRoute);
+                }, TaskCreationOptions.LongRunning)
+            };
+
+            // Act
+            await AsyncTestHelpers.WaitUntilAsync(
+                () => transfers.All(transfer => transfer.IsCompleted),
+                message: $"Concurrent ownership-route transfer did not complete on attempt {attempt}");
+            await Task.WhenAll(transfers);
+
+            // Assert
+            Assert.NotEqual(results[0], results[1]);
+            var service = Assert.Single(context.GetServices<IRouteService>());
+            Assert.Same(results[0] ? firstService : secondService, service);
+        }
+    }
+
+    [Fact]
+    public async Task WhenRouteAndTargetMutateConcurrently_ThenQuiescentResolutionSeesAllTargetServices()
+    {
+        // Arrange
+        const int mutations = 200;
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target-initial"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        var initialRoute = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, initialRoute));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        using var start = new Barrier(3);
+        using var routeMidpoint = new ManualResetEventSlim(false);
+        using var readerObservedMidpoint = new ManualResetEventSlim(false);
+        var activeWriters = 2;
+
+        var routeWriter = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            try
+            {
+                var current = initialRoute;
+                for (var index = 0; index < mutations; index++)
+                {
+                    Assert.True(context.TryChangeOwnershipRoute(current, null));
+                    current = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+                    Assert.True(context.TryChangeOwnershipRoute(null, current));
+
+                    if (index == mutations / 2)
+                    {
+                        routeMidpoint.Set();
+                        readerObservedMidpoint.Wait();
+                    }
+                }
+            }
+            finally
+            {
+                routeMidpoint.Set();
+                Interlocked.Decrement(ref activeWriters);
+            }
+        }, TaskCreationOptions.LongRunning);
+
+        var serviceWriter = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            try
+            {
+                for (var index = 0; index < mutations; index++)
+                {
+                    target.AddService<IRouteService>(new RouteService($"target-{index}"));
+                }
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeWriters);
+            }
+        }, TaskCreationOptions.LongRunning);
+
+        var reader = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            try
+            {
+                while (!routeMidpoint.IsSet)
+                {
+                    _ = context.GetServices<IRouteService>();
+                }
+
+                _ = context.GetServices<IRouteService>();
+            }
+            finally
+            {
+                readerObservedMidpoint.Set();
+            }
+
+            while (Volatile.Read(ref activeWriters) != 0)
+            {
+                _ = context.GetServices<IRouteService>();
+            }
+        }, TaskCreationOptions.LongRunning);
+
+        // Act
+        var workers = new[] { routeWriter, serviceWriter, reader };
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => workers.All(worker => worker.IsCompleted),
+            message: "Concurrent route, target, and resolution work did not complete");
+        await Task.WhenAll(workers);
+
+        // Assert
+        Assert.Equal(mutations + 2, context.GetServices<IRouteService>().Length);
+    }
+
+    private interface IRouteService
+    {
+        string Name { get; }
+    }
+
+    private sealed class RouteService(string name) : IRouteService
+    {
+        public string Name { get; } = name;
+    }
+}
+```
+
+- [ ] **Step 2: Extend the recursive service-order oracle before implementation**
+
+Modify `ContextServiceWalkOrderTests.cs` so its independent model includes an optional route after fallbacks.
+
+Add route creation at the end of `BuildGraph`:
+
+```csharp
+var ownershipDomain = InterceptorSubjectContext.Create();
+foreach (var source in nodes)
+{
+    if (random.Next(2) == 0)
+    {
+        continue;
+    }
+
+    var target = nodes[random.Next(nodes.Length)];
+    source.OwnershipRoute = target;
+    var route = new InterceptorSubjectContext.ContextOwnershipRoute(target.Context, ownershipDomain);
+    Assert.True(source.Context.TryChangeOwnershipRoute(null, route));
+}
+```
+
+Update the recursive reference to traverse the route after fallbacks:
+
+```csharp
+foreach (var fallback in node.Fallbacks)
+{
+    collected.AddRange(CollectWithReference(fallback, visited));
+}
+
+if (node.OwnershipRoute is not null)
+{
+    collected.AddRange(CollectWithReference(node.OwnershipRoute, visited));
+}
+```
+
+Add these exact model members to `Node`:
+
+```csharp
+internal Node? OwnershipRoute { get; set; }
+
+internal IEnumerable<Node> Relationships =>
+    OwnershipRoute is null ? Fallbacks : Fallbacks.Append(OwnershipRoute!);
+
+internal Node? DelegationTarget
+{
+    get
+    {
+        if (Services.Count != 0)
+        {
+            return null;
+        }
+
+        if (OwnershipRoute is null)
+        {
+            return Fallbacks.Count == 1 ? Fallbacks[0] : null;
+        }
+
+        if (Fallbacks.Count == 0)
+        {
+            return OwnershipRoute;
+        }
+
+        return Fallbacks.Count == 1 && ReferenceEquals(Fallbacks[0], OwnershipRoute)
+            ? OwnershipRoute
+            : null;
+    }
+}
+```
+
+Replace the corresponding coverage and description logic with:
+
+```csharp
+Assert.True(coverage.OwnershipRoutes > 0, "No graph contained an ownership route.");
+Assert.True(coverage.RelationshipCycles > 0, "No graph contained a relationship cycle.");
+
+var ownershipRoute = node.OwnershipRoute;
+builder.AppendLine(
+    $"  c{node.Index} services [{string.Join(", ", node.Services)}] " +
+    $"fallbacks [{string.Join(", ", node.Fallbacks.Select(fallback => $"c{fallback.Index}"))}] " +
+    $"route [{(ownershipRoute is null ? string.Empty : $"c{ownershipRoute.Index}")}]");
+
+internal int OwnershipRoutes;
+internal int RelationshipCycles;
+
+if (node.OwnershipRoute is not null)
+{
+    OwnershipRoutes++;
+}
+
+if (nodes.SelectMany(other => other.Relationships).Count(target => ReferenceEquals(target, node)) > 1)
+{
+    SharedNodes++;
+}
+
+if (ReachesItself(node))
+{
+    RelationshipCycles++;
+}
+
+private static bool ReachesItself(Node node)
+{
+    var visited = new HashSet<Node>();
+    var pending = new Stack<Node>(node.Relationships);
+    while (pending.Count != 0)
+    {
+        var current = pending.Pop();
+        if (ReferenceEquals(current, node))
+        {
+            return true;
+        }
+
+        if (!visited.Add(current))
+        {
+            continue;
+        }
+
+        foreach (var relationship in current.Relationships)
+        {
+            pending.Push(relationship);
+        }
+    }
+
+    return false;
+}
+```
+
+Rename the existing `FallbackCycles` counter and assertion to `RelationshipCycles`; do not retain both counters. Keep the model independent: it derives expected order from its own `Fallbacks` and `OwnershipRoute`, never from production state.
+
+- [ ] **Step 3: Add the deep ownership-route test before implementation**
+
+Add this test to `ContextDeepGraphTests.cs` using the existing `ChainLength` constant:
+
+```csharp
+[Fact]
+public void WhenOwnershipRouteChainIsVeryDeep_ThenResolutionAndInvalidationRemainIterative()
+{
+    // Arrange
+    var ownershipDomain = InterceptorSubjectContext.Create();
+    var rootContext = InterceptorSubjectContext.Create();
+    rootContext.AddService(new MarkerService());
+
+    var deepestContext = rootContext;
+    for (var index = 0; index < ChainLength; index++)
+    {
+        var context = InterceptorSubjectContext.Create();
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(deepestContext, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        deepestContext = context;
+    }
+
+    Assert.Single(deepestContext.GetServices<MarkerService>());
+
+    // Act
+    rootContext.AddService(new MarkerService());
+
+    // Assert
+    Assert.Equal(2, deepestContext.GetServices<MarkerService>().Length);
+    Assert.Null(GetThreadStaticBuffer("_delegationCyclePath"));
+    Assert.Null(GetThreadStaticBuffer("_delegationCycleVisited"));
+    Assert.Null(GetThreadStaticBuffer("_invalidationVisited"));
+    Assert.Null(GetThreadStaticBuffer("_invalidationPending"));
+}
+```
+
+- [ ] **Step 4: Run the new tests and verify RED**
+
+Run:
+
+```bash
+dotnet test src/Namotion.Interceptor.Tests/Namotion.Interceptor.Tests.csproj --filter "FullyQualifiedName~ContextOwnershipRouteTests|FullyQualifiedName~ContextServiceWalkOrderTests|FullyQualifiedName~WhenOwnershipRouteChainIsVeryDeep"
+```
+
+Expected: build fails with `CS0426` for missing `InterceptorSubjectContext.ContextOwnershipRoute` and `CS1061` for missing `TryChangeOwnershipRoute`. This is the expected RED because the internal route capability does not exist on `master`.
+
+- [ ] **Step 5: Add the immutable descriptor and routed state**
+
+In `InterceptorSubjectContext.cs`, add the nested immutable descriptor:
+
+```csharp
+internal sealed class ContextOwnershipRoute
+{
+    internal ContextOwnershipRoute(
+        InterceptorSubjectContext target,
+        InterceptorSubjectContext ownershipDomain)
+    {
+        Target = target;
+        OwnershipDomain = ownershipDomain;
+    }
+
+    internal InterceptorSubjectContext Target { get; }
+
+    internal InterceptorSubjectContext OwnershipDomain { get; }
+}
+```
+
+Change `ContextState` from sealed to an inheritable private class without adding instance fields. Add:
+
+```csharp
+private sealed class RoutedContextState : ContextState
+{
+    internal RoutedContextState(
+        ImmutableArray<object> services,
+        ImmutableArray<InterceptorSubjectContext> fallbackContexts,
+        ContextOwnershipRoute ownershipRoute)
+        : base(services, fallbackContexts, ownershipRoute.Target)
+    {
+        OwnershipRoute = ownershipRoute;
+    }
+
+    internal readonly ContextOwnershipRoute OwnershipRoute;
+}
+
+private static ContextOwnershipRoute? GetOwnershipRoute(ContextState state)
+{
+    return state is RoutedContextState routedState ? routedState.OwnershipRoute : null;
+}
+
+private static ContextState CreateContextState(
+    ImmutableArray<object> services,
+    ImmutableArray<InterceptorSubjectContext> fallbackContexts,
+    ContextOwnershipRoute? ownershipRoute)
+{
+    return ownershipRoute is null
+        ? new ContextState(services, fallbackContexts)
+        : new RoutedContextState(services, fallbackContexts, ownershipRoute);
+}
+```
+
+Give `ContextState`'s constructor an optional `ownershipRouteTarget` parameter and derive delegation exactly as follows:
+
+```csharp
+internal ContextState(
+    ImmutableArray<object> services,
+    ImmutableArray<InterceptorSubjectContext> fallbackContexts,
+    InterceptorSubjectContext? ownershipRouteTarget = null)
+{
+    Services = services;
+    FallbackContexts = fallbackContexts;
+
+    if (!services.IsEmpty)
+    {
+        DelegationTarget = null;
+    }
+    else if (fallbackContexts.IsEmpty)
+    {
+        DelegationTarget = ownershipRouteTarget;
+    }
+    else if (fallbackContexts.Length == 1 &&
+             (ownershipRouteTarget is null || ReferenceEquals(fallbackContexts[0], ownershipRouteTarget)))
+    {
+        DelegationTarget = fallbackContexts[0];
+    }
+}
+
+internal bool IsEmpty => Services.IsEmpty && FallbackContexts.IsEmpty;
+```
+
+Keep the existing `IsEmpty` expression unchanged. Add a comment at its use in
+`GetServicesFromState`: a route-only source always has `DelegationTarget` and every caller resolves
+that delegation before reaching the empty-state check. This preserves the route-free hot path.
+
+`WithoutCaches()` returns `CreateContextState(Services, FallbackContexts, GetOwnershipRoute(this))`. Use these exact replacement-state expressions so an installed route survives every unrelated mutation:
+
+```csharp
+// AddFallbackContext
+var replacementState = CreateContextState(
+    state.Services,
+    state.FallbackContexts.Add(contextImpl),
+    GetOwnershipRoute(state));
+
+// RemoveFallbackContext
+var replacementState = CreateContextState(
+    state.Services,
+    state.FallbackContexts.RemoveAt(index),
+    GetOwnershipRoute(state));
+
+// TryAddService and AddService
+var replacementState = CreateContextState(
+    state.Services.Add(service!),
+    state.FallbackContexts,
+    GetOwnershipRoute(state));
+
+// ContextState.WithoutCaches
+return CreateContextState(Services, FallbackContexts, GetOwnershipRoute(this));
+```
+
+- [ ] **Step 6: Add the exact route transition and reverse dependency union**
+
+Add this internal operation beside the fallback mutators:
+
+```csharp
+internal bool TryChangeOwnershipRoute(
+    ContextOwnershipRoute? expected,
+    ContextOwnershipRoute? replacement)
+{
+    var changed = false;
+
+    lock (_mutationLock)
+    {
+        var state = Volatile.Read(ref _state);
+        var current = GetOwnershipRoute(state);
+        if (!ReferenceEquals(current, expected))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(current, replacement))
+        {
+            return true;
+        }
+
+        var replacementState = CreateContextState(state.Services, state.FallbackContexts, replacement);
+
+        if (replacement is not null &&
+            !ReferenceEquals(current?.Target, replacement.Target))
+        {
+            RegisterUsingContext(replacement.Target);
+        }
+
+        PublishState(replacementState);
+
+        if (current is not null &&
+            !ReferenceEquals(current.Target, replacement?.Target) &&
+            !UsesTarget(replacementState, current.Target))
+        {
+            UnregisterUsingContext(current.Target);
+        }
+
+        changed = true;
+    }
+
+    if (changed)
+    {
+        InvalidateUsingContexts();
+    }
+
+    return true;
+}
+```
+
+Extract the existing reverse-set add and remove bodies into private helpers that never call another context mutation method:
+
+```csharp
+private void RegisterUsingContext(InterceptorSubjectContext target)
+{
+    var usedByContexts = target.GetOrCreateUsedByContexts();
+    lock (usedByContexts)
+    {
+        usedByContexts.Add(this);
+    }
+}
+
+private void UnregisterUsingContext(InterceptorSubjectContext target)
+{
+    var usedByContexts = Volatile.Read(ref target._usedByContexts);
+    if (usedByContexts is not null)
+    {
+        lock (usedByContexts)
+        {
+            usedByContexts.Remove(this);
+        }
+    }
+}
+
+private static bool UsesTarget(ContextState state, InterceptorSubjectContext target)
+{
+    return state.FallbackContexts.Contains(target) ||
+           ReferenceEquals(GetOwnershipRoute(state)?.Target, target);
+}
+```
+
+Construct `replacementState` before reverse registration. An allocation failure must leave no extra using-set entry.
+
+Use `RegisterUsingContext` in `AddFallbackContext`. In `RemoveFallbackContext`, publish the replacement state first and call `UnregisterUsingContext` only when `UsesTarget(replacementState, contextImpl)` is false. This is the load-bearing union rule for a fallback and ownership route that share a target.
+
+In `AddFallbackContext`, construct `replacementState` before `RegisterUsingContext(contextImpl)`,
+then register and publish in that order. This preserves register-before-publish while ensuring an
+allocation failure cannot leave an extra reverse entry.
+
+- [ ] **Step 7: Traverse the ownership route after public fallbacks**
+
+Add `OwnershipRouteEntered` to `ServiceWalkFrame`. After its fallback cursor is exhausted but before `ReduceFrame`, enter the route once:
+
+```csharp
+if (!frame.OwnershipRouteEntered)
+{
+    frame.OwnershipRouteEntered = true;
+    frames[frameIndex] = frame;
+
+    var ownershipRoute = GetOwnershipRoute(frame.State);
+    if (ownershipRoute is not null &&
+        TryEnterContext(
+            ownershipRoute.Target,
+            Volatile.Read(ref ownershipRoute.Target._state),
+            visited,
+            out var ownershipRouteState))
+    {
+        PushFrame(frames, collected, type, ownershipRouteState);
+        continue;
+    }
+}
+```
+
+The existing visited set makes fallback plus same-target route resolve once. `ContextState.DelegationTarget` handles route-only delegation and same-target fallback plus route. Do not add any route check to `GetServices`, `ExecuteInterceptedRead`, `ExecuteInterceptedWrite`, or `ExecuteInterceptedInvoke`.
+
+Update only Core comments that become inaccurate: the top-level topology snapshot, delegation,
+service-walk, reverse using-graph, `ContextState.DelegationTarget`, and `ServiceWalkFrame` comments
+must name public fallbacks plus the internal ownership route where both now participate. Keep the
+existing delegation-cycle exception message byte-for-byte unchanged in PR 1 because fallback-only
+production failures remain behavior-neutral. The internal route-cycle test asserts only the stable
+`delegation cycle` phrase.
+
+- [ ] **Step 8: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+dotnet test src/Namotion.Interceptor.Tests/Namotion.Interceptor.Tests.csproj --filter "FullyQualifiedName~ContextOwnershipRouteTests|FullyQualifiedName~ContextServiceWalkOrderTests|FullyQualifiedName~ContextDelegationCycleTests|FullyQualifiedName~ContextDeepGraphTests"
+```
+
+Expected: all selected tests pass with zero warnings and zero failures.
+
+- [ ] **Step 9: Run the complete Core test project**
+
+Run:
+
+```bash
+dotnet test src/Namotion.Interceptor.Tests/Namotion.Interceptor.Tests.csproj
+```
+
+Expected: exit 0, zero failed tests, and no `.received.txt` file.
+
+- [ ] **Step 10: Perform the task self-review**
+
+Inspect the task diff and verify all of the following:
+
+```bash
+git diff --check
+git diff --stat HEAD
+git diff -U40 HEAD -- src/Namotion.Interceptor/InterceptorSubjectContext.cs src/Namotion.Interceptor.Tests/Context
+rg --files src -g '*.received.txt'
+```
+
+Confirm the base `ContextState` has no new instance field, route-free hot methods have no new branch,
+every state publication preserves the descriptor, replacement state is allocated before reverse
+registration, and the new ownership-route transition invokes no callback, factory, or virtual
+method under `_mutationLock`.
+
+- [ ] **Step 11: Commit the Core implementation**
+
+```bash
+git add src/Namotion.Interceptor/InterceptorSubjectContext.cs src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs src/Namotion.Interceptor.Tests/Context/ContextDeepGraphTests.cs
+git commit -m "Add internal context ownership route"
+```
+
+## Task 2: Document the Permanent Context-Resolution Contract
+
+**Files:**
+- Create: `docs/design/context-resolution.md`
+
+**Interfaces:**
+- Consumes: the implemented internal descriptor, routed context state, exact transition, traversal order, and reverse dependency union from Task 1.
+- Produces: the canonical internal mechanics document that PR 2 extends and user-facing documentation can reference without duplicating implementation facts.
+
+- [ ] **Step 1: Create the internal context-resolution document**
+
+Create `docs/design/context-resolution.md` with these exact sections and contracts:
+
+```markdown
+# Context Resolution
+
+Namotion.Interceptor contexts resolve interceptors and coordination services through an immutable,
+copy-on-write state. This document defines the internal relationship types, traversal order, and
+cache invalidation rules used by Core. The ownership route is an internal foundation in the first
+pull request and receives its production lifecycle owner in the following attachment pull request.
+
+## Concepts and terms
+
+- **Local services:** Services registered directly on the context being queried.
+- **Fallback composition:** Public service composition created by `AddFallbackContext`. Existing
+  lifecycle side effects remain until the attachment pull request separates them.
+- **Ownership route:** One internal resolution relationship used later by explicit attachment or an
+  active parent branch.
+- **Ownership domain:** The plain configured context whose reference identity names one lifecycle
+  domain.
+- **Using context:** A context whose resolution depends on another context and must be invalidated
+  when that dependency changes.
+
+## Contract at a glance
+
+- A query pins one immutable state and takes no context mutation lock.
+- Resolution visits local services, public fallbacks in insertion order, then one ownership route.
+- Ordering attributes override route order only where they declare a dependency.
+- Repeated contexts and service instances are returned once according to the existing visited and
+  distinct rules.
+- Services, fallbacks, the ownership route, delegation, and caches belong to one published state.
+- A route change compares the exact previous descriptor instance before it publishes.
+- Reverse dependency registration remains while either a fallback or ownership route uses a target.
+- Topology changes publish a cache-free state and invalidate every upstream using context.
+- Traversal and invalidation are iterative and terminate on cyclic graphs.
+
+## Immutable state and publication
+
+Route-free contexts use the existing `ContextState`. A context with an ownership route uses a
+derived state containing one immutable route descriptor. The descriptor contains the target and
+ownership-domain references and also serves as the transition generation token.
+
+Mutators serialize on one context's mutation lock, build the complete replacement state, register a
+new reverse dependency before publication, publish once, conditionally remove the old reverse
+dependency, and invalidate upstream contexts after releasing the mutation lock. Queries continue to
+use one volatile state read.
+
+## Resolution and delegation
+
+The service walk is depth-first. Each entered context contributes local services, then each public
+fallback, then its ownership route. The existing visited set cuts cycles and gives the earliest
+route to a repeated context precedence.
+
+An empty context delegates directly when it has one distinct target: one fallback, one ownership
+route, or both relationships to the same target. Different fallback and ownership targets require
+the normal service walk. A pure delegation cycle raises the existing delegation-cycle exception.
+
+## Reverse dependencies and invalidation
+
+`_usedByContexts` represents whether a source depends on a target, not how many relationship kinds
+connect them. Removing a fallback must retain the reverse entry while an ownership route still uses
+the target. Clearing a route must retain it while a fallback still uses the target.
+
+Registration occurs before publication so the reverse set is always a superset of the true using
+set. Conditional removal occurs after publication. An extra entry can cause a harmless invalidation;
+a missing entry can preserve a stale compiled chain and is forbidden.
+
+## Performance
+
+Route-free contexts keep the existing base state layout. Cached service queries and steady-state
+intercepted reads, writes, and invocations do not inspect an ownership descriptor. A route attempt
+allocates its descriptor before the exact comparison; only a successful route publication uses the
+derived routed state.
+
+Timing comparisons on a development machine are diagnostic. Final performance acceptance uses the
+stable benchmark machine and compares the exact pull request head with its exact base commit.
+```
+
+- [ ] **Step 2: Check documentation style and scope**
+
+Run:
+
+```bash
+rg -n -P "\x{2014}|TBD|TODO" docs/design/context-resolution.md
+git diff --check
+```
+
+Expected: `rg` has no matches and `git diff --check` has no output.
+
+- [ ] **Step 3: Commit the documentation**
+
+```bash
+git add docs/design/context-resolution.md
+git commit -m "Document internal context resolution"
+```
+
+## Task 3: Complete the PR 1 Release Gate
+
+**Files:**
+- Inspect only: all files changed since `868a4d109d53b24805c9ee180efbf5029ee12c1a`
+- Report only: this plan's ignored SDD task report and final controller handoff
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2 at a clean committed head.
+- Produces: reproducible local verification evidence, exact external benchmark handoff, and a merge-readiness verdict with no uncommitted product changes.
+
+- [ ] **Step 1: Verify worktree and diff hygiene**
+
+Run:
+
+```bash
+git status --short
+git diff --check 868a4d109d53b24805c9ee180efbf5029ee12c1a..HEAD
+git diff --name-only 868a4d109d53b24805c9ee180efbf5029ee12c1a..HEAD
+rg --files src -g '*.received.txt'
+```
+
+Expected: clean status; no diff-check output; no received snapshots; changed product files limited to Core context state, Core context tests, and internal documentation plus the approved roadmap, spec, and plan.
+
+- [ ] **Step 2: Verify the Core Public API snapshot**
+
+Run:
+
+```bash
+dotnet test src/Namotion.Interceptor.Tests/Namotion.Interceptor.Tests.csproj --filter "FullyQualifiedName~VerifyChecksTests.PublicApi"
+```
+
+Expected: exit 0, one passing Public API test, no received file, and no snapshot edit.
+
+- [ ] **Step 3: Run the complete focused Core suite**
+
+Run:
+
+```bash
+dotnet test src/Namotion.Interceptor.Tests/Namotion.Interceptor.Tests.csproj
+```
+
+Expected: exit 0 and zero failures.
+
+- [ ] **Step 4: Build the complete solution**
+
+Run:
+
+```bash
+dotnet build src/Namotion.Interceptor.slnx
+```
+
+Expected: exit 0 with zero warnings and zero errors. A timeout or a nonzero exit with zero diagnostics is recorded as an infrastructure problem, not accepted as a successful build.
+
+- [ ] **Step 5: Run the complete non-integration suite**
+
+Run:
+
+```bash
+dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"
+```
+
+Expected: exit 0 and zero failed tests across every project.
+
+- [ ] **Step 6: Verify package creation**
+
+Run:
+
+```bash
+dotnet pack src/Namotion.Interceptor.slnx --no-restore
+```
+
+Expected: exit 0 with zero warnings and zero errors.
+
+- [ ] **Step 7: Perform static allocation and hot-path analysis**
+
+Run:
+
+```bash
+git diff -U80 868a4d109d53b24805c9ee180efbf5029ee12c1a..HEAD -- src/Namotion.Interceptor/InterceptorSubjectContext.cs
+```
+
+Record evidence for each claim:
+
+- `InterceptorSubjectContext` has no new instance field.
+- Base `ContextState` has no new instance field.
+- Initial and route-free replacement states instantiate the base state.
+- `GetServices`, `ExecuteInterceptedRead`, `ExecuteInterceptedWrite`, and `ExecuteInterceptedInvoke` retain their current route-free instruction shape and contain no ownership-route type test.
+- The ownership-route type test occurs only during cold service traversal or mutation.
+- No route-free production path creates a descriptor or routed state.
+- The ownership-route transition executes no callback, factory, or public virtual method while
+  `_mutationLock` is held.
+
+Also record that PR 1 is an intentional small net production addition and identify each added block
+with its invariant. The combined PR 1 plus PR 2 review must later account for deleted fallback and
+lifecycle coupling, with no temporary compatibility bridge retained.
+
+If source inspection cannot settle an instruction-level difference, produce diffable JIT output for both exact commits using the procedure in `docs/benchmarking.md`. Do not infer from timing noise.
+
+- [ ] **Step 8: Record the external stable-machine benchmark handoff**
+
+Record the exact outputs of:
+
+```bash
+git rev-parse 868a4d109d53b24805c9ee180efbf5029ee12c1a
+git rev-parse HEAD
+```
+
+Ask the maintainer before handing off this comparison from a worktree outside the repository:
+
+```powershell
+pwsh scripts/benchmark.ps1 -Filter "*ContextDelegationDepthBenchmark*","*SubjectHierarchyBenchmark*","*ServiceOrderResolverBenchmark.LinearChain*" -LaunchCount 3 -BaseBranch 868a4d109d53b24805c9ee180efbf5029ee12c1a
+```
+
+`ServiceOrderResolverBenchmark.LinearChain` is the noise reference because its class setup does not create subjects or contexts. Final acceptance is no repeatable timing regression outside contemporaneous control-row noise and no new steady-state allocation. Do not run or trust the final timing gate on this development machine.
+
+- [ ] **Step 9: Recheck final hygiene and report the gate honestly**
+
+Run:
+
+```bash
+git status --short
+git diff --check 868a4d109d53b24805c9ee180efbf5029ee12c1a..HEAD
+rg --files src -g '*.received.txt'
+```
+
+Report exact commands, exit codes, test totals, current head, base, static performance findings, and whether the external stable-machine result is pending. Do not call the pull request fully performance-verified until the maintainer supplies that result.

--- a/docs/superpowers/specs/2026-08-17-effective-ownership-route-state-design.md
+++ b/docs/superpowers/specs/2026-08-17-effective-ownership-route-state-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-17
 
-**Status:** Draft for written-spec review
+**Status:** Approved
 
 **Stack position:** PR 1 on `master`
 
@@ -158,9 +158,10 @@ change.
 
 ### Empty-state behavior
 
-`ContextState.IsEmpty` remains a direct check over existing fields plus the derived delegation
-result. A routed state is never treated as empty. Route-only contexts delegate before service-cache
-lookup and therefore do not allocate a service cache on the source state.
+`ContextState.IsEmpty` keeps its existing direct check over services and public fallbacks, with no
+new route-free branch. A route-only state has a delegation target and is resolved before
+`GetServicesFromState` reaches the empty-state check. It therefore does not allocate a service cache
+on the source state. This caller invariant is documented next to that check.
 
 ## Reverse Dependency and Invalidation
 
@@ -195,8 +196,9 @@ stale and is therefore forbidden.
 - Reverse using-set locks remain leaf locks. No path takes a second context mutation lock.
 - Route construction and state construction happen before publication. An allocation failure leaves
   the old state and relationships unchanged.
-- No user code, service factory, lifecycle callback, or virtual context method executes while the
-  mutation lock is held.
+- The ownership-route transition executes no user code, service factory, lifecycle callback, or
+  virtual context method while the mutation lock is held. Existing service registration semantics
+  are outside this statement.
 - Internal route graphs use the existing visited sets and iterative worklists. Cycles terminate and
   deep graphs do not recurse.
 

--- a/docs/superpowers/specs/2026-08-17-effective-ownership-route-state-design.md
+++ b/docs/superpowers/specs/2026-08-17-effective-ownership-route-state-design.md
@@ -1,0 +1,273 @@
+# Effective Ownership-Route State Design
+
+**Date:** 2026-08-17
+
+**Status:** Draft for written-spec review
+
+**Stack position:** PR 1 on `master`
+
+## Purpose
+
+The final lifecycle model needs one effective ownership route per subject executor, separate from
+public fallback composition. Introducing attachment callbacks before the complete root and property
+membership ledger exists would create a transitional model that cannot safely handle reentrancy,
+plural lifecycle interceptors, or attach and final-detach races.
+
+PR 1 therefore adds only the permanent Core context-state mechanism. It can represent and resolve
+one internal ownership route, but no production code installs a route yet. Existing lifecycle and
+fallback behavior remains unchanged until PR 2 lands the complete semantic change.
+
+## Concepts and Terms
+
+- **Fallback composition:** a public context relationship created by `AddFallbackContext`. On
+  `master`, `InterceptorExecutor` also gives it lifecycle side effects. PR 1 does not change those
+  side effects.
+- **Ownership route:** one internal context-resolution relationship that PR 2 will use for explicit
+  attachment or the active parent branch. It is stored separately from fallbacks.
+- **Ownership domain:** a plain configured context whose reference identity names one lifecycle
+  domain. An inherited route can target a parent executor while retaining the root configured
+  context as its domain identity.
+- **Route descriptor:** one immutable object holding the route target and ownership-domain identity.
+  The descriptor's own reference identity is the generation token used for exact transitions.
+- **Using context:** a context whose resolution depends on another context. Reverse using-context
+  registration drives downstream cache invalidation.
+
+## Goals
+
+- Represent one ownership route independently from public fallbacks.
+- Publish the complete route atomically with the immutable context state.
+- Resolve local services, public fallbacks, then the ownership route.
+- Keep public composition and ownership-route relationships independently removable when they
+  target the same context.
+- Prevent a stale clear from removing a later same-target route generation.
+- Preserve delegation, repeated-path deduplication, cycle termination, deep-graph safety, and
+  downstream invalidation.
+- Keep existing route-free context objects and states at their current instance size.
+- Add no public API and change no production behavior.
+
+## Non-goals
+
+- Adding subject attachment APIs.
+- Making fallbacks composition-only.
+- Calling lifecycle interceptors through the new route.
+- Changing generated or dynamic constructors.
+- Changing Tracking, Registry, connectors, OPC UA, Hosting, or HomeBlaze.
+- Defining root and property membership or parent transfer.
+- Enforcing a single ownership domain or unique context authorities.
+- Freezing any context mutation.
+- Renaming or separating `InterceptorExecutor` from `IInterceptorSubjectContext`.
+
+## Architecture
+
+### Immutable route descriptor
+
+Core adds a nested internal immutable descriptor with exactly two fields:
+
+```csharp
+internal sealed class ContextOwnershipRoute
+{
+    internal ContextOwnershipRoute(
+        InterceptorSubjectContext target,
+        InterceptorSubjectContext ownershipDomain);
+
+    internal InterceptorSubjectContext Target { get; }
+
+    internal InterceptorSubjectContext OwnershipDomain { get; }
+}
+```
+
+Both references are required. The descriptor object is also the transition generation. A later
+route that happens to use the same target and domain has a different descriptor identity, so an old
+operation cannot clear it accidentally.
+
+The descriptor does not contain lifecycle callbacks, parent references, reference counts, or
+reservations. Those belong to PR 2's ownership ledger.
+
+### Route-free and routed context states
+
+The existing `ContextState` remains the route-free state representation. It keeps the same instance
+fields and therefore the same object size. It becomes a base class for a private routed state that
+adds exactly one descriptor reference:
+
+```csharp
+private sealed class RoutedContextState : ContextState
+{
+    internal readonly ContextOwnershipRoute OwnershipRoute;
+}
+```
+
+A factory creates `ContextState` when no route exists and `RoutedContextState` when a route exists.
+Every service, fallback, invalidation, and cache-reset publication preserves the current descriptor.
+No separate mutable route field exists on the context.
+
+This shape has two purposes:
+
+1. services, fallbacks, the route, delegation, and all derived caches are one atomically published
+   snapshot;
+2. contexts that never receive an ownership route pay no extra state bytes and allocate no route
+   descriptor.
+
+### Internal transition
+
+Core exposes one internal compare-by-descriptor operation:
+
+```csharp
+internal bool TryChangeOwnershipRoute(
+    ContextOwnershipRoute? expected,
+    ContextOwnershipRoute? replacement);
+```
+
+The operation linearizes under the context's existing mutation lock:
+
+- install uses `expected: null` and a new descriptor;
+- transfer uses the exact current descriptor as `expected` and a new descriptor as `replacement`;
+- clear uses the exact current descriptor as `expected` and `replacement: null`;
+- an identity mismatch returns `false` without publication or invalidation;
+- passing the same descriptor as expected and replacement returns `true` as a no-op.
+
+The descriptor constructor and transition remain internal. PR 1 tests are their only caller. PR 2's
+ownership ledger becomes the production caller without changing this contract.
+
+## Resolution Semantics
+
+For every entered context, service traversal remains depth-first and gathers in this order:
+
+1. services on the entered context;
+2. public fallback contexts in insertion order;
+3. the ownership-route target, when present.
+
+The existing visited set deduplicates contexts reached through repeated paths. If a public fallback
+and the ownership route target the same context, its services appear once at the public fallback's
+earlier position.
+
+Ordering attributes continue to reorder the gathered services by declared dependencies. Route
+order breaks only otherwise unconstrained ties.
+
+### Delegation
+
+An empty context can delegate directly when its distinct reachable target is exactly one context:
+
+- one public fallback and no ownership route delegates to that fallback as today;
+- one ownership route and no public fallback delegates to the route target;
+- one public fallback and an ownership route to the same target delegate to that target;
+- different public-fallback and ownership-route targets require the normal service walk.
+
+The existing resolved-terminal cache remains attached to the immutable state. Route publication
+creates a cache-free state, so a terminal recorded from an older topology cannot survive a route
+change.
+
+### Empty-state behavior
+
+`ContextState.IsEmpty` remains a direct check over existing fields plus the derived delegation
+result. A routed state is never treated as empty. Route-only contexts delegate before service-cache
+lookup and therefore do not allocate a service cache on the source state.
+
+## Reverse Dependency and Invalidation
+
+The target context's existing `_usedByContexts` set records a boolean dependency, not a relationship
+count. PR 1 preserves this representation and makes registration depend on the union of public
+fallbacks and the ownership route.
+
+For a route install or transfer:
+
+1. register the source in the new target's using set before publishing the new state;
+2. publish the new immutable state;
+3. remove the source from the old target only when the published state has no fallback and no
+   ownership route to that old target;
+4. invalidate every context that resolves through the source.
+
+For fallback removal, the source remains registered in the target while an ownership route still
+targets it. For route removal, it remains registered while a public fallback still targets it.
+
+This keeps the using set a superset of the true dependency set through every transition. An extra
+entry can cause a harmless invalidation. A missing entry can leave a compiled chain permanently
+stale and is therefore forbidden.
+
+## Concurrency and Failure Semantics
+
+- The existing `_mutationLock` serializes services, fallbacks, and ownership-route transitions for
+  one context.
+- Queries take no context lock. They pin one immutable state with the existing volatile read.
+- A route descriptor and all its fields become visible in one state publication. Readers cannot
+  observe a target without its domain identity or the reverse.
+- The exact expected descriptor prevents an old clear or transfer from acting on a later route
+  generation, including a later generation with the same target and domain.
+- Reverse using-set locks remain leaf locks. No path takes a second context mutation lock.
+- Route construction and state construction happen before publication. An allocation failure leaves
+  the old state and relationships unchanged.
+- No user code, service factory, lifecycle callback, or virtual context method executes while the
+  mutation lock is held.
+- Internal route graphs use the existing visited sets and iterative worklists. Cycles terminate and
+  deep graphs do not recurse.
+
+## Public and Consumer Behavior
+
+PR 1 adds no public type, member, or capability. `IInterceptorSubjectContext`, generated code,
+`InterceptorExecutor`, and all feature packages behave as on `master` because no production path
+creates an ownership route.
+
+Public API snapshots must remain unchanged. Existing binaries and generated model assemblies do not
+need rebuilding specifically for PR 1.
+
+## Performance Contract
+
+For a route-free context:
+
+- `InterceptorSubjectContext` instance fields do not change;
+- the base `ContextState` instance fields and object size do not change;
+- initial state, service mutation, fallback mutation, and cache invalidation allocate the same state
+  shape as `master`;
+- steady-state intercepted read, write, invoke, delegation, and cached service-resolution paths do
+  not inspect a route descriptor or allocate new objects;
+- first uncached service traversal performs at most one routed-state type check per entered context.
+
+Route-free production paths allocate no descriptor. Each attempted replacement supplies one
+descriptor, including an attempt that loses the expected-descriptor comparison. Only a successful
+route publication uses the one-reference-larger routed state. PR 2 must compare that cost with the
+one-element fallback representation it replaces.
+
+Local verification uses static layout and hot-path inspection. Local benchmark timings are
+diagnostic only. Before PR finalization, the maintainer runs the approved comparison against the
+exact base commit on the stable benchmark machine. The acceptance criterion is no repeatable timing
+regression outside control-row noise and no new steady-state allocation.
+
+## Test Design
+
+Core tests cover:
+
+- route-only resolution;
+- local, fallback, then route ordering;
+- ordering attributes across all routes;
+- repeated target deduplication when fallback and route share a target;
+- independent removal in both orders when fallback and route share a target;
+- downstream cache invalidation after service mutation through the relationship that remains;
+- route transfer and exact-descriptor stale-clear rejection;
+- route-only delegation and delegation-cache invalidation;
+- cycles containing fallbacks and ownership routes;
+- a deep route chain without recursion;
+- concurrent route install, transfer, clear, service resolution, and downstream invalidation;
+- unchanged public API snapshots;
+- unchanged focused and full non-integration suites.
+
+Tests follow repository naming and Arrange, Act, Assert conventions. Deterministic concurrency tests
+use barriers or events rather than hardcoded waits.
+
+## Documentation
+
+PR 1 adds `docs/design/context-resolution.md` with an introduction, the terms used by that document,
+the route-order and publication invariants, and the cache/invalidation mechanics. It describes the
+ownership route as an internal foundation not yet used by public attachment.
+
+User-facing attachment and lifecycle documentation does not change until PR 2 changes public
+semantics. PR 2 makes `docs/interceptor.md` the canonical user-facing ownership and context model and
+cross-references it from affected feature pages.
+
+## Release Boundary
+
+PR 1 is independently releasable and behavior-neutral for consumers. Its diff is limited to Core
+context state and traversal, focused Core tests, the internal design document, and the roadmap. It
+does not touch source generation, Tracking, Registry, Hosting, connectors, OPC UA, or HomeBlaze.
+
+PR 2 can use the internal descriptor and transition without replacing them. PR 3 adds authority
+validation around the established ownership route. PR 4 consumes the resulting ownership and
+authority contracts.

--- a/docs/superpowers/specs/2026-08-17-single-effective-context-stack-roadmap.md
+++ b/docs/superpowers/specs/2026-08-17-single-effective-context-stack-roadmap.md
@@ -314,6 +314,11 @@ Each pull request:
 9. records the exact head and base commits for external performance verification;
 10. asks the maintainer before handing benchmark work to the stable external machine.
 
+PR 1 is expected to be a small internal net addition. The combined PR 1 plus PR 2 review also
+includes a production simplification audit. Every new production block must enforce a named
+invariant, legacy fallback and lifecycle coupling must be deleted, and no compatibility bridge or
+temporary multi-domain recovery path may survive into the pair.
+
 Local benchmark timing is diagnostic only on the development machine. It can catch an obvious
 regression but does not accept or reject a performance change.
 

--- a/docs/superpowers/specs/2026-08-17-single-effective-context-stack-roadmap.md
+++ b/docs/superpowers/specs/2026-08-17-single-effective-context-stack-roadmap.md
@@ -1,0 +1,346 @@
+# Single Effective Context Stack Roadmap
+
+**Date:** 2026-08-17
+
+**Status:** Approved direction, detailed designs are approved one pull request at a time
+
+## Purpose
+
+Namotion.Interceptor currently uses fallback contexts for three separate jobs:
+
+1. composing services;
+2. attaching a subject to lifecycle handling;
+3. inheriting a parent subject's effective context.
+
+That overlap lets one local topology mutation change service resolution, lifecycle ownership,
+reference-derived membership, cache invalidation, and authority selection at the same time. The
+result is difficult to make atomic and difficult for consumers to understand.
+
+This roadmap separates those responsibilities into four stacked, independently releasable pull
+requests:
+
+```text
+master
+  -> PR 1: internal effective ownership-route state
+       -> PR 2: explicit attachment and one effective ownership route (#419 rewrite)
+            -> PR 3: stable unique authorities (#472 rewrite)
+                 -> PR 4: hosted lifecycle coordination (#440 rewrite)
+```
+
+The current experimental #419, #472, and #440 branches remain sources of tests and reproduced
+schedules. Their production implementations are not transplanted wholesale.
+
+PR 1 is intentionally behavior-neutral. It lands only the permanent context-resolution mechanism
+needed by PR 2. PR 2 then changes attachment and inheritance as one complete semantic unit. This
+avoids a transitional lifecycle model that would be unsafe with plural lifecycle interceptors and
+would be removed by the next pull request.
+
+## Shared Model
+
+### Separate concepts
+
+The final model keeps four concepts distinct:
+
+- **Object-reference graph:** relationships formed by subject-valued properties, collections, and
+  dictionaries. The object model is the source of truth for these edges.
+- **Lifecycle ownership:** the lifecycle domain responsible for a subject. Explicit attachment can
+  establish ownership while the subject has no incoming property reference and a reference count
+  of zero. Property references can establish or retain inherited ownership.
+- **Context resolution:** services and interceptors registered on the subject executor, public
+  composition fallbacks, and the subject's one effective ownership route.
+- **Registry projection:** an optional index of lifecycle-owned subjects and their
+  object-reference relationships. It observes lifecycle changes. It does not create ownership and
+  is not the source of truth for the object graph.
+
+One ownership domain may manage several disconnected explicit roots. They share lifecycle,
+registry, transaction, and hosting authorities without becoming one object-reference graph.
+
+### Subject executor
+
+Every subject keeps its own `InterceptorExecutor`. The executor remains an
+`IInterceptorSubjectContext` and holds subject-local interception state and services. A child does
+not replace its executor with the parent's context. Instead, its one effective ownership route
+points through the active parent executor, which lets subject-local branch services flow to that
+subject and its descendants.
+
+The current type and public names remain unchanged. Separating or renaming the executor would add
+API and generator churn without simplifying the ownership model.
+
+### Context relationships
+
+The final model distinguishes three relationships:
+
+- **Explicit root attachment:** intentionally gives one subject root ownership in a supplied plain
+  configured context.
+- **Branch inheritance:** gives a subject one effective route from its active parent branch when
+  explicit root ownership does not supply the route.
+- **Fallback composition:** explicitly aggregates services and interceptors. It has no lifecycle
+  meaning.
+
+Each subject has at most one effective ownership route. An explicit root owns it when present.
+Otherwise, the earliest surviving compatible parent reference owns it. Public fallback composition
+never owns or changes lifecycle membership.
+
+The plain configured context supplied to explicit root attachment is the ownership-domain identity
+token, compared by reference. Descendants copy that identity even though their effective route
+targets a distinct parent executor. Several parents are compatible only when they carry the same
+identity.
+
+### Service resolution
+
+Resolution gathers services in this route order:
+
+1. services registered on the current context;
+2. explicitly composed fallback contexts;
+3. the one effective ownership route, when present.
+
+Ordering attributes apply across the complete gathered service set. Route order breaks only ties
+that have no declared dependency.
+
+Nonunique services can aggregate from all reachable paths. This preserves branch interceptors,
+ordered lifecycle handlers, and other intentionally plural facilities. Reaching the same service
+instance through several paths still produces it once.
+
+### Runtime mutation and performance
+
+Late nonunique service registration remains supported. Adding one publishes a new immutable context
+state and invalidates dependent compiled chains as it does today.
+
+PR 3 makes authority-bearing configuration stable after activation. A fresh branch can still link
+to an active parent, and lifecycle transitions can change the one internal ownership route.
+
+The stable path does not run an invalidation walk. Steady-state intercepted reads, writes, method
+invocations, and cached service resolution remain allocation-free apart from work already required
+by configured interceptors.
+
+## Pull Request 1: Internal Effective Ownership-Route State
+
+### Contract
+
+Core can represent one internal ownership route independently from public fallback composition.
+The route participates in service resolution, delegation, cycle handling, and reverse cache
+invalidation. No production code creates such a route in this pull request.
+
+### Included
+
+- Add one immutable internal route descriptor containing a target context and ownership-domain
+  identity.
+- Publish the descriptor as part of the same immutable context state as services and fallbacks.
+- Keep route-free contexts on the existing base state shape. Allocate the derived routed state only
+  for a successful route publication. Route-free production paths create no route descriptors.
+- Add an internal compare-by-descriptor transition that can install, transfer, or clear a route
+  without an ABA-prone context-only clear.
+- Resolve the ownership route after public fallbacks.
+- Keep public composition and the internal route independently removable even when both target the
+  same context.
+- Preserve reverse invalidation until the final relationship to a target is removed.
+- Cover ordering, repeated paths, delegation, cycles, deep graphs, invalidation, and concurrent
+  route changes.
+- Add an internal context-resolution design document using the agreed terminology.
+
+### Capability removed
+
+None. There is no public API change and no production caller of the new internal route transition.
+Fallback composition and current lifecycle behavior remain unchanged.
+
+### Release contract
+
+PR 1 is independently releasable as an internal foundation. Existing binaries and generated models
+continue to behave as on `master`. Public API snapshots do not change.
+
+## Pull Request 2: Explicit Attachment and One Effective Ownership Route
+
+### Contract
+
+Fallback composition has no lifecycle meaning. A subject has at most one explicit root attachment,
+one lifecycle-ownership domain, and one effective ownership route. Root membership and
+property-reference membership are represented separately and reconciled through one permanent
+ledger and reservation protocol.
+
+### Included
+
+- Add explicit `AttachToContext`, `DetachFromContext`, and `TryGetAttachContext` subject APIs.
+- Make `AddFallbackContext` and `RemoveFallbackContext` pure service composition operations.
+- Capture the successful lifecycle authority sequence for explicit attachment and use it for
+  detach.
+- Replace Tracking's empty-property-set root sentinel with separate explicit-root and property-edge
+  membership.
+- Add the complete ordered parent-reference ledger, generation-aware transition state, and
+  prospective reservation before any property value commits.
+- Support several parent references only when they share one ownership-domain identity.
+- Keep the earliest surviving compatible parent active and transfer deterministically when its
+  final reference disappears.
+- Keep explicit root ownership active when compatible parent references exist. Transfer to a
+  surviving parent without final lifecycle-detach callbacks when the root is removed.
+- Reject incompatible root or parent ownership before lifecycle membership changes or an
+  incompatible property value commits.
+- Preserve subject-local services and interceptors as branch overlays for the subject and its
+  descendants.
+- Update generated and dynamic constructors, first-party root call sites, connectors, OPC UA, and
+  HomeBlaze in the same coordinated change.
+- Publish connector-created children through the parent edge before recursive population and
+  verify the committed child before continuing.
+- Preserve the ordinary callback sequence for successful single-context consumers.
+- Update user-facing context, lifecycle, registry, connector, and migration documentation that the
+  semantic change affects.
+
+### Capability removed
+
+- Adding or removing a fallback no longer attaches or detaches a subject.
+- A subject can no longer use several fallback calls as several lifecycle roots.
+- Public fallback composition no longer establishes property inheritance.
+- A subject can no longer aggregate unrelated parent ownership domains or all parent branch
+  overlays.
+- Reparenting into an incompatible ownership domain no longer succeeds temporarily.
+- A property-child factory can no longer return a child already owned by an incompatible route.
+- Explicit attachment to another subject executor is rejected. Explicit roots attach to a plain
+  configured context; property children inherit through their parent.
+
+Fallback composition, cycles, repeated service paths, nonunique services, late nonunique service
+registration, and branch-local services remain supported.
+
+### Release contract
+
+PR 2 is independently releasable on PR 1 as a coordinated binary-semantic breaking release. The
+runtime, source generator, Dynamic package, connectors, OPC UA loader, and HomeBlaze call sites ship
+together. Consumer model assemblies generated against the old constructor behavior must be rebuilt.
+
+PR 2 is the complete #419 replacement. It does not depend on the unique-authority marker or hosting
+changes.
+
+## Pull Request 3: Stable Unique Authorities
+
+### Contract
+
+Every active effective context exposes at most one distinct instance per declared authority
+contract, and an authority-bearing mutation cannot publish an invalid active topology.
+
+### Included
+
+- Introduce `IUniqueContextService<TContract>`.
+- Validate authority identity across the complete effective context using reference identity.
+- Allow the same instance through repeated paths.
+- Mark lifecycle, registry, transaction, and other individually audited authority services unique.
+- Make authority-establishing configuration helpers reject incompatibility before factories or
+  other side effects run.
+- Audit every built-in `WithX()` helper and every first-party composition site.
+- Preserve intentionally plural facilities such as source monitors without manufacturing several
+  lifecycle authorities.
+- Freeze only mutations that would change an active unique-authority map.
+- Keep late nonunique additions and their normal invalidation behavior legal.
+- Move first-party late authority configuration to bootstrap before activation.
+
+### Capability removed
+
+- An effective context can no longer expose two distinct instances of one unique authority
+  contract.
+- Unique authorities can no longer be added, replaced, or introduced through a new route after the
+  affected context is active.
+- Feature helpers that establish an authority can no longer be used late.
+
+Independent ownership domains may still use different authorities. Nonunique branch services and
+interceptors remain mutable.
+
+### Release contract
+
+PR 3 is independently releasable on PR 2. It replaces #472 and settles the transaction-authority
+ambiguity tracked by issue #466. It does not change hosted-service behavior.
+
+## Pull Request 4: Hosted Lifecycle Coordination
+
+### Contract
+
+One hosting authority per ownership domain serializes start and stop for each hosted target and
+defines one atomic drain boundary for host shutdown.
+
+### Included
+
+- Mark the hosting handler as the ownership domain's unique hosting authority.
+- Serialize transitions per hosted target while allowing unrelated targets to progress
+  concurrently.
+- Define awaited attach, awaited detach, refusal, cancellation, failure, and drain completion.
+- Take the drain snapshot under the same lock that accepts target starts.
+- Observe and log drain and cancellation-callback failures without losing the shared drain.
+- Preserve caller ownership of hosted-service instances and subject objects.
+- Keep public factory APIs out until a production consumer ships with them.
+
+### Capability removed
+
+- Several hosting handlers can no longer compete for one target inside one ownership domain.
+- A target start is no longer accepted after draining begins.
+- Accidental handler-wide ordering across unrelated targets is not a contract.
+
+### Release contract
+
+PR 4 is independently releasable on PR 3. It replaces #440 and changes only hosted lifecycle
+coordination plus the small tracking seam required for already-attached targets.
+
+## Documentation Strategy
+
+Documentation evolves with the behavior it describes:
+
+| Pull request | Documentation outcome |
+| --- | --- |
+| PR 1 | Add the internal context-resolution terms, invariants, route order, and cache rules. |
+| PR 2 | Make `docs/interceptor.md` the canonical user-facing ownership and context model. Explain explicit roots, property membership, reference counts, parent transfer, composition-only fallbacks, and migration. |
+| PR 3 | Explain unique authorities, activation, mutation restrictions, and helper configuration timing. |
+| PR 4 | Explain one hosting authority, per-target transitions, signalling, cancellation, and drain. |
+
+Affected user-facing feature documents use this lightweight structure:
+
+1. an opening paragraph stating what the feature does and when to use it;
+2. a short **Concepts and terms** list containing only vocabulary used by that document;
+3. a short **Contract at a glance** list stating important guarantees and limits;
+4. detailed setup, behavior, examples, and edge cases;
+5. links to the canonical model instead of repeating its complete glossary.
+
+Internal documents under `docs/design/` use purpose, terms, invariants, and mechanics. Each pull
+request restructures only documents it materially changes. After PR 4, a repository-wide audit can
+identify unrelated legacy pages for a dedicated documentation change.
+
+## Review, Verification, and Delivery
+
+Each pull request:
+
+1. receives an approved detailed design and implementation plan before production changes;
+2. is implemented test-first from the preceding exact base commit;
+3. preserves callback-order characterization unless its design explicitly changes the contract;
+4. runs focused consumer suites, Public API snapshots, and the full non-integration suite;
+5. runs connector integration and Connector Tester coverage when connector behavior changes, with
+   the exact long-running scope agreed during that pull request's planning;
+6. receives an independent whole-PR review;
+7. updates its title and body to describe only its actual scope;
+8. completes local static hot-path and allocation analysis;
+9. records the exact head and base commits for external performance verification;
+10. asks the maintainer before handing benchmark work to the stable external machine.
+
+Local benchmark timing is diagnostic only on the development machine. It can catch an obvious
+regression but does not accept or reject a performance change.
+
+The final performance acceptance criterion for every pull request is:
+
+> For the normal one-global-context use case, the pull request introduces no repeatable performance
+> regression relative to its exact base commit. Steady-state intercepted reads, scalar writes,
+> method invocations, and cached service resolution add no allocations. Targeted comparisons on
+> the stable benchmark machine show no repeatable timing regression outside contemporaneous
+> control-row noise. A regression above noise requires explicit maintainer approval.
+
+The maintainer supplies the external benchmark result before a pull request is finalized. PR 1's
+route-free state shape and hot paths also receive static inspection because the new route has no
+production caller yet.
+
+## Whole-Stack Success Criteria
+
+The stack is complete when:
+
+- one-global-context and HomeBlaze consumers retain expected behavior;
+- branch-local services and interceptors reach descendants and remain sibling-isolated;
+- fallback composition never invokes lifecycle callbacks;
+- every subject has at most one explicit root attachment and one effective ownership route;
+- active effective contexts cannot publish conflicting unique authorities;
+- late nonunique services continue to invalidate dependent caches;
+- hosted targets have deterministic start, stop, detach, cancellation, and drain completion;
+- documentation consistently distinguishes object-reference relationships, lifecycle ownership,
+  context resolution, ownership domains, and registry projection;
+- stable property and service access remains allocation-free apart from configured interceptor
+  work.

--- a/src/Namotion.Interceptor.Tests/Context/ContextDeepGraphTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextDeepGraphTests.cs
@@ -228,6 +228,36 @@ public class ContextDeepGraphTests
         Assert.NotSame(stateBefore, GetState(usingContext));
     }
 
+    [Fact]
+    public void WhenOwnershipRouteChainIsVeryDeep_ThenResolutionAndInvalidationRemainIterative()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var rootContext = InterceptorSubjectContext.Create();
+        rootContext.AddService(new MarkerService());
+
+        var deepestContext = rootContext;
+        for (var index = 0; index < ChainLength; index++)
+        {
+            var context = InterceptorSubjectContext.Create();
+            var route = new InterceptorSubjectContext.ContextOwnershipRoute(deepestContext, ownershipDomain);
+            Assert.True(context.TryChangeOwnershipRoute(null, route));
+            deepestContext = context;
+        }
+
+        Assert.Single(deepestContext.GetServices<MarkerService>());
+
+        // Act
+        rootContext.AddService(new MarkerService());
+
+        // Assert
+        Assert.Equal(2, deepestContext.GetServices<MarkerService>().Length);
+        Assert.Null(GetThreadStaticBuffer("_delegationCyclePath"));
+        Assert.Null(GetThreadStaticBuffer("_delegationCycleVisited"));
+        Assert.Null(GetThreadStaticBuffer("_invalidationVisited"));
+        Assert.Null(GetThreadStaticBuffer("_invalidationPending"));
+    }
+
     private sealed class MarkerService;
 
     private sealed class OtherMarkerService;

--- a/src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs
@@ -231,7 +231,7 @@ public class ContextOwnershipRouteTests
     }
 
     [Fact]
-    public void WhenOwnershipRoutesFormDelegationCycle_ThenResolutionThrows()
+    public void WhenOwnershipRoutesFormDelegationCycle_ThenExceptionGuidesToRemoveOwnershipRoute()
     {
         // Arrange
         var ownershipDomain = InterceptorSubjectContext.Create();
@@ -248,6 +248,7 @@ public class ContextOwnershipRouteTests
 
         // Assert
         Assert.Contains("delegation cycle", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("ownership-route registration", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -286,11 +287,18 @@ public class ContextOwnershipRouteTests
                 }, TaskCreationOptions.LongRunning)
             };
 
-            // Act
-            await AsyncTestHelpers.WaitUntilAsync(
-                () => installers.All(installer => installer.IsCompleted),
-                message: $"Concurrent ownership-route installation did not complete on attempt {attempt}");
-            await Task.WhenAll(installers);
+            // Act: event-driven so completed attempts do not wait for a polling interval, while
+            // the timeout still turns a deadlock into a useful failure.
+            try
+            {
+                await Task.WhenAll(installers).WaitAsync(TimeSpan.FromSeconds(15));
+            }
+            catch (TimeoutException exception)
+            {
+                throw new TimeoutException(
+                    $"Concurrent ownership-route installation did not complete on attempt {attempt} of {attempts}.",
+                    exception);
+            }
 
             // Assert
             Assert.NotEqual(results[0], results[1]);
@@ -338,11 +346,18 @@ public class ContextOwnershipRouteTests
                 }, TaskCreationOptions.LongRunning)
             };
 
-            // Act
-            await AsyncTestHelpers.WaitUntilAsync(
-                () => transfers.All(transfer => transfer.IsCompleted),
-                message: $"Concurrent ownership-route transfer did not complete on attempt {attempt}");
-            await Task.WhenAll(transfers);
+            // Act: event-driven so completed attempts do not wait for a polling interval, while
+            // the timeout still turns a deadlock into a useful failure.
+            try
+            {
+                await Task.WhenAll(transfers).WaitAsync(TimeSpan.FromSeconds(15));
+            }
+            catch (TimeoutException exception)
+            {
+                throw new TimeoutException(
+                    $"Concurrent ownership-route transfer did not complete on attempt {attempt} of {attempts}.",
+                    exception);
+            }
 
             // Assert
             Assert.NotEqual(results[0], results[1]);

--- a/src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs
@@ -252,6 +252,33 @@ public class ContextOwnershipRouteTests
     }
 
     [Fact]
+    public void WhenSharedTargetFallbackAndOwnershipRoutesFormDelegationCycle_ThenExceptionGuidesToRemoveBothRegistrations()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var contextA = InterceptorSubjectContext.Create();
+        var contextB = InterceptorSubjectContext.Create();
+        contextA.AddFallbackContext(contextB);
+        contextB.AddFallbackContext(contextA);
+        Assert.True(contextA.TryChangeOwnershipRoute(
+            null,
+            new InterceptorSubjectContext.ContextOwnershipRoute(contextB, ownershipDomain)));
+        Assert.True(contextB.TryChangeOwnershipRoute(
+            null,
+            new InterceptorSubjectContext.ContextOwnershipRoute(contextA, ownershipDomain)));
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => contextA.GetServices<IRouteService>());
+
+        // Assert
+        Assert.Contains(
+            "both the fallback-context and ownership-route registrations from a shared-target hop",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task WhenTwoThreadsInstallFirstRoute_ThenExactlyOneDescriptorWins()
     {
         const int attempts = 500;

--- a/src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextOwnershipRouteTests.cs
@@ -1,0 +1,459 @@
+using Namotion.Interceptor.Testing;
+
+using static Namotion.Interceptor.Tests.Context.ContextStateReflection;
+
+namespace Namotion.Interceptor.Tests.Context;
+
+public class ContextOwnershipRouteTests
+{
+    [Fact]
+    public void WhenOwnershipRouteIsInstalled_ThenServicesResolveAfterFallbacks()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var routeTarget = InterceptorSubjectContext.Create();
+        routeTarget.AddService<IRouteService>(new RouteService("route"));
+
+        var fallback = InterceptorSubjectContext.Create();
+        fallback.AddService<IRouteService>(new RouteService("fallback"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        context.AddFallbackContext(fallback);
+
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(routeTarget, ownershipDomain);
+
+        // Act
+        var installed = context.TryChangeOwnershipRoute(null, route);
+        var names = context.GetServices<IRouteService>().Select(service => service.Name).ToArray();
+
+        // Assert
+        Assert.True(installed);
+        Assert.Equal(["local", "fallback", "route"], names);
+    }
+
+    [Fact]
+    public void WhenFallbackAndOwnershipRouteShareTarget_ThenTargetServicesResolveOnce()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        var service = new RouteService("target");
+        target.AddService<IRouteService>(service);
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddFallbackContext(target);
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+
+        // Act
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        var services = context.GetServices<IRouteService>();
+
+        // Assert
+        Assert.Single(services);
+        Assert.Same(service, services[0]);
+    }
+
+    [Fact]
+    public void WhenOldDescriptorClearsSameTargetGeneration_ThenNewGenerationRemains()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target"));
+        var context = InterceptorSubjectContext.Create();
+
+        var first = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        var second = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, first));
+        Assert.True(context.TryChangeOwnershipRoute(first, second));
+
+        // Act
+        var staleClear = context.TryChangeOwnershipRoute(first, null);
+
+        // Assert
+        Assert.False(staleClear);
+        Assert.Single(context.GetServices<IRouteService>());
+        Assert.True(context.TryChangeOwnershipRoute(second, null));
+        Assert.Empty(context.GetServices<IRouteService>());
+    }
+
+    [Fact]
+    public void WhenServicesAreAddedReentrantlyAfterRouteInstall_ThenRouteSurvivesEveryStatePublication()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("route"));
+
+        var context = InterceptorSubjectContext.Create();
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+
+        // Act
+        var added = context.TryAddService<IRouteService>(
+            () =>
+            {
+                context.AddService<IRouteService>(new RouteService("reentrant"));
+                return new RouteService("added");
+            },
+            _ => false);
+
+        var names = context.GetServices<IRouteService>().Select(service => service.Name).ToArray();
+
+        // Assert
+        Assert.True(added);
+        Assert.Equal(["reentrant", "added", "route"], names);
+    }
+
+    [Fact]
+    public void WhenRouteTargetMutatesAfterResolution_ThenInvalidatedStateRetainsRoute()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target-1"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        // Act
+        target.AddService<IRouteService>(new RouteService("target-2"));
+
+        // Assert
+        Assert.Equal(3, context.GetServices<IRouteService>().Length);
+    }
+
+    [Fact]
+    public void WhenRouteTransfersToDifferentTarget_ThenReverseDependenciesFollowPublishedRelationships()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var targetA = InterceptorSubjectContext.Create();
+        var targetB = InterceptorSubjectContext.Create();
+        targetA.AddService<IRouteService>(new RouteService("a-1"));
+        targetB.AddService<IRouteService>(new RouteService("b-1"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        var routeA = new InterceptorSubjectContext.ContextOwnershipRoute(targetA, ownershipDomain);
+        var routeB = new InterceptorSubjectContext.ContextOwnershipRoute(targetB, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, routeA));
+        Assert.True(context.AddFallbackContext(targetA));
+        Assert.Equal(["local", "a-1"],
+            context.GetServices<IRouteService>().Select(service => service.Name).ToArray());
+
+        // Act: transfer the route away from A while the fallback still depends on A.
+        Assert.True(context.TryChangeOwnershipRoute(routeA, routeB));
+
+        // Assert
+        Assert.Equal(["local", "a-1", "b-1"],
+            context.GetServices<IRouteService>().Select(service => service.Name).ToArray());
+
+        var stateWithA = GetState(context);
+        targetA.AddService<IRouteService>(new RouteService("a-2"));
+
+        // Assert
+        Assert.NotSame(stateWithA, GetState(context));
+        Assert.Equal(4, context.GetServices<IRouteService>().Length);
+
+        // Act: removing the fallback ends the final relationship to A.
+        Assert.True(context.RemoveFallbackContext(targetA));
+        Assert.Equal(["local", "b-1"],
+            context.GetServices<IRouteService>().Select(service => service.Name).ToArray());
+
+        var stateWithoutA = GetState(context);
+        targetA.AddService<IRouteService>(new RouteService("a-3"));
+
+        // Assert
+        Assert.Same(stateWithoutA, GetState(context));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        var stateWithB = GetState(context);
+        targetB.AddService<IRouteService>(new RouteService("b-2"));
+        Assert.NotSame(stateWithB, GetState(context));
+        Assert.Equal(3, context.GetServices<IRouteService>().Length);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WhenFallbackAndRouteShareTarget_ThenRemovingOneKeepsInvalidationThroughTheOther(
+        bool removeFallbackFirst)
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target-1"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        context.AddFallbackContext(target);
+        var route = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, route));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        // Act
+        if (removeFallbackFirst)
+        {
+            Assert.True(context.RemoveFallbackContext(target));
+        }
+        else
+        {
+            Assert.True(context.TryChangeOwnershipRoute(route, null));
+        }
+
+        target.AddService<IRouteService>(new RouteService("target-2"));
+
+        // Assert
+        Assert.Equal(3, context.GetServices<IRouteService>().Length);
+
+        // Act
+        if (removeFallbackFirst)
+        {
+            Assert.True(context.TryChangeOwnershipRoute(route, null));
+        }
+        else
+        {
+            Assert.True(context.RemoveFallbackContext(target));
+        }
+
+        Assert.Single(context.GetServices<IRouteService>());
+        var stateAfterFinalRemoval = GetState(context);
+        target.AddService<IRouteService>(new RouteService("target-3"));
+
+        // Assert
+        Assert.Same(stateAfterFinalRemoval, GetState(context));
+        Assert.Single(context.GetServices<IRouteService>());
+    }
+
+    [Fact]
+    public void WhenOwnershipRoutesFormDelegationCycle_ThenResolutionThrows()
+    {
+        // Arrange
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var contextA = InterceptorSubjectContext.Create();
+        var contextB = InterceptorSubjectContext.Create();
+        var routeA = new InterceptorSubjectContext.ContextOwnershipRoute(contextB, ownershipDomain);
+        var routeB = new InterceptorSubjectContext.ContextOwnershipRoute(contextA, ownershipDomain);
+        Assert.True(contextA.TryChangeOwnershipRoute(null, routeA));
+        Assert.True(contextB.TryChangeOwnershipRoute(null, routeB));
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => contextA.GetServices<IRouteService>());
+
+        // Assert
+        Assert.Contains("delegation cycle", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WhenTwoThreadsInstallFirstRoute_ThenExactlyOneDescriptorWins()
+    {
+        const int attempts = 500;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            // Arrange
+            var ownershipDomain = InterceptorSubjectContext.Create();
+            var firstTarget = InterceptorSubjectContext.Create();
+            var secondTarget = InterceptorSubjectContext.Create();
+            var firstService = new RouteService("first");
+            var secondService = new RouteService("second");
+            firstTarget.AddService<IRouteService>(firstService);
+            secondTarget.AddService<IRouteService>(secondService);
+
+            var context = InterceptorSubjectContext.Create();
+            var firstRoute = new InterceptorSubjectContext.ContextOwnershipRoute(firstTarget, ownershipDomain);
+            var secondRoute = new InterceptorSubjectContext.ContextOwnershipRoute(secondTarget, ownershipDomain);
+            using var start = new Barrier(2);
+            var results = new bool[2];
+
+            var installers = new[]
+            {
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[0] = context.TryChangeOwnershipRoute(null, firstRoute);
+                }, TaskCreationOptions.LongRunning),
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[1] = context.TryChangeOwnershipRoute(null, secondRoute);
+                }, TaskCreationOptions.LongRunning)
+            };
+
+            // Act
+            await AsyncTestHelpers.WaitUntilAsync(
+                () => installers.All(installer => installer.IsCompleted),
+                message: $"Concurrent ownership-route installation did not complete on attempt {attempt}");
+            await Task.WhenAll(installers);
+
+            // Assert
+            Assert.NotEqual(results[0], results[1]);
+            var service = Assert.Single(context.GetServices<IRouteService>());
+            Assert.Same(results[0] ? firstService : secondService, service);
+        }
+    }
+
+    [Fact]
+    public async Task WhenTwoThreadsTransferSameRoute_ThenExactlyOneReplacementWins()
+    {
+        const int attempts = 500;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            // Arrange
+            var ownershipDomain = InterceptorSubjectContext.Create();
+            var initialTarget = InterceptorSubjectContext.Create();
+            var firstTarget = InterceptorSubjectContext.Create();
+            var secondTarget = InterceptorSubjectContext.Create();
+            var firstService = new RouteService("first");
+            var secondService = new RouteService("second");
+            firstTarget.AddService<IRouteService>(firstService);
+            secondTarget.AddService<IRouteService>(secondService);
+
+            var context = InterceptorSubjectContext.Create();
+            var initialRoute = new InterceptorSubjectContext.ContextOwnershipRoute(initialTarget, ownershipDomain);
+            var firstRoute = new InterceptorSubjectContext.ContextOwnershipRoute(firstTarget, ownershipDomain);
+            var secondRoute = new InterceptorSubjectContext.ContextOwnershipRoute(secondTarget, ownershipDomain);
+            Assert.True(context.TryChangeOwnershipRoute(null, initialRoute));
+
+            using var start = new Barrier(2);
+            var results = new bool[2];
+            var transfers = new[]
+            {
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[0] = context.TryChangeOwnershipRoute(initialRoute, firstRoute);
+                }, TaskCreationOptions.LongRunning),
+                Task.Factory.StartNew(() =>
+                {
+                    start.SignalAndWait();
+                    results[1] = context.TryChangeOwnershipRoute(initialRoute, secondRoute);
+                }, TaskCreationOptions.LongRunning)
+            };
+
+            // Act
+            await AsyncTestHelpers.WaitUntilAsync(
+                () => transfers.All(transfer => transfer.IsCompleted),
+                message: $"Concurrent ownership-route transfer did not complete on attempt {attempt}");
+            await Task.WhenAll(transfers);
+
+            // Assert
+            Assert.NotEqual(results[0], results[1]);
+            var service = Assert.Single(context.GetServices<IRouteService>());
+            Assert.Same(results[0] ? firstService : secondService, service);
+        }
+    }
+
+    [Fact]
+    public async Task WhenRouteAndTargetMutateConcurrently_ThenQuiescentResolutionSeesAllTargetServices()
+    {
+        // Arrange
+        const int mutations = 200;
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        var target = InterceptorSubjectContext.Create();
+        target.AddService<IRouteService>(new RouteService("target-initial"));
+
+        var context = InterceptorSubjectContext.Create();
+        context.AddService<IRouteService>(new RouteService("local"));
+        var initialRoute = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+        Assert.True(context.TryChangeOwnershipRoute(null, initialRoute));
+        Assert.Equal(2, context.GetServices<IRouteService>().Length);
+
+        using var start = new Barrier(3);
+        using var routeMidpoint = new ManualResetEventSlim(false);
+        using var readerObservedMidpoint = new ManualResetEventSlim(false);
+        var activeWriters = 2;
+
+        var routeWriter = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            try
+            {
+                var current = initialRoute;
+                for (var index = 0; index < mutations; index++)
+                {
+                    Assert.True(context.TryChangeOwnershipRoute(current, null));
+                    current = new InterceptorSubjectContext.ContextOwnershipRoute(target, ownershipDomain);
+                    Assert.True(context.TryChangeOwnershipRoute(null, current));
+
+                    if (index == mutations / 2)
+                    {
+                        routeMidpoint.Set();
+                        readerObservedMidpoint.Wait();
+                    }
+                }
+            }
+            finally
+            {
+                routeMidpoint.Set();
+                Interlocked.Decrement(ref activeWriters);
+            }
+        }, TaskCreationOptions.LongRunning);
+
+        var serviceWriter = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            try
+            {
+                for (var index = 0; index < mutations; index++)
+                {
+                    target.AddService<IRouteService>(new RouteService($"target-{index}"));
+                }
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeWriters);
+            }
+        }, TaskCreationOptions.LongRunning);
+
+        var reader = Task.Factory.StartNew(() =>
+        {
+            start.SignalAndWait();
+            try
+            {
+                while (!routeMidpoint.IsSet)
+                {
+                    _ = context.GetServices<IRouteService>();
+                }
+
+                _ = context.GetServices<IRouteService>();
+            }
+            finally
+            {
+                readerObservedMidpoint.Set();
+            }
+
+            while (Volatile.Read(ref activeWriters) != 0)
+            {
+                _ = context.GetServices<IRouteService>();
+            }
+        }, TaskCreationOptions.LongRunning);
+
+        // Act
+        var workers = new[] { routeWriter, serviceWriter, reader };
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => workers.All(worker => worker.IsCompleted),
+            message: "Concurrent route, target, and resolution work did not complete");
+        await Task.WhenAll(workers);
+
+        // Assert
+        Assert.Equal(mutations + 2, context.GetServices<IRouteService>().Length);
+    }
+
+    private interface IRouteService
+    {
+        string Name { get; }
+    }
+
+    private sealed class RouteService(string name) : IRouteService
+    {
+        public string Name { get; } = name;
+    }
+}

--- a/src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs
@@ -81,7 +81,8 @@ public class ContextServiceWalkOrderTests
         // otherwise this test could pass by never producing one.
         Assert.True(coverage.DelegationChains > 0, "No graph contained a delegating context.");
         Assert.True(coverage.DelegationCycles > 0, "No graph contained a delegation cycle.");
-        Assert.True(coverage.FallbackCycles > 0, "No graph contained a fallback cycle.");
+        Assert.True(coverage.OwnershipRoutes > 0, "No graph contained an ownership route.");
+        Assert.True(coverage.RelationshipCycles > 0, "No graph contained a relationship cycle.");
         Assert.True(coverage.MultiFallbackNodes > 0, "No graph contained a context with several fallback contexts.");
         Assert.True(coverage.SharedNodes > 0, "No graph contained a context reachable over more than one path.");
         Assert.True(coverage.DuplicateServices > 0, "No graph contained a service instance registered twice.");
@@ -128,6 +129,11 @@ public class ContextServiceWalkOrderTests
         foreach (var fallback in node.Fallbacks)
         {
             collected.AddRange(CollectWithReference(fallback, visited));
+        }
+
+        if (node.OwnershipRoute is not null)
+        {
+            collected.AddRange(CollectWithReference(node.OwnershipRoute, visited));
         }
 
         return ServiceOrderResolver
@@ -187,6 +193,20 @@ public class ContextServiceWalkOrderTests
             source.Context.AddFallbackContext(target.Context);
         }
 
+        var ownershipDomain = InterceptorSubjectContext.Create();
+        foreach (var source in nodes)
+        {
+            if (random.Next(2) == 0)
+            {
+                continue;
+            }
+
+            var target = nodes[random.Next(nodes.Length)];
+            source.OwnershipRoute = target;
+            var route = new InterceptorSubjectContext.ContextOwnershipRoute(target.Context, ownershipDomain);
+            Assert.True(source.Context.TryChangeOwnershipRoute(null, route));
+        }
+
         return nodes;
     }
 
@@ -210,9 +230,11 @@ public class ContextServiceWalkOrderTests
         builder.AppendLine($"Seed {seed}, graph {graphIndex}:");
         foreach (var node in nodes)
         {
+            var ownershipRoute = node.OwnershipRoute;
             builder.AppendLine(
                 $"  c{node.Index} services [{string.Join(", ", node.Services)}] " +
-                $"fallbacks [{string.Join(", ", node.Fallbacks.Select(fallback => $"c{fallback.Index}"))}]");
+                $"fallbacks [{string.Join(", ", node.Fallbacks.Select(fallback => $"c{fallback.Index}"))}] " +
+                $"route [{(ownershipRoute is null ? string.Empty : $"c{ownershipRoute.Index}")}]");
         }
 
         builder.AppendLine($"  expected: [{string.Join(", ", expected)}]");
@@ -224,7 +246,8 @@ public class ContextServiceWalkOrderTests
     {
         internal int DelegationChains;
         internal int DelegationCycles;
-        internal int FallbackCycles;
+        internal int OwnershipRoutes;
+        internal int RelationshipCycles;
         internal int MultiFallbackNodes;
         internal int SharedNodes;
         internal int DuplicateServices;
@@ -248,14 +271,19 @@ public class ContextServiceWalkOrderTests
                     DuplicateServices++;
                 }
 
-                if (nodes.Count(other => other.Fallbacks.Contains(node)) > 1)
+                if (node.OwnershipRoute is not null)
+                {
+                    OwnershipRoutes++;
+                }
+
+                if (nodes.SelectMany(other => other.Relationships).Count(target => ReferenceEquals(target, node)) > 1)
                 {
                     SharedNodes++;
                 }
 
                 if (ReachesItself(node))
                 {
-                    FallbackCycles++;
+                    RelationshipCycles++;
                 }
             }
         }
@@ -263,11 +291,11 @@ public class ContextServiceWalkOrderTests
         private static bool ReachesItself(Node node)
         {
             var visited = new HashSet<Node>();
-            var pending = new Stack<Node>(node.Fallbacks);
+            var pending = new Stack<Node>(node.Relationships);
             while (pending.Count != 0)
             {
                 var current = pending.Pop();
-                if (current == node)
+                if (ReferenceEquals(current, node))
                 {
                     return true;
                 }
@@ -277,9 +305,9 @@ public class ContextServiceWalkOrderTests
                     continue;
                 }
 
-                foreach (var fallback in current.Fallbacks)
+                foreach (var relationship in current.Relationships)
                 {
-                    pending.Push(fallback);
+                    pending.Push(relationship);
                 }
             }
 
@@ -297,8 +325,36 @@ public class ContextServiceWalkOrderTests
 
         internal List<Node> Fallbacks { get; } = [];
 
+        internal Node? OwnershipRoute { get; set; }
+
+        internal IEnumerable<Node> Relationships =>
+            OwnershipRoute is null ? Fallbacks : Fallbacks.Append(OwnershipRoute!);
+
         /// <summary>Mirrors <c>ContextState.DelegationTarget</c>.</summary>
-        internal Node? DelegationTarget => Services.Count == 0 && Fallbacks.Count == 1 ? Fallbacks[0] : null;
+        internal Node? DelegationTarget
+        {
+            get
+            {
+                if (Services.Count != 0)
+                {
+                    return null;
+                }
+
+                if (OwnershipRoute is null)
+                {
+                    return Fallbacks.Count == 1 ? Fallbacks[0] : null;
+                }
+
+                if (Fallbacks.Count == 0)
+                {
+                    return OwnershipRoute;
+                }
+
+                return Fallbacks.Count == 1 && ReferenceEquals(Fallbacks[0], OwnershipRoute)
+                    ? OwnershipRoute
+                    : null;
+            }
+        }
     }
 
     // The attributes never contradict each other, so no subset of these types can make the resolver

--- a/src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs
@@ -11,11 +11,11 @@ namespace Namotion.Interceptor.Tests.Context;
 /// exact shape of the walk and not only on the set it reaches.
 ///
 /// The reference below is a direct transcription of the recursive walk that the iterative one
-/// replaced: depth first, left to right, own services before the fallback contexts, distinct and
-/// reordered once per context, and a visited set that both cuts cycles and collapses a shared
-/// subgraph onto the path that reached it first. Randomized graphs are resolved with both and the
-/// two sequences are compared element by element, so a walk that reaches the same services in a
-/// different order fails here.
+/// replaced: depth first, left to right, own services before fallback contexts and the ownership
+/// route after them, distinct and reordered once per context, and a visited set that both cuts
+/// cycles and collapses a shared subgraph onto the path that reached it first. Randomized graphs
+/// are resolved with both and the two sequences are compared element by element, so a walk that
+/// reaches the same services in a different order fails here.
 /// </summary>
 public class ContextServiceWalkOrderTests
 {
@@ -376,9 +376,6 @@ public class ContextServiceWalkOrderTests
         internal List<Node> Fallbacks { get; } = [];
 
         internal Node? OwnershipRoute { get; set; }
-
-        internal IEnumerable<Node> Relationships =>
-            OwnershipRoute is null ? Fallbacks : Fallbacks.Append(OwnershipRoute!);
 
         /// <summary>Mirrors <c>ContextState.DelegationTarget</c>.</summary>
         internal Node? DelegationTarget

--- a/src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs
+++ b/src/Namotion.Interceptor.Tests/Context/ContextServiceWalkOrderTests.cs
@@ -81,10 +81,14 @@ public class ContextServiceWalkOrderTests
         // otherwise this test could pass by never producing one.
         Assert.True(coverage.DelegationChains > 0, "No graph contained a delegating context.");
         Assert.True(coverage.DelegationCycles > 0, "No graph contained a delegation cycle.");
-        Assert.True(coverage.OwnershipRoutes > 0, "No graph contained an ownership route.");
-        Assert.True(coverage.RelationshipCycles > 0, "No graph contained a relationship cycle.");
+        Assert.True(coverage.FallbackSources > 0, "No graph contained a fallback context.");
+        Assert.True(coverage.OwnershipRouteSources > 0, "No graph contained an ownership route.");
+        Assert.True(coverage.FallbackCycles > 0, "No graph contained a fallback-only relationship cycle.");
+        Assert.True(coverage.OwnershipRouteCycles > 0, "No graph contained an ownership-route-only relationship cycle.");
+        Assert.True(coverage.MixedRelationshipCycles > 0, "No graph contained a mixed relationship cycle.");
         Assert.True(coverage.MultiFallbackNodes > 0, "No graph contained a context with several fallback contexts.");
-        Assert.True(coverage.SharedNodes > 0, "No graph contained a context reachable over more than one path.");
+        Assert.True(coverage.FallbackSharedNodes > 0, "No shared node had a fallback-context source.");
+        Assert.True(coverage.OwnershipRouteSharedNodes > 0, "No shared node had an ownership-route source.");
         Assert.True(coverage.DuplicateServices > 0, "No graph contained a service instance registered twice.");
     }
 
@@ -246,16 +250,25 @@ public class ContextServiceWalkOrderTests
     {
         internal int DelegationChains;
         internal int DelegationCycles;
-        internal int OwnershipRoutes;
-        internal int RelationshipCycles;
+        internal int FallbackSources;
+        internal int OwnershipRouteSources;
+        internal int FallbackCycles;
+        internal int OwnershipRouteCycles;
+        internal int MixedRelationshipCycles;
         internal int MultiFallbackNodes;
-        internal int SharedNodes;
+        internal int FallbackSharedNodes;
+        internal int OwnershipRouteSharedNodes;
         internal int DuplicateServices;
 
         internal void Observe(Node[] nodes)
         {
             foreach (var node in nodes)
             {
+                if (node.Fallbacks.Count != 0)
+                {
+                    FallbackSources++;
+                }
+
                 if (node.DelegationTarget is not null)
                 {
                     DelegationChains++;
@@ -273,45 +286,82 @@ public class ContextServiceWalkOrderTests
 
                 if (node.OwnershipRoute is not null)
                 {
-                    OwnershipRoutes++;
+                    OwnershipRouteSources++;
                 }
 
-                if (nodes.SelectMany(other => other.Relationships).Count(target => ReferenceEquals(target, node)) > 1)
+                var fallbackSourceCount = nodes.Sum(other => other.Fallbacks.Count(target => ReferenceEquals(target, node)));
+                var ownershipRouteSourceCount = nodes.Count(other => ReferenceEquals(other.OwnershipRoute, node));
+                if (fallbackSourceCount + ownershipRouteSourceCount > 1)
                 {
-                    SharedNodes++;
+                    if (fallbackSourceCount != 0)
+                    {
+                        FallbackSharedNodes++;
+                    }
+
+                    if (ownershipRouteSourceCount != 0)
+                    {
+                        OwnershipRouteSharedNodes++;
+                    }
                 }
 
-                if (ReachesItself(node))
-                {
-                    RelationshipCycles++;
-                }
+                ObserveCycleShapes(node, node, false, false, [node]);
             }
         }
 
-        private static bool ReachesItself(Node node)
+        private void ObserveCycleShapes(
+            Node start,
+            Node current,
+            bool hasFallback,
+            bool hasOwnershipRoute,
+            HashSet<Node> path)
         {
-            var visited = new HashSet<Node>();
-            var pending = new Stack<Node>(node.Relationships);
-            while (pending.Count != 0)
+            foreach (var fallback in current.Fallbacks)
             {
-                var current = pending.Pop();
-                if (ReferenceEquals(current, node))
-                {
-                    return true;
-                }
-
-                if (!visited.Add(current))
-                {
-                    continue;
-                }
-
-                foreach (var relationship in current.Relationships)
-                {
-                    pending.Push(relationship);
-                }
+                ObserveCycleEdge(start, fallback, true, hasFallback, hasOwnershipRoute, path);
             }
 
-            return false;
+            if (current.OwnershipRoute is not null)
+            {
+                ObserveCycleEdge(start, current.OwnershipRoute, false, hasFallback, hasOwnershipRoute, path);
+            }
+        }
+
+        private void ObserveCycleEdge(
+            Node start,
+            Node target,
+            bool isFallback,
+            bool hasFallback,
+            bool hasOwnershipRoute,
+            HashSet<Node> path)
+        {
+            hasFallback |= isFallback;
+            hasOwnershipRoute |= !isFallback;
+
+            if (ReferenceEquals(target, start))
+            {
+                if (hasFallback && hasOwnershipRoute)
+                {
+                    MixedRelationshipCycles++;
+                }
+                else if (hasFallback)
+                {
+                    FallbackCycles++;
+                }
+                else
+                {
+                    OwnershipRouteCycles++;
+                }
+
+                return;
+            }
+
+            if (!path.Add(target))
+            {
+                return;
+            }
+
+            ObserveCycleShapes(start, target, hasFallback, hasOwnershipRoute, path);
+            path.Remove(target);
         }
     }
 

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -96,6 +96,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         return new InterceptorSubjectContext();
     }
 
+    /// <summary>
+    /// A single-install generation token for an internal ownership route. Once a descriptor has
+    /// been cleared or replaced, internal callers must never install that exact instance again.
+    /// </summary>
     internal sealed class ContextOwnershipRoute
     {
         internal ContextOwnershipRoute(
@@ -143,10 +147,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
                 return false;
             }
 
-            var replacementState = CreateContextState(
+            var replacementState = CreateStateReplacement(
+                state,
                 state.Services,
-                state.FallbackContexts.Add(contextImpl),
-                GetOwnershipRoute(state));
+                state.FallbackContexts.Add(contextImpl));
 
             // R4: register into the fallback BEFORE publishing, so its _usedByContexts is always a
             // superset of the true using set. A missing entry leaves a compiled chain above
@@ -180,10 +184,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
                 return false;
             }
 
-            var replacementState = CreateContextState(
+            var replacementState = CreateStateReplacement(
+                state,
                 state.Services,
-                state.FallbackContexts.RemoveAt(index),
-                GetOwnershipRoute(state));
+                state.FallbackContexts.RemoveAt(index));
             PublishState(replacementState);
 
             // R4: unregister from the fallback only AFTER publishing so that its _usedByContexts
@@ -199,12 +203,15 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         return true;
     }
 
+    /// <summary>
+    /// Atomically changes the internal ownership route when <paramref name="expected"/> is still
+    /// installed. Callers own all lifecycle side effects of the transition, and must never call
+    /// this while holding another context's mutation lock.
+    /// </summary>
     internal bool TryChangeOwnershipRoute(
         ContextOwnershipRoute? expected,
         ContextOwnershipRoute? replacement)
     {
-        var changed = false;
-
         lock (_mutationLock)
         {
             var state = Volatile.Read(ref _state);
@@ -235,15 +242,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
             {
                 UnregisterUsingContext(current.Target);
             }
-
-            changed = true;
         }
 
-        if (changed)
-        {
-            InvalidateUsingContexts();
-        }
-
+        InvalidateUsingContexts();
         return true;
     }
 
@@ -266,10 +267,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
             // the state to not lose it. Mutating a different context from here is forbidden, see
             // the lock order note at the top of the class.
             state = Volatile.Read(ref _state);
-            var replacementState = CreateContextState(
+            var replacementState = CreateStateReplacement(
+                state,
                 state.Services.Add(service!),
-                state.FallbackContexts,
-                GetOwnershipRoute(state));
+                state.FallbackContexts);
             PublishState(replacementState);
         }
 
@@ -282,10 +283,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         lock (_mutationLock)
         {
             var state = Volatile.Read(ref _state);
-            var replacementState = CreateContextState(
+            var replacementState = CreateStateReplacement(
+                state,
                 state.Services.Add(service!),
-                state.FallbackContexts,
-                GetOwnershipRoute(state));
+                state.FallbackContexts);
             PublishState(replacementState);
         }
 
@@ -528,11 +529,13 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     private static InvalidOperationException CreateDelegationCycleException()
     {
         return new InvalidOperationException(
-            "The fallback contexts form a delegation cycle, so no service can be resolved. A context " +
-            "without own services and with exactly one fallback context resolves everything through " +
-            "that fallback context, and following those references leads back to a context already " +
-            "visited. Break the cycle by removing one of the fallback context registrations or by " +
-            "registering a service on one of the contexts on it.");
+            "The fallback-context and ownership-route relationships form a delegation cycle, so no " +
+            "service can be resolved. A context without own services delegates through its one fallback " +
+            "context, or through its ownership route when it has no fallback contexts. It also delegates " +
+            "when its one fallback and ownership route target the same context. Following those " +
+            "relationships leads back to a context already visited. Break the cycle by removing a " +
+            "fallback-context registration, an ownership-route registration, or both registrations from " +
+            "a shared-target hop in the cycle, or by registering a service on one of the contexts in it.");
     }
 
     /// <summary>One context on the delegation walk and the state it was pinned on.</summary>
@@ -610,11 +613,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     }
 
     /// <summary>
-    /// Resolves services from the given pinned snapshot, normally one whose delegation the caller
-    /// already resolved. That is an expectation and not a precondition: the walk re-follows
-    /// delegation from whatever state it is handed. The cache entry is computed from the same
-    /// snapshot that owns the cache, so a topology change (which publishes a new state) can never
-    /// receive a stale entry.
+    /// Resolves services from a pinned snapshot whose delegation callers have already resolved.
+    /// The cache entry is computed from the same snapshot that owns the cache, so a topology
+    /// change (which publishes a new state) can never receive a stale entry.
     /// </summary>
     private ImmutableArray<TInterface> GetServicesFromState<TInterface>(ContextState state)
     {
@@ -1145,7 +1146,7 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         /// </summary>
         internal ContextState WithoutCaches()
         {
-            return CreateContextState(Services, FallbackContexts, GetOwnershipRoute(this));
+            return CreateStateReplacement(this, Services, FallbackContexts);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1260,4 +1261,13 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
             ? new ContextState(services, fallbackContexts)
             : new RoutedContextState(services, fallbackContexts, ownershipRoute);
     }
+
+    private static ContextState CreateStateReplacement(
+        ContextState state,
+        ImmutableArray<object> services,
+        ImmutableArray<InterceptorSubjectContext> fallbackContexts)
+    {
+        return CreateContextState(services, fallbackContexts, GetOwnershipRoute(state));
+    }
+
 }

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -10,13 +10,13 @@ namespace Namotion.Interceptor;
 
 public class InterceptorSubjectContext : IInterceptorSubjectContext
 {
-    // All topology (services, fallback contexts) and everything derived from it (delegation
-    // target, caches, compiled chains) lives in one immutable snapshot per context, published
-    // atomically.
+    // All topology (services, public fallback contexts, internal ownership route) and everything
+    // derived from it (delegation target, caches, compiled chains) lives in one immutable snapshot
+    // per context, published atomically.
     //
     // R1: queries take no context lock. A query pins one snapshot with a single volatile read and
     // walks other contexts' snapshots the same way, so the downward service walk and the upward
-    // invalidation walk cannot form a lock cycle, including in cyclic fallback graphs.
+    // invalidation walk cannot form a lock cycle, including in cyclic relationship graphs.
     //
     // Lock order: _mutationLock -> a _usedByContexts set lock, never reverse. A set lock is a leaf,
     // touching only that set and calling into no other context, so two contexts registering into
@@ -95,6 +95,21 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         return new InterceptorSubjectContext();
     }
 
+    internal sealed class ContextOwnershipRoute
+    {
+        internal ContextOwnershipRoute(
+            InterceptorSubjectContext target,
+            InterceptorSubjectContext ownershipDomain)
+        {
+            Target = target;
+            OwnershipDomain = ownershipDomain;
+        }
+
+        internal InterceptorSubjectContext Target { get; }
+
+        internal InterceptorSubjectContext OwnershipDomain { get; }
+    }
+
     private static InterceptorSubjectContext CreateCyclicDelegationMarker()
     {
         var marker = new InterceptorSubjectContext();
@@ -127,18 +142,18 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
                 return false;
             }
 
+            var replacementState = CreateContextState(
+                state.Services,
+                state.FallbackContexts.Add(contextImpl),
+                GetOwnershipRoute(state));
+
             // R4: register into the fallback BEFORE publishing, so its _usedByContexts is always a
             // superset of the true using set. A missing entry leaves a compiled chain above
             // permanently stale. An extra entry costs a spurious invalidation and lets the
             // invalidation walk arrive out of chain order, which is why no walk may trust what a
             // context further down recorded (see ResolveDelegationChain).
-            var usedByContexts = contextImpl.GetOrCreateUsedByContexts();
-            lock (usedByContexts)
-            {
-                usedByContexts.Add(this);
-            }
-
-            PublishState(new ContextState(state.Services, state.FallbackContexts.Add(contextImpl)));
+            RegisterUsingContext(contextImpl);
+            PublishState(replacementState);
         }
 
         InvalidateUsingContexts();
@@ -164,22 +179,70 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
                 return false;
             }
 
-            PublishState(new ContextState(state.Services, state.FallbackContexts.RemoveAt(index)));
+            var replacementState = CreateContextState(
+                state.Services,
+                state.FallbackContexts.RemoveAt(index),
+                GetOwnershipRoute(state));
+            PublishState(replacementState);
 
             // R4: unregister from the fallback only AFTER publishing so that its _usedByContexts
             // stays a superset of the true using set for the whole transition (see
             // AddFallbackContext).
-            var usedByContexts = Volatile.Read(ref contextImpl._usedByContexts);
-            if (usedByContexts is not null)
+            if (!UsesTarget(replacementState, contextImpl))
             {
-                lock (usedByContexts)
-                {
-                    usedByContexts.Remove(this);
-                }
+                UnregisterUsingContext(contextImpl);
             }
         }
 
         InvalidateUsingContexts();
+        return true;
+    }
+
+    internal bool TryChangeOwnershipRoute(
+        ContextOwnershipRoute? expected,
+        ContextOwnershipRoute? replacement)
+    {
+        var changed = false;
+
+        lock (_mutationLock)
+        {
+            var state = Volatile.Read(ref _state);
+            var current = GetOwnershipRoute(state);
+            if (!ReferenceEquals(current, expected))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(current, replacement))
+            {
+                return true;
+            }
+
+            var replacementState = CreateContextState(state.Services, state.FallbackContexts, replacement);
+
+            if (replacement is not null &&
+                !ReferenceEquals(current?.Target, replacement.Target))
+            {
+                RegisterUsingContext(replacement.Target);
+            }
+
+            PublishState(replacementState);
+
+            if (current is not null &&
+                !ReferenceEquals(current.Target, replacement?.Target) &&
+                !UsesTarget(replacementState, current.Target))
+            {
+                UnregisterUsingContext(current.Target);
+            }
+
+            changed = true;
+        }
+
+        if (changed)
+        {
+            InvalidateUsingContexts();
+        }
+
         return true;
     }
 
@@ -202,7 +265,11 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
             // the state to not lose it. Mutating a different context from here is forbidden, see
             // the lock order note at the top of the class.
             state = Volatile.Read(ref _state);
-            PublishState(new ContextState(state.Services.Add(service!), state.FallbackContexts));
+            var replacementState = CreateContextState(
+                state.Services.Add(service!),
+                state.FallbackContexts,
+                GetOwnershipRoute(state));
+            PublishState(replacementState);
         }
 
         InvalidateUsingContexts();
@@ -214,7 +281,11 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         lock (_mutationLock)
         {
             var state = Volatile.Read(ref _state);
-            PublishState(new ContextState(state.Services.Add(service!), state.FallbackContexts));
+            var replacementState = CreateContextState(
+                state.Services.Add(service!),
+                state.FallbackContexts,
+                GetOwnershipRoute(state));
+            PublishState(replacementState);
         }
 
         InvalidateUsingContexts();
@@ -275,8 +346,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
     /// <summary>
     /// Resolves the context that answers for this one and replaces <paramref name="state"/> with
-    /// the state that context was pinned on. A context with no own service and exactly one fallback
-    /// resolves everything through it, so the chain is as deep as the subject graph.
+    /// the state that context was pinned on. A context with no own service and exactly one public
+    /// fallback or an internal ownership route resolves everything through it, so the chain is as
+    /// deep as the subject graph.
     ///
     /// Walked once per state rather than once per query, which is what makes depth free. The record
     /// holds the terminal CONTEXT and never its state: a context's state is replaced whenever
@@ -544,8 +616,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     /// </summary>
     private ImmutableArray<TInterface> GetServicesFromState<TInterface>(ContextState state)
     {
-        // An empty context allocates no service cache. The compiled chain arrays are unaffected:
-        // an empty state that answers intercepted access still fills those.
+        // A route-only source always has DelegationTarget and every caller resolves that delegation
+        // before reaching this empty-state check. An empty context allocates no service cache. The
+        // compiled chain arrays are unaffected: an empty state that answers intercepted access
+        // still fills those.
         if (state.IsEmpty)
         {
             return ImmutableArray<TInterface>.Empty;
@@ -587,14 +661,16 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
     /// <summary>
     /// Collects the services of the given type from the pinned snapshot and every context it
-    /// reaches, with an explicit worklist rather than recursion: the fallback graph is as deep as
-    /// the subject graph, so recursion died on an uncatchable <see cref="StackOverflowException"/>.
+    /// reaches, with an explicit worklist rather than recursion: the public fallback plus internal
+    /// ownership-route graph is as deep as the subject graph, so recursion died on an uncatchable
+    /// <see cref="StackOverflowException"/>.
     ///
     /// The shape of the recursive walk is preserved exactly, because the result order is
     /// observable: <see cref="ServiceOrderResolver.OrderByDependencies"/> keeps input order among
     /// services no ordering attribute separates. So the walk stays depth first and left to right,
-    /// each context contributes its own services first, and the result is made distinct and
-    /// reordered once per context rather than once at the end.
+    /// each context contributes its own services first, then public fallbacks, then its internal
+    /// ownership route, and the result is made distinct and reordered once per context rather than
+    /// once at the end.
     ///
     /// It terminates because a context is entered only when <c>visited</c> did not hold it, which
     /// is also what makes the walk safe on a cyclic graph.
@@ -644,6 +720,24 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
                 continue;
             }
 
+            if (!frame.OwnershipRouteEntered)
+            {
+                frame.OwnershipRouteEntered = true;
+                frames[frameIndex] = frame;
+
+                var ownershipRoute = GetOwnershipRoute(frame.State);
+                if (ownershipRoute is not null &&
+                    TryEnterContext(
+                        ownershipRoute.Target,
+                        Volatile.Read(ref ownershipRoute.Target._state),
+                        visited,
+                        out var ownershipRouteState))
+                {
+                    PushFrame(frames, collected, type, ownershipRouteState);
+                    continue;
+                }
+            }
+
             frames.RemoveAt(frameIndex);
             ReduceFrame(collected, frame.ResultStart, distinctServices);
         }
@@ -689,7 +783,8 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
     /// <summary>
     /// Opens the buffer region of a context and appends its own matching services to it, which the
-    /// recursive walk placed ahead of everything its fallback contexts contribute.
+    /// recursive walk placed ahead of everything its public fallbacks and internal ownership route
+    /// contribute.
     /// </summary>
     private static void PushFrame(List<ServiceWalkFrame> frames, List<object> collected, Type type, ContextState state)
     {
@@ -750,19 +845,22 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
     /// <summary>
     /// One context on the walk stack: the snapshot it was pinned on, the index at which its region
-    /// of the shared buffer begins, and the cursor over its fallback contexts.
+    /// of the shared buffer begins, the cursor over its public fallback contexts, and whether its
+    /// internal ownership route was entered.
     /// </summary>
     private struct ServiceWalkFrame
     {
         internal readonly ContextState State;
         internal readonly int ResultStart;
         internal int NextFallbackIndex;
+        internal bool OwnershipRouteEntered;
 
         internal ServiceWalkFrame(ContextState state, int resultStart)
         {
             State = state;
             ResultStart = resultStart;
             NextFallbackIndex = 0;
+            OwnershipRouteEntered = false;
         }
     }
 
@@ -802,6 +900,33 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         Interlocked.CompareExchange(ref _state, current.WithoutCaches(), current);
     }
 
+    private void RegisterUsingContext(InterceptorSubjectContext target)
+    {
+        var usedByContexts = target.GetOrCreateUsedByContexts();
+        lock (usedByContexts)
+        {
+            usedByContexts.Add(this);
+        }
+    }
+
+    private void UnregisterUsingContext(InterceptorSubjectContext target)
+    {
+        var usedByContexts = Volatile.Read(ref target._usedByContexts);
+        if (usedByContexts is not null)
+        {
+            lock (usedByContexts)
+            {
+                usedByContexts.Remove(this);
+            }
+        }
+    }
+
+    private static bool UsesTarget(ContextState state, InterceptorSubjectContext target)
+    {
+        return state.FallbackContexts.Contains(target) ||
+               ReferenceEquals(GetOwnershipRoute(state)?.Target, target);
+    }
+
     /// <summary>
     /// Returns the canonical using set of this context, creating it on first use. The CAS keeps
     /// one instance when two contexts register concurrently, which is what lets callers use the
@@ -821,8 +946,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
 
     /// <summary>
     /// Invalidates every context that resolves through this one, with an explicit worklist rather
-    /// than recursion: the using graph is the fallback graph reversed and therefore as deep as the
-    /// subject graph, where recursion died on an uncatchable <see cref="StackOverflowException"/>.
+    /// than recursion: the using graph is the public fallback plus internal ownership-route graph
+    /// reversed and therefore as deep as the subject graph, where recursion died on an uncatchable
+    /// <see cref="StackOverflowException"/>.
     ///
     /// It terminates because a context is queued only when <c>visited</c> did not hold it, which is
     /// also what makes the walk safe on a cyclic graph.
@@ -935,7 +1061,7 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         }
     }
 
-    private sealed class ContextState
+    private class ContextState
     {
         // Insertion order is kept and duplicate references tolerated: dedup moved from
         // registration into the service walk, which keeps the same occurrence under the same
@@ -945,8 +1071,8 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         internal readonly ImmutableArray<object> Services;
         internal readonly ImmutableArray<InterceptorSubjectContext> FallbackContexts;
 
-        // Derived in the constructor from the two fields above, so no reader can ever observe
-        // it disagreeing with them.
+        // Derived in the constructor from the fields above and the internal ownership-route target,
+        // so no reader can ever observe it disagreeing with them.
         internal readonly InterceptorSubjectContext? DelegationTarget;
 
         // Caches belong to the state that produced them, created lazily via CAS. A topology change
@@ -965,11 +1091,27 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         // one's caches.
         private InterceptorSubjectContext? _resolvedTerminal;
 
-        internal ContextState(ImmutableArray<object> services, ImmutableArray<InterceptorSubjectContext> fallbackContexts)
+        internal ContextState(
+            ImmutableArray<object> services,
+            ImmutableArray<InterceptorSubjectContext> fallbackContexts,
+            InterceptorSubjectContext? ownershipRouteTarget = null)
         {
             Services = services;
             FallbackContexts = fallbackContexts;
-            DelegationTarget = services.IsEmpty && fallbackContexts.Length == 1 ? fallbackContexts[0] : null;
+
+            if (!services.IsEmpty)
+            {
+                DelegationTarget = null;
+            }
+            else if (fallbackContexts.IsEmpty)
+            {
+                DelegationTarget = ownershipRouteTarget;
+            }
+            else if (fallbackContexts.Length == 1 &&
+                     (ownershipRouteTarget is null || ReferenceEquals(fallbackContexts[0], ownershipRouteTarget)))
+            {
+                DelegationTarget = fallbackContexts[0];
+            }
         }
 
         internal bool IsEmpty => Services.IsEmpty && FallbackContexts.IsEmpty;
@@ -999,7 +1141,7 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         /// </summary>
         internal ContextState WithoutCaches()
         {
-            return new ContextState(Services, FallbackContexts);
+            return CreateContextState(Services, FallbackContexts, GetOwnershipRoute(this));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1084,5 +1226,34 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         {
             return Interlocked.CompareExchange(ref _methodInvocationFunction, function, null) ?? function;
         }
+    }
+
+    private sealed class RoutedContextState : ContextState
+    {
+        internal RoutedContextState(
+            ImmutableArray<object> services,
+            ImmutableArray<InterceptorSubjectContext> fallbackContexts,
+            ContextOwnershipRoute ownershipRoute)
+            : base(services, fallbackContexts, ownershipRoute.Target)
+        {
+            OwnershipRoute = ownershipRoute;
+        }
+
+        internal readonly ContextOwnershipRoute OwnershipRoute;
+    }
+
+    private static ContextOwnershipRoute? GetOwnershipRoute(ContextState state)
+    {
+        return state is RoutedContextState routedState ? routedState.OwnershipRoute : null;
+    }
+
+    private static ContextState CreateContextState(
+        ImmutableArray<object> services,
+        ImmutableArray<InterceptorSubjectContext> fallbackContexts,
+        ContextOwnershipRoute? ownershipRoute)
+    {
+        return ownershipRoute is null
+            ? new ContextState(services, fallbackContexts)
+            : new RoutedContextState(services, fallbackContexts, ownershipRoute);
     }
 }

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -74,8 +74,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     private readonly object _mutationLock = new();
 
     // Contexts that resolve through this context, lazily allocated because most contexts are
-    // never used as a fallback. The set instance is its own lock: it is created once via CAS and
-    // never replaced, so every thread locks the same canonical object without a second allocation.
+    // never used as a public fallback or internal ownership-route target. The set instance is its
+    // own lock: it is created once via CAS and never replaced, so every thread locks the same
+    // canonical object without a second allocation.
     private HashSet<InterceptorSubjectContext>? _usedByContexts;
 
     /// <summary>
@@ -495,8 +496,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     /// Reports whether every context on the candidate loop still holds the state the walk pinned.
     /// A state is never installed twice, so one still in place has been in place since it was
     /// pinned, and every edge of the loop therefore existed at the same moment. That is a cycle.
-    /// Comparing states rather than the fallback contexts they point at is what makes this exact: a
-    /// sequence of rewirings that is acyclic throughout can otherwise produce a repeat.
+    /// Comparing states rather than the public fallback and internal ownership-route relationships
+    /// they describe is what makes this exact: a sequence of rewirings that is acyclic throughout
+    /// can otherwise produce a repeat.
     ///
     /// <paramref name="loopStart"/> reports where the loop begins, because the run ahead of it is
     /// deliberately not re-read and proves nothing, see <see cref="CacheResolvedTerminal"/>.
@@ -804,9 +806,10 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
     }
 
     /// <summary>
-    /// Turns the buffer region a context and its fallbacks filled into that context's result:
-    /// duplicates dropped keeping the first occurrence, then reordered by the ordering attributes.
-    /// Per context rather than once at the end, which is what the result order depends on.
+    /// Turns the buffer region a context, its public fallbacks, and its internal ownership route
+    /// filled into that context's result: duplicates dropped keeping the first occurrence, then
+    /// reordered by the ordering attributes. Per context rather than once at the end, which is what
+    /// the result order depends on.
     /// </summary>
     private static void ReduceFrame(List<object> collected, int resultStart, HashSet<object> distinctServices)
     {
@@ -1006,10 +1009,11 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
         HashSet<InterceptorSubjectContext> visited,
         List<InterceptorSubjectContext> pending)
     {
-        // Contexts never used as a fallback take no lock. The field is written once by a CAS
-        // ordered before the registrant's own publish, so a racing registration is either visible
-        // here or belongs to a context that has not published yet, whose own walk then covers
-        // everything above it. This depends on the publish being a full fence, see PublishState.
+        // Contexts never used as a public fallback or internal ownership-route target take no lock.
+        // The field is written once by a CAS ordered before the registrant's own publish, so a
+        // racing registration is either visible here or belongs to a context that has not published
+        // yet, whose own walk then covers everything above it. This depends on the publish being a
+        // full fence, see PublishState.
         //
         // Emptiness is deliberately NOT checked outside the lock: HashSet.Count is a composite of
         // two independently mutated fields, so an unlocked read can compute a count that was never

--- a/src/Namotion.Interceptor/InterceptorSubjectContext.cs
+++ b/src/Namotion.Interceptor/InterceptorSubjectContext.cs
@@ -534,8 +534,9 @@ public class InterceptorSubjectContext : IInterceptorSubjectContext
             "context, or through its ownership route when it has no fallback contexts. It also delegates " +
             "when its one fallback and ownership route target the same context. Following those " +
             "relationships leads back to a context already visited. Break the cycle by removing a " +
-            "fallback-context registration, an ownership-route registration, or both registrations from " +
-            "a shared-target hop in the cycle, or by registering a service on one of the contexts in it.");
+            "fallback-context registration from a fallback-only hop, an ownership-route registration from " +
+            "an ownership-route-only hop, or both the fallback-context and ownership-route registrations " +
+            "from a shared-target hop in the cycle, or by registering a service on one of the contexts in it.");
     }
 
     /// <summary>One context on the delegation walk and the state it was pinned on.</summary>


### PR DESCRIPTION
## Summary

- Add an internal effective ownership route to `InterceptorSubjectContext` state.
- Make ownership-route transitions compare exact descriptor identity so stale clears and transfers cannot affect a newer generation.
- Preserve reverse invalidation when public fallback composition and the internal ownership route share a target.
- Integrate the route into service traversal, delegation, cycle handling, and cache-free state replacement.
- Document the internal context-resolution model and the roadmap for the stacked ownership, unique-authority, and hosted-lifecycle changes.

## Scope

This is a behavior-neutral foundation PR. It adds no public API, no production caller installs an ownership route, and existing lifecycle and fallback behavior is unchanged.

The stacked ownership PR will use this permanent primitive and remove the legacy coupling between public fallback composition and lifecycle ownership. The two PRs are intended to be reviewed together and merged in the same release.

## Verification

- Core tests: 171 passed
- Public API snapshot: 1 passed with no received snapshot
- Full non-integration solution tests: exit 0 with no failed tests
- Affected Core project build and pack: passed with 0 warnings and 0 errors
- Independent whole-PR review and final fix re-review: no Critical or Important findings
- Diff hygiene: clean against merge base `55df0a84ebc19489cc114297b1e5fb6b4aa0b4b9`

The local aggregate solution build exited at the environment's five-minute boundary with 0 warnings and 0 errors. The aggregate pack exited at the same boundary without diagnostics. Both remain pending on a stable machine. Stable-machine benchmarks are also pending and will compare exact head `a88b456ef681dc4505f1edce040b56fb83a6a034` against the recorded merge base.

## Performance contract

- Route-free contexts add no instance field or route descriptor allocation.
- The steady `GetServices` and intercepted read, write, and invoke entry paths do not inspect ownership-route state.
- Acceptance requires no repeatable timing regression beyond contemporaneous control-row noise and no new steady-state allocation.
