### PR TITLE
Name the source-write boundary when a commit rejects a model read

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -338,6 +338,8 @@ public sealed class DatabaseSource : SubjectSourceBase
 
 **Constructor parameters**: `bufferTime` (default 8ms) controls the change queue batching window. Changes within this window are coalesced into a single `WriteChangesAsync` call. `retryTime` (default 10s) controls the delay between retry attempts when `StartListeningAsync` or the pump loop fails.
 
+**Build the payload from `changes` only**: never read subject properties in `WriteChangesAsync`. Under transactions the built-in writer calls the source on the committing flow, where property reads and writes throw `InvalidOperationException`, because sibling and landed-model state is outside the frozen snapshot and can make the payload inconsistent with it. Capture any other subject state the write needs before `CommitAsync`, and see [Transactions](tracking-transactions.md) for the full committing access boundary.
+
 **WriteResult**: Return `WriteResult.Success` when all changes were written. Return `WriteResult.Failure(changes, exception)` when all changes failed, or `WriteResult.PartialFailure(changes, exception)` when some succeeded. The failed changes list everything not confirmed written; unlisted changes count as written, and an error with an empty list is treated as the whole batch having failed. The base class enqueues the failed changes into the write retry queue automatically.
 
 #### Registering a Source

--- a/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionSourceTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Transactions/SubjectTransactionSourceTests.cs
@@ -1001,4 +1001,39 @@ public class SubjectTransactionSourceTests : TransactionTestBase
         Assert.Equal("Joh", person.FirstName);
         Assert.Equal("Doe", person.LastName);
     }
+
+    [Fact]
+    public async Task WhenSourceReadsPropertyWhileWriting_ThenErrorNamesTheSourceWriteBoundary()
+    {
+        // Arrange - a source that builds its payload by reading the model instead of the supplied
+        // changes. The built-in writer calls it on the committing flow, where reads are rejected.
+        var context = CreateContext();
+        var person = new Person(context);
+
+        var sourceMock = new Mock<ISubjectSource>();
+        sourceMock.Setup(s => s.WriteBatchSize).Returns(0);
+        sourceMock
+            .Setup(s => s.WriteChangesAsync(
+                It.IsAny<ReadOnlyMemory<SubjectPropertyChange>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((ReadOnlyMemory<SubjectPropertyChange> _, CancellationToken _) =>
+            {
+                _ = person.LastName;
+                return new ValueTask<WriteResult>(WriteResult.Success);
+            });
+
+        new PropertyReference(person, nameof(Person.FirstName)).SetSource(sourceMock.Object);
+
+        using var transaction = await context.BeginTransactionAsync(TransactionFailureHandling.BestEffort);
+        person.FirstName = "Joh";
+
+        // Act
+        var exception = await Assert.ThrowsAsync<SubjectTransactionException>(
+            () => transaction.CommitAsync(CancellationToken.None).AsTask());
+
+        // Assert - the message has to point at the write boundary and its remedy, not at threading
+        var error = Assert.IsType<InvalidOperationException>(Assert.Single(exception.Errors).GetBaseException());
+        Assert.Contains("commit is in progress", error.Message);
+        Assert.Contains("supplied changes", error.Message);
+    }
 }

--- a/src/Namotion.Interceptor.Connectors/ISubjectSource.cs
+++ b/src/Namotion.Interceptor.Connectors/ISubjectSource.cs
@@ -39,6 +39,14 @@ public interface ISubjectSource : ISubjectConnector
     /// Do not retain <paramref name="changes"/> after the returned task completes: the caller may
     /// reuse or mutate the underlying buffer.
     /// When reporting an error, enumerate the failed changes; see <see cref="WriteResult.FailedChanges"/>.
+    /// <para>
+    /// Build the payload from <paramref name="changes"/> alone, never by reading subject properties.
+    /// Under transactions the built-in writer calls this on the committing flow, where property reads
+    /// and writes throw <see cref="InvalidOperationException"/>: sibling and landed-model state is
+    /// outside the frozen snapshot and can make the payload inconsistent with it. Capture any other
+    /// subject state the write needs before <see cref="Tracking.Transactions.SubjectTransaction.CommitAsync"/>,
+    /// and see <see cref="Tracking.Transactions.ITransactionWriter"/> for the full committing access boundary.
+    /// </para>
     /// </remarks>
     /// <param name="changes">The collection of subject property changes.</param>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -196,7 +196,9 @@ public sealed class SubjectTransaction : IDisposable
         {
             throw new InvalidOperationException(
                 "Cannot access transactional property while commit is in progress. " +
-                "This typically indicates the transaction is being used from multiple threads.");
+                "Source writes and transaction writer callbacks run on the committing flow: build the " +
+                "payload from the supplied changes instead of reading or writing subject properties. " +
+                "This is also reported when the transaction is used from another thread.");
         }
     }
 

--- a/src/Namotion.Interceptor.WebSocket.Tests/Integration/WebSocketTestClient.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Integration/WebSocketTestClient.cs
@@ -19,6 +19,8 @@ public class WebSocketTestClient<TRoot> : IAsyncDisposable
 
     public TRoot? Root { get; private set; }
 
+    public IInterceptorSubjectContext? Context { get; private set; }
+
     public WebSocketTestClient(ITestOutputHelper output)
     {
         _output = output;
@@ -27,7 +29,8 @@ public class WebSocketTestClient<TRoot> : IAsyncDisposable
     public async Task StartAsync(
         Func<IInterceptorSubjectContext, TRoot> createRoot,
         Func<TRoot, bool>? isConnected = null,
-        int port = 18080)
+        int port = 18080,
+        Action<IInterceptorSubjectContext>? configureContext = null)
     {
         var builder = Host.CreateApplicationBuilder();
         builder.Services.AddLogging(logging =>
@@ -43,6 +46,9 @@ public class WebSocketTestClient<TRoot> : IAsyncDisposable
             .WithLifecycle()
             .WithHostedServices(builder.Services);
 
+        configureContext?.Invoke(context);
+
+        Context = context;
         Root = createRoot(context);
 
         builder.Services.AddSingleton(Root);

--- a/src/Namotion.Interceptor.WebSocket.Tests/Integration/WebSocketTransactionTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Integration/WebSocketTransactionTests.cs
@@ -1,0 +1,156 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Namotion.Interceptor.Connectors;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking.Transactions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Namotion.Interceptor.WebSocket.Tests.Integration;
+
+/// <summary>
+/// Covers outbound WebSocket writes that happen inside a transaction commit. The commit writes to
+/// sources from the committing flow, so the source runs while the ambient transaction is committing
+/// and property reads on that flow are rejected.
+/// </summary>
+[Trait("Category", "Integration")]
+public class WebSocketTransactionTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public WebSocketTransactionTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task WhenPropertyIsWrittenInTransaction_ThenServerReceivesCommittedValue()
+    {
+        // Arrange
+        using var portLease = await WebSocketTestPortPool.AcquireAsync();
+        await using var server = new WebSocketTestServer<TestRoot>(_output);
+        await using var client = new WebSocketTestClient<TestRoot>(_output);
+
+        await server.StartAsync(
+            context => new TestRoot(context),
+            (_, root) => root.Name = "Initial",
+            port: portLease.Port);
+
+        await client.StartAsync(
+            context => new TestRoot(context),
+            port: portLease.Port,
+            configureContext: context => context.WithSourceTransactions());
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => client.Root!.Name == "Initial",
+            message: "Client should receive initial state");
+
+        AssertSourceOwns(client.Root!, nameof(TestRoot.Name));
+
+        // Act
+        using (var transaction = await client.Context!.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            client.Root!.Name = "From transaction";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => server.Root!.Name == "From transaction",
+            message: "Server should receive the transactionally committed value");
+    }
+
+    [Fact]
+    public async Task WhenMultiplePropertiesAreWrittenInTransaction_ThenServerReceivesAllOfThem()
+    {
+        // Arrange
+        using var portLease = await WebSocketTestPortPool.AcquireAsync();
+        await using var server = new WebSocketTestServer<TestRoot>(_output);
+        await using var client = new WebSocketTestClient<TestRoot>(_output);
+
+        await server.StartAsync(
+            context => new TestRoot(context),
+            (_, root) => root.Name = "Initial",
+            port: portLease.Port);
+
+        await client.StartAsync(
+            context => new TestRoot(context),
+            port: portLease.Port,
+            configureContext: context => context.WithSourceTransactions());
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => client.Root!.Name == "Initial",
+            message: "Client should receive initial state");
+
+        AssertSourceOwns(client.Root!, nameof(TestRoot.Number));
+
+        // Act
+        using (var transaction = await client.Context!.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            client.Root!.Name = "Batched";
+            client.Root.Number = 42.5m;
+            client.Root.Connected = true;
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => server.Root!.Name == "Batched" &&
+                  server.Root.Number == 42.5m &&
+                  server.Root.Connected,
+            message: "Server should receive every property committed by the transaction");
+    }
+
+    [Fact]
+    public async Task WhenNestedSubjectPropertyIsWrittenInTransaction_ThenServerReceivesCommittedValue()
+    {
+        // Arrange
+        using var portLease = await WebSocketTestPortPool.AcquireAsync();
+        await using var server = new WebSocketTestServer<TestRoot>(_output);
+        await using var client = new WebSocketTestClient<TestRoot>(_output);
+
+        await server.StartAsync(
+            context => new TestRoot(context),
+            (_, root) =>
+            {
+                root.Name = "Initial";
+                root.Child = new TestItem { Label = "ServerChild" };
+            },
+            port: portLease.Port);
+
+        await client.StartAsync(
+            context => new TestRoot(context),
+            port: portLease.Port,
+            configureContext: context => context.WithSourceTransactions());
+
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => client.Root!.Child?.Label == "ServerChild",
+            message: "Client should receive the initial child state");
+
+        AssertSourceOwns(client.Root!.Child!, nameof(TestItem.Label));
+
+        // Act
+        using (var transaction = await client.Context!.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            client.Root!.Child!.Label = "From transaction";
+            client.Root.Child.Value = 7;
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+
+        // Assert
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => server.Root!.Child?.Label == "From transaction" && server.Root.Child.Value == 7,
+            message: "Server should receive the transactionally committed nested values");
+    }
+
+    /// <summary>
+    /// The commit only writes to sources that own the changed property, so an ownership regression
+    /// would silently downgrade these tests to covering plain non-transactional propagation.
+    /// </summary>
+    private static void AssertSourceOwns(IInterceptorSubject subject, string propertyName)
+    {
+        Assert.True(
+            new PropertyReference(subject, propertyName).TryGetSource(out _),
+            $"The WebSocket client source must own {propertyName} for the commit to write through it");
+    }
+}


### PR DESCRIPTION
Improves the diagnostic and the documentation behind #475. It does not change transaction semantics, and it does not fix #475 for #197, which is where that failure actually lives. See "Relationship to #197" below.

## #475 is not reachable on master

The issue reports that `WebSocketSubjectClientSource.WriteChangesAsync` rebuilds partial updates by reading the model, and that the commit guard from #468 rejects those reads.

The rebuild only reads the model for **structural** changes. `ApplyPropertyChangeToUpdate` re-reads via `ProcessSubjectComplete` in its subject reference, collection and dictionary branches only; a scalar change is serialized straight from `change.GetNewValue<T>()`.

On master, `ClaimPropertyOwnership` claims only properties where `!p.CanContainSubjects`, and `CanContainSubjects` is exactly `IsSubjectReferenceType || IsSubjectCollectionType || IsSubjectDictionaryType`, so the owned set is the exact complement of the three branches that read. Both routes into `WriteChangesAsync` filter to source-owned properties (`SubjectSourceBase`'s change queue and `SourceTransactionWriter`). The client source therefore never receives a structural change and never re-reads the model.

Confirmed against a live client and server: `Connected`, `Name`, `Number`, `TestItem.Label` and `TestItem.Value` are owned; `Items`, `Child` and `Lookup` are not. The server side (`WebSocketSubjectHandler.BroadcastChangesAsync`) does re-read for structural changes, but runs on a `ChangeQueueProcessor` flush loop that carries no ambient transaction.

The three integration tests added here pass unmodified on master.

## Relationship to #197

#197 (`feature/websocket-structural-mutations`) is where #475 is real. That branch deliberately drops the `!p.CanContainSubjects` filter:

> Get all properties (including structural), filtered by PathProvider if configured. Structural properties (Collection, Dictionary, ObjectRef) must be claimed so that client-side structural mutations are forwarded to the server.

and adds an `OnSubjectAttached` claim with no structural filter. So on that branch the client source does own structural properties, `WriteChangesAsync` does receive structural changes, and `CreatePartialUpdateFromChanges` does walk the graph and read properties.

That branch is 36 commits behind master and still carries the pre-#468 guard, with no `EnterCommitModelAccess` machinery. #475 therefore lands on #197 the moment it rebases.

Relaxing the guard is not the answer there either: during the source-write phase the local apply has not run, so a subject assigned inside the transaction is not yet registered. `ProcessSubjectComplete` bails only after `GetOrCreateId` has minted an id, so the walk would emit an object reference whose id has no entry in `Subjects`, turning a loud exception into a silently truncated update. A structural payload is only coherent after the local apply, which is what the outbound queue already does. The options for #197 are to make structural serialization self-sufficient from `changes`, or to keep structural properties out of the transactional source-write path and let the post-commit outbound queue push them. Either is #197's design call, not something to settle here.

## The rejection is intentional

`ITransactionWriter` and `docs/tracking-transactions.md` both specify it: build source payloads from the supplied `changes`, never by reading subject properties, because sibling and landed-model state is outside the frozen snapshot and can make the payload inconsistent with it.

## What this changes

Two things made a contract violation look like a connector bug:

1. The exception said "This typically indicates the transaction is being used from multiple threads", which is wrong for the case people actually hit, where the source runs on the commit's own flow. It now names the source-write boundary and the remedy, and still mentions cross-thread use.
2. `ISubjectSource.WriteChangesAsync` documented none of the constraint. It was stated on `ITransactionWriter` and in the transaction docs, neither of which a source author has reason to read, even though the built-in `SourceTransactionWriter` calls every source inside that boundary. Documented now on the interface and in `docs/connectors.md`.

No behaviour change: the guard still rejects exactly what it rejected before, and both existing guard tests pass untouched.

## Tests

- `WhenSourceReadsPropertyWhileWriting_ThenErrorNamesTheSourceWriteBoundary` reproduces #475's scenario at the layer where it is reachable on master, a source reading the model in `WriteChangesAsync`, and pins the new message. It fails on master with "Sub-string not found".
- Three WebSocket integration tests cover transactional writes end to end (single scalar, batched multi-property, nested subject scalar), closing the coverage gap #475 names. They assert source ownership first, so an ownership regression cannot silently downgrade them to covering plain propagation. `WebSocketTestClient.StartAsync` gained a `configureContext` hook so a test can enable `WithSourceTransactions()`.

Tracking 511, Connectors 634, WebSocket 134 including integration, all green; solution builds clean with warnings as errors.

## Follow-ups, not in scope here

- A custom `ISubjectUpdateProcessor` runs for every change including scalars, so one that reads the model would reopen #475's chain without any structural change involved. No shipped processor does.
- No Connector Tester profile sets `UseTransactions`, so no profile exercises a transactional commit against a connector.
