### PR TITLE
chore: Add a release-notes skill, a pull request template, and a diff composition script

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,42 +2,12 @@
   "permissions": {
     "allow": [
       "Bash(dotnet build:*)",
-      "Bash(dotnet test:*)",
-      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --no-build)",
-      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --filter \"FullyQualifiedName~PerPropertySubscriptionTests\")",
-      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.slnx --filter \"Category!=Integration\")",
-      "Bash(echo \"emdash: $?\")",
-      "Bash(recursion\\\\|same policy *)",
-      "Bash(grep -n \"leaf slot\\\\|while holding the tracker lock\\\\|generation counter\\\\|Lock` recursion\\\\|same policy as\" docs/superpowers/specs/2026-07-18-path-subscriptions-design.md)",
-      "Bash(echo \"emdash-exit: $?\")",
-      "Read(//Users/ricosuter/Projects/GitHub/Namotion.Interceptor-path-subscriptions/**)",
-      "Bash(sed -n '/DispatchLateConsumers/,/^    }$/p' src/Namotion.Interceptor.Tracking/Change/PropertyChangeInterceptor.cs)",
-      "Bash(git add *)",
-      "Bash(git commit *)",
-      "Bash(/Users/ricosuter/.claude/plugins/cache/superpowers-marketplace/superpowers/6.1.1/skills/subagent-driven-development/scripts/task-brief docs/superpowers/plans/2026-07-21-path-subscriptions.md 15)",
-      "Bash(perl -0pi -e 's/            if \\\\\\(_segmentObservers\\\\[observer\\\\.Position\\\\] != observer\\\\\\)\\\\n            \\\\{\\\\n                return;\\\\n            \\\\}/            \\\\/\\\\/ TEMP-DISABLED\\\\n            \\\\/\\\\/ if \\(_segmentObservers[observer.Position] != observer\\) { return; }/' src/Namotion.Interceptor.Tracking/Paths/SubjectPathSubscription.cs)",
-      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --filter \"FullyQualifiedName~WhenLateCallbackArrivesForRetrackedObserver\")",
-      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --filter \"FullyQualifiedName~WhenLateCallbackArrivesForRetrackedObserver\" --no-restore --no-build)",
-      "Bash(DiffEngine_Disabled=true dotnet run -c Release --no-build -- --filter \"*Benchmark.PathDeliverDepth4\" \"*Benchmark.BareDeliverDepth4\" \"*Benchmark.PathHotLeafSuppressedDepth4\" \"*Benchmark.PathStructuralRetrackDepth4\" \"*Benchmark.CurrentReadDepth1\" \"*Benchmark.CurrentReadDepth4\" \"*Benchmark.SubscribeDisposeChurnDepth4\" \"*Benchmark.PathDeliverMixedDepth\" --job Short)",
-      "Bash(DiffEngine_Disabled=true dotnet run -c Release --no-build -- --filter \"*Benchmark.PathDeliverDepth1\" \"*Benchmark.BareDeliverDepth1\" \"*Benchmark.PathDeliverStringDepth1\" \"*Benchmark.PathDeliverImmutableArrayIntermediate\" \"*Benchmark.PathDeliverStructLeafDepth1\" \"*Benchmark.PathDeliverDepth4\" \"*Benchmark.CurrentReadDepth1\" \"*Benchmark.CurrentReadDepth4\" --job Short)",
-      "mcp__plugin_playwright_playwright__browser_navigate",
-      "mcp__plugin_playwright_playwright__browser_find",
-      "mcp__plugin_playwright_playwright__browser_click",
-      "mcp__plugin_playwright_playwright__browser_take_screenshot",
-      "Bash(awk -v s=9 '{printf \"%d:%s\\\\n\", NR+s, substr\\($0, index\\($0,\"\\\\t\"\\)+1\\)}')",
-      "WebFetch(domain:mudblazor.com)",
-      "WebFetch(domain:raw.githubusercontent.com)",
-      "Bash(DiffEngine_Disabled=true dotnet test src/HomeBlaze/HomeBlaze.History.Tests)",
-      "Bash(DiffEngine_Disabled=true dotnet test *)",
-      "Bash(python3 -)"
+      "Bash(dotnet test:*)"
     ],
     "deny": [],
     "ask": [],
     "additionalDirectories": [
       "C:\\Users\\rsute\\GitHub\\HomeBlaze"
     ]
-  },
-  "disabledMcpjsonServers": [
-    "homeblaze"
-  ]
+  }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,12 +2,42 @@
   "permissions": {
     "allow": [
       "Bash(dotnet build:*)",
-      "Bash(dotnet test:*)"
+      "Bash(dotnet test:*)",
+      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --no-build)",
+      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --filter \"FullyQualifiedName~PerPropertySubscriptionTests\")",
+      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.slnx --filter \"Category!=Integration\")",
+      "Bash(echo \"emdash: $?\")",
+      "Bash(recursion\\\\|same policy *)",
+      "Bash(grep -n \"leaf slot\\\\|while holding the tracker lock\\\\|generation counter\\\\|Lock` recursion\\\\|same policy as\" docs/superpowers/specs/2026-07-18-path-subscriptions-design.md)",
+      "Bash(echo \"emdash-exit: $?\")",
+      "Read(//Users/ricosuter/Projects/GitHub/Namotion.Interceptor-path-subscriptions/**)",
+      "Bash(sed -n '/DispatchLateConsumers/,/^    }$/p' src/Namotion.Interceptor.Tracking/Change/PropertyChangeInterceptor.cs)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(/Users/ricosuter/.claude/plugins/cache/superpowers-marketplace/superpowers/6.1.1/skills/subagent-driven-development/scripts/task-brief docs/superpowers/plans/2026-07-21-path-subscriptions.md 15)",
+      "Bash(perl -0pi -e 's/            if \\\\\\(_segmentObservers\\\\[observer\\\\.Position\\\\] != observer\\\\\\)\\\\n            \\\\{\\\\n                return;\\\\n            \\\\}/            \\\\/\\\\/ TEMP-DISABLED\\\\n            \\\\/\\\\/ if \\(_segmentObservers[observer.Position] != observer\\) { return; }/' src/Namotion.Interceptor.Tracking/Paths/SubjectPathSubscription.cs)",
+      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --filter \"FullyQualifiedName~WhenLateCallbackArrivesForRetrackedObserver\")",
+      "Bash(DiffEngine_Disabled=true dotnet test src/Namotion.Interceptor.Tracking.Tests --filter \"FullyQualifiedName~WhenLateCallbackArrivesForRetrackedObserver\" --no-restore --no-build)",
+      "Bash(DiffEngine_Disabled=true dotnet run -c Release --no-build -- --filter \"*Benchmark.PathDeliverDepth4\" \"*Benchmark.BareDeliverDepth4\" \"*Benchmark.PathHotLeafSuppressedDepth4\" \"*Benchmark.PathStructuralRetrackDepth4\" \"*Benchmark.CurrentReadDepth1\" \"*Benchmark.CurrentReadDepth4\" \"*Benchmark.SubscribeDisposeChurnDepth4\" \"*Benchmark.PathDeliverMixedDepth\" --job Short)",
+      "Bash(DiffEngine_Disabled=true dotnet run -c Release --no-build -- --filter \"*Benchmark.PathDeliverDepth1\" \"*Benchmark.BareDeliverDepth1\" \"*Benchmark.PathDeliverStringDepth1\" \"*Benchmark.PathDeliverImmutableArrayIntermediate\" \"*Benchmark.PathDeliverStructLeafDepth1\" \"*Benchmark.PathDeliverDepth4\" \"*Benchmark.CurrentReadDepth1\" \"*Benchmark.CurrentReadDepth4\" --job Short)",
+      "mcp__plugin_playwright_playwright__browser_navigate",
+      "mcp__plugin_playwright_playwright__browser_find",
+      "mcp__plugin_playwright_playwright__browser_click",
+      "mcp__plugin_playwright_playwright__browser_take_screenshot",
+      "Bash(awk -v s=9 '{printf \"%d:%s\\\\n\", NR+s, substr\\($0, index\\($0,\"\\\\t\"\\)+1\\)}')",
+      "WebFetch(domain:mudblazor.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(DiffEngine_Disabled=true dotnet test src/HomeBlaze/HomeBlaze.History.Tests)",
+      "Bash(DiffEngine_Disabled=true dotnet test *)",
+      "Bash(python3 -)"
     ],
     "deny": [],
     "ask": [],
     "additionalDirectories": [
       "C:\\Users\\rsute\\GitHub\\HomeBlaze"
     ]
-  }
+  },
+  "disabledMcpjsonServers": [
+    "homeblaze"
+  ]
 }

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -29,7 +29,15 @@ HomeBlaze must not appear in any prose chapter: not in the intro, Features, Fixe
 
 HomeBlaze appears only inside `## What's Changed`, under a `### HomeBlaze` subheading at the end of that list.
 
-Classify by the paths a pull request touches, not by its title: if every changed file is under `src/HomeBlaze/`, it is a HomeBlaze entry. One that ships core code and also touches HomeBlaze is a core entry, and stays in the main list; write up only its core half in the prose. If removing HomeBlaze content empties a section, drop the section. A short body is the correct outcome for a release that was mostly HomeBlaze; do not pad it.
+Classify by the paths a pull request touches, not by its title. Anything under `src/` that is not `src/Namotion.Interceptor*` is HomeBlaze: today that is `src/HomeBlaze/`, and on older tags the device libraries that sat at `src/Namotion.Devices.*` before they moved.
+
+```
+git show --pretty=format: --name-only <commit> | grep '^src/Namotion\.Interceptor'
+```
+
+A pull request that changes `src/Namotion.Interceptor*` source as well is a core entry and stays in the main list; write up only its core half. Judge on source files and ignore incidental ones, since almost every HomeBlaze change also touches the solution file, `Directory.Build.props`, a workflow or a doc. Titles mislead in both directions: "HomeBlaze: Philips Hue" (#243) shipped seven source files in `Namotion.Interceptor.Mcp` and is a core entry, while "HomeBlaze: Add myStrom WiFi Switch integration" (#245) touched nothing outside HomeBlaze but the solution file.
+
+If removing HomeBlaze content empties a section, drop the section. A short body is the correct outcome for a release that was mostly HomeBlaze; do not pad it.
 
 ## Structure
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -68,7 +68,15 @@ Headings are sentence case exactly as spelled above.
 
 Keep it compact: one sentence per bullet, two at most, each ending with its pull request reference like `(#420)`. Detail belongs in the pull request, which the reader can open.
 
-`## Breaking changes` is the exception, because a reader acts on it. Group by area with `### Area (#PR)` subsections when there is more than one, and allow two sentences per bullet. `## Migration` is a numbered list, one instruction per line. Keep measured numbers (percentages, byte sizes, allocation counts) wherever the source has them, and never invent one.
+`## Breaking changes` is the exception, because a reader acts on it. Group by area with `### Area (#PR)` subsections when there is more than one, and allow two sentences per bullet.
+
+Badge every bullet there with its kind, matching the labels a pull request description uses, so the note can carry the author's own classification through instead of re-deriving it:
+
+- `API:` a signature, rename or removal. The compiler catches it, or a failed recompile does.
+- `Behavior:` compiles and runs, and does something different.
+- `Contract:` compiles and runs, and the caller is now wrong unless it changes. State the new obligation.
+
+Badge all three consistently rather than only the surprising ones, so a reader can scan for `Contract:` and trust that its absence means there is none. That kind is the rare and dangerous one: nothing in a build or an API snapshot reveals it, and both instances in the last ten releases were of it, `LastSynchronizedAt` becoming a correctness obligation for direct `ISubjectSource` implementers and `WriteChangesAsync` no longer permitted to read the model. `## Migration` is a numbered list, one instruction per line. Keep measured numbers (percentages, byte sizes, allocation counts) wherever the source has them, and never invent one.
 
 ## Doc links
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -17,9 +17,11 @@ Write the body of a GitHub release for one tag, in the format every release from
 GitHub's generated list is unreliable: it has silently omitted merged pull requests on several tags of this repository. Derive the list yourself.
 
 ```
-git log --oneline <PREVIOUS_TAG>..<TAG>            # squash merges carry "Title (#NNN)"
-gh pr list --state merged --limit 100 --json number,title,author   # titles and authors in one call
+git log --oneline <PREVIOUS_TAG>..<TAG>                       # squash merges carry "Title (#NNN)"
+gh pr view <NNN> --json number,title,author                   # title and author, per number found above
 ```
+
+Look each number up individually. `gh pr list --limit 100` reaches only the hundred most recently merged pull requests, which today stops at #225, so on an older tag it silently returns nothing for the entries you need.
 
 Every entry is `* <pull request title> by @<author> in https://github.com/RicoSuter/Namotion.Interceptor/pull/<NNN>`. A commit in the range with no pull request reference still belongs in the list; give it its subject and short SHA so nothing merged is invisible. Close with `**Full Changelog**: https://github.com/RicoSuter/Namotion.Interceptor/compare/<PREVIOUS_TAG>...<TAG>`, matching the tag prefix style the compare link already uses for that pair.
 
@@ -127,7 +129,7 @@ State the claim, state what the tree shows, and stop there. Whether a descriptio
 
 ## Style
 
-The repository rules in AGENTS.md apply: no em dashes, no AI attribution anywhere, markdown paragraphs on one line with no hard wrapping, and no abbreviations in prose. Use exact API names in backticks.
+AGENTS.md applies: no em dashes, no abbreviations in prose, and no AI attribution anywhere. Also keep markdown paragraphs on one line rather than wrapping at a column, and use exact API names in backticks.
 
 ## Apply and check
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: release-notes
+description: "Use when writing or rewriting the GitHub release description for a tag of this repository, whether the release is published or still a draft. Produces the house format: bolded theme blocks, then Features, Fixes, Performance, Breaking changes, Migration."
+---
+
+# Release notes
+
+Write the body of a GitHub release for one tag, in the format every release from v0.5.0 onward uses.
+
+## Read first
+
+1. **The existing description of the tag**: `gh release view <TAG> --json body -q .body`. Where it already has prose, that prose is your primary source: it carries facts, measured numbers, and wording someone chose deliberately. Restructure and compact it rather than regenerating from scratch, and never drop a breaking change, a migration step, or a measured number it states. Older tags often have no prose at all, only an auto-generated list, in which case you are authoring from the pull requests instead and every claim needs a source.
+2. **Two or three recent releases** as the voice reference: `gh release view v0.9.2 --json body -q .body`, and the same for v0.9.1 and v0.9.0. Match their bullet length and section shapes.
+
+## Build the change list from git, not from GitHub
+
+GitHub's generated list is unreliable: it has silently omitted merged pull requests on several tags of this repository. Derive the list yourself.
+
+```
+git log --oneline <PREVIOUS_TAG>..<TAG>            # squash merges carry "Title (#NNN)"
+gh pr list --state merged --limit 100 --json number,title,author   # titles and authors in one call
+```
+
+Every entry is `* <pull request title> by @<author> in https://github.com/RicoSuter/Namotion.Interceptor/pull/<NNN>`. A commit in the range with no pull request reference still belongs in the list; give it its subject and short SHA so nothing merged is invisible. Close with `**Full Changelog**: https://github.com/RicoSuter/Namotion.Interceptor/compare/<PREVIOUS_TAG>...<TAG>`, matching the tag prefix style the compare link already uses for that pair.
+
+## Scope: Namotion.Interceptor only
+
+HomeBlaze must not appear in any prose chapter: not in the intro, Features, Fixes, Performance, Breaking changes, Migration, or any tail section. This includes HomeBlaze-only breaking changes and their migration steps.
+
+HomeBlaze appears only inside `## What's Changed`, under a `### HomeBlaze` subheading at the end of that list.
+
+Classify by the paths a pull request touches, not by its title: if every changed file is under `src/HomeBlaze/`, it is a HomeBlaze entry. One that ships core code and also touches HomeBlaze is a core entry, and stays in the main list; write up only its core half in the prose. If removing HomeBlaze content empties a section, drop the section. A short body is the correct outcome for a release that was mostly HomeBlaze; do not pad it.
+
+## Structure
+
+The intro is **only** bolded theme blocks. No framing or scene-setting sentence before them, no lead-in like "Two threads run through this release". Start straight at the first block.
+
+```
+**Theme name (#PR).** Two or three sentences: what changed and why it matters to a consumer.
+
+**Second theme (#PR).** Same.
+```
+
+Three to five blocks on a normal release, one or two on a small one. Nothing else above the first `##` heading.
+
+Then, omitting any section with nothing to say:
+
+1. `## Features`
+2. `## Fixes`
+3. `## Performance`
+4. `## Breaking changes`
+5. `## Migration`
+6. A release-specific tail section when one is warranted (`## Dependencies and cleanup`, `## Known limitation`)
+7. `## What's Changed`
+8. The `**Full Changelog**` line
+
+Headings are sentence case exactly as spelled above.
+
+Keep it compact: one sentence per bullet, two at most, each ending with its pull request reference like `(#420)`. Detail belongs in the pull request, which the reader can open.
+
+`## Breaking changes` is the exception, because a reader acts on it. Group by area with `### Area (#PR)` subsections when there is more than one, and allow two sentences per bullet. `## Migration` is a numbered list, one instruction per line. Keep measured numbers (percentages, byte sizes, allocation counts) wherever the source has them, and never invent one.
+
+## Doc links
+
+Link terms inline in the prose. Never add a list-of-links section.
+
+Use absolute URLs pinned to the release's own tag, so they show the docs as of that version:
+`https://github.com/RicoSuter/Namotion.Interceptor/blob/<TAG>/docs/<file>.md`
+
+Verify before linking, because the docs of an old tag are not today's docs:
+
+```
+git ls-tree --name-only <TAG> docs/                    # the file exists at that tag
+git show <TAG>:docs/<file>.md | grep -nE '^#{2,3} '    # the heading exists; lowercase it and hyphenate spaces for the anchor
+```
+
+A handful of links is right. Link the doc that covers a theme, not every noun.
+
+## Verify claims against the tree, and report what is wrong
+
+Pull request bodies describe intent at the time of writing and drift from what shipped. Several claims in this repository's history did not survive checking: a rename to a member that never existed at the base tag, a removal of helpers that were private all along, diagnostics counters described as new that already existed. All three were true when written and false by merge, which is a drift problem no amount of care at authoring time prevents.
+
+So check anything load-bearing before it reaches the notes. The tree wins; a claim the tree contradicts comes out.
+
+```
+git show <TAG>:<path>                                        # what actually shipped under that name
+git grep -n '<MemberName>' <PREVIOUS_TAG> -- src/            # did it exist at the base at all
+git diff <PREVIOUS_TAG> <TAG> -- '*PublicApi.verified.txt'   # exact public API breaks, where snapshots exist
+```
+
+Public API snapshots only exist from v0.6.0 onward. Below that, breaking changes rest on source diffs, so say less rather than more.
+
+Run the check in both directions:
+
+- **Wrong**: a claim in a pull request body that the tree contradicts at this tag. Note what the body says and what shipped.
+- **Incomplete**: a change in the tree that no pull request body mentions. The public API snapshot diff is the sharp tool here, since every entry in it should be traceable to some description. An unexplained entry is a real break nobody wrote up, which is how the `sourceName` to `connectorName` rename across the OPC UA registrations was found.
+
+### Report it
+
+Finish the run with a short report to the user, separate from the release body and never inside it:
+
+```
+Pull request descriptions worth correcting:
+
+- #323 says `GetPath` was renamed to `TryGetPath`. `GetPath` does not exist at v0.6.1; only
+  `TryGetPath` did, with the same signature. The rename predates the base tag.
+- #321 lists `PollingItemCount` and `TotalReconnectionAttempts` as new diagnostics. Both already
+  existed on `OpcUaClientDiagnostics` at v0.6.1. Only `PendingWriteCount` is new.
+- #262 says it removed `OpcUaClientRegistration` and `OpcUaServerRegistration`. Neither type exists
+  at either tag, so it describes an intermediate branch state.
+
+Not mentioned by any description, found in the API snapshot diff:
+
+- `sourceName` renamed to `connectorName` on `AddOpcUaSubjectClientSource`, `AddOpcUaSubjectServer`
+  and their keyed overloads. Breaks named-argument call sites.
+```
+
+State the claim, state what the tree shows, and stop there. Whether a description gets corrected is the user's call, not something to fix on their behalf, and the release notes ship correct either way because the wrong claims never entered them.
+
+## Style
+
+The repository rules in AGENTS.md apply: no em dashes, no AI attribution anywhere, markdown paragraphs on one line with no hard wrapping, and no abbreviations in prose. Use exact API names in backticks.
+
+## Apply and check
+
+```
+gh release edit <TAG> --notes-file <path>
+gh release view <TAG> --json body -q .body | grep -E '^## '     # section order
+```
+
+Confirm the body opens on a `**` block, contains no em dash, mentions HomeBlaze nowhere before `## What's Changed`, and links only to its own tag:
+
+```
+gh release view <TAG> --json body -q .body | grep -oE '/blob/v[0-9.]+/' | sort -u
+```
+
+That last check is also how you catch a body written for the wrong tag.
+
+A draft release keeps an `untagged-...` URL and its tag does not exist yet, so its tag-pinned doc links only resolve once it is published. That is expected; do not switch them to `master`.
+
+## Doing several tags at once
+
+One agent per tag works well. Give each a private scratchpad path or tag-scoped filenames (`v0.6.1-body.md`, not `body.md`); agents sharing a directory have overwritten each other's working files, and the failure mode is publishing one release's text under another tag. The `/blob/` check above catches it.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -76,7 +76,11 @@ Badge every bullet there with its kind, matching the labels a pull request descr
 - `Behavior:` compiles and runs, and does something different.
 - `Contract:` compiles and runs, and the caller is now wrong unless it changes. State the new obligation.
 
-Badge all three consistently rather than only the surprising ones, so a reader can scan for `Contract:` and trust that its absence means there is none. That kind is the rare and dangerous one: nothing in a build or an API snapshot reveals it, and both instances in the last ten releases were of it, `LastSynchronizedAt` becoming a correctness obligation for direct `ISubjectSource` implementers and `WriteChangesAsync` no longer permitted to read the model. `## Migration` is a numbered list, one instruction per line. Keep measured numbers (percentages, byte sizes, allocation counts) wherever the source has them, and never invent one.
+Badge all three consistently rather than only the surprising ones, so a reader can scan for `Contract:` and trust that its absence means there is none. That kind is the rare and dangerous one: nothing in a build or an API snapshot reveals it, and both instances in the last ten releases were of it, `LastSynchronizedAt` becoming a correctness obligation for direct `ISubjectSource` implementers and `WriteChangesAsync` no longer permitted to read the model.
+
+`## Migration` is a numbered list, one instruction per line, harvested from the migration step each breaking bullet in the pull request carries. Keep measured numbers (percentages, byte sizes, allocation counts) wherever the source has them, and never invent one.
+
+A pull request description has one section with no counterpart here. Its `## Contract` states the invariants the change establishes, which split two ways: a guarantee that is new becomes a `## Features` bullet, and a guarantee that changed becomes a `Contract:` bullet under `## Breaking changes`. A limitation stated there, such as a queue being unbounded, belongs in a `## Known limitation` tail section when a consumer would otherwise be surprised by it.
 
 ## Doc links
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -76,7 +76,7 @@ Badge every bullet there with its kind, matching the labels a pull request descr
 - `Behavior:` compiles and runs, and does something different.
 - `Contract:` compiles and runs, and the caller is now wrong unless it changes. State the new obligation.
 
-Badge all three consistently rather than only the surprising ones, so a reader can scan for `Contract:` and trust that its absence means there is none. That kind is the rare and dangerous one: nothing in a build or an API snapshot reveals it, and both instances in the last ten releases were of it, `LastSynchronizedAt` becoming a correctness obligation for direct `ISubjectSource` implementers and `WriteChangesAsync` no longer permitted to read the model.
+Badge all three consistently rather than only the surprising ones, so a reader can scan for `Contract:` and trust that its absence means there is none. Two kinds of bullet take no badge, because neither is a change a caller acts on in code: a scope note such as "no public API is added or removed", and a packaging change such as a new transitive dependency. That kind is the rare and dangerous one: nothing in a build or an API snapshot reveals it, and both instances in the last ten releases were of it, `LastSynchronizedAt` becoming a correctness obligation for direct `ISubjectSource` implementers and `WriteChangesAsync` no longer permitted to read the model.
 
 `## Migration` is a numbered list, one instruction per line, harvested from the migration step each breaking bullet in the pull request carries. Keep measured numbers (percentages, byte sizes, allocation counts) wherever the source has them, and never invent one.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,16 +58,19 @@
 
 ## Verification
 
-<!-- Tick what you ran, and give the count where a suite reports one. Strike an entry through with
+<!-- Tick what you did, and give the count where a suite reports one. Strike an entry through with
      ~~two tildes~~ and a short reason when it does not apply, so an unticked box always means
      "not done yet" rather than "not relevant". Say plainly what you did not run and why.
 
+     Documentation:     the docs/ pages describing the behavior or API this changes. A stale sample
+                        outlives a rename by months, and the release notes link these pages.
      Unit tests:        dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"
      Integration tests: per project, for connector or HomeBlaze UI changes
      Benchmarks:        docs/benchmarking.md, every benchmark the change can reach plus a noise reference
      Connector Tester:  docs/connector-tester.md, load and chaos profiles for risky connector work,
                         agreed while planning because they take hours -->
 
+- [ ] Documentation updated
 - [ ] Unit tests
 - [ ] Integration tests
 - [ ] Benchmarks

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,10 +18,23 @@
 
 <!-- The problem this solves, when the summary does not already make it obvious. Drop this heading if it does. -->
 
+## Contract
+
+<!-- Optional. What a caller can now rely on: the invariants this change establishes or alters.
+     One guarantee per bullet, stating the limit as plainly as the promise, for example "serialization
+     is per subscription, an observer shared by several subscriptions may still be invoked
+     concurrently" or "disposal drops queued work, a delivery already in flight may still complete".
+     Drop this heading when the change establishes no new guarantee. -->
+
 ## Breaking changes
 
-<!-- Public API changes, renamed or removed members, and behavior changes a consumer must act on,
-     each with the migration step that follows from it.
+<!-- What a consumer must act on, each with the migration step that follows from it. Cover all three
+     kinds, since only the first announces itself:
+
+     - API:      a signature, rename or removal. The compiler catches it, or a failed recompile does.
+     - Behavior: compiles and runs, and does something different.
+     - Contract: compiles and runs, and the caller is now wrong unless it changes. State the new
+                 obligation, for example an interface implementer that must now stamp a timestamp.
 
      Write "None" rather than deleting this heading, so an empty section is a decision rather than
      an oversight. This is the section the release notes most often need and most often lack.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,8 +19,22 @@
 
 ## Performance
 
-<!-- Measured numbers, with the benchmark they came from. Include a known regression as readily as an
-     improvement. Drop this heading when nothing was measured; an unmeasured claim is worse than silence. -->
+<!-- Start with a paragraph in plain terms: what the change costs or saves, and where. State a known
+     regression as readily as an improvement, and say when a cost was accepted on purpose.
+
+     Then condense the numbers into the table below, one row per benchmark the change can reach. Do not
+     paste raw BenchmarkDotNet output for both arms; a reader cannot diff two 15-column tables by eye.
+
+     Include at least one row the change cannot reach, marked as the noise reference. A delta means
+     nothing until it clears what that row did in the same run, and picking a reference is subtler than
+     it looks, because [GlobalSetup] is per class. See docs/benchmarking.md.
+
+     Drop this heading when nothing was measured; an unmeasured claim is worse than silence. -->
+
+| Benchmark | Before | After | Delta | Allocated |
+|---|---:|---:|---:|---|
+|  |  |  |  |  |
+| _noise reference_ |  |  |  |  |
 
 ## Diff composition
 
@@ -38,7 +52,7 @@
 
 - [ ] Unit tests, `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
 - [ ] Integration tests, per project, for connector or HomeBlaze UI changes
-- [ ] Benchmarks, `pwsh scripts/benchmark.ps1`, for changes that can affect a hot path
+- [ ] Benchmarks, `pwsh scripts/benchmark.ps1`, covering every benchmark the change can reach (find them with `--list flat`, and add a row it cannot reach as the noise reference)
 - [ ] Connector Tester load profile, for risky connector work
 - [ ] Connector Tester chaos profile, for risky connector work
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- What changed and why it matters to a consumer. A few sentences or bullets. -->
+
+## Why
+
+<!-- The problem this solves, when the summary does not already make it obvious. Drop this heading if it does. -->
+
+## Breaking changes
+
+<!-- Public API changes, renamed or removed members, and behavior changes a consumer must act on,
+     each with the migration step that follows from it.
+
+     Write "None" rather than deleting this heading, so an empty section is a decision rather than
+     an oversight. This is the section the release notes most often need and most often lack.
+
+     Check the public API snapshot diff before answering: a change in
+     VerifyChecksTests.PublicApi.verified.txt that is not described here reaches consumers unannounced. -->
+
+## Performance
+
+<!-- Measured numbers, with the benchmark they came from. Include a known regression as readily as an
+     improvement. Drop this heading when nothing was measured; an unmeasured claim is worse than silence. -->
+
+## Verification
+
+<!-- What you ran and what it reported: test suites and counts, integration or connector tester runs,
+     benchmarks, manual checks. Say plainly what you did not run. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,18 @@
-<!-- Delete each comment as you fill its section in, so the description reads as prose rather than
-     half boilerplate. Anything left here also reaches the tools that read this body later.
-     Drop any heading that does not apply, except Breaking changes. -->
+<!-- Start with the summary: what changed and why it matters to a consumer, in a few sentences or
+     bullets. No heading; the description opens on it.
 
-## Summary
-
-<!-- What changed and why it matters to a consumer. A few sentences or bullets.
-
-     Where issues are involved, close the section with a list of them. The first form has a
+     Where issues are involved, close the summary with a list of them. The first form has a
      mechanical effect on merge and the others do not:
 
      - Closes #123        closes the issue on merge. Only GitHub's keywords do this:
                           close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
      - Related to #123    touched but not finished. Avoid the keywords above or it closes anyway,
                           which is what "addresses" and "supersedes" are for.
-     - Follow-up: #123    deliberately left for later, so a reviewer can see where the scope line is. -->
+     - Follow-up: #123    deliberately left for later, so a reviewer can see where the scope line is.
+
+     Delete each comment as you fill its section in, so the description reads as prose rather than
+     half boilerplate. Anything left here also reaches the tools that read this body later.
+     Drop any heading that does not apply, except Breaking changes. -->
 
 ## Why
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,8 +52,8 @@
 
 - [ ] Unit tests, `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
 - [ ] Integration tests, per project, for connector or HomeBlaze UI changes
-- [ ] Benchmarks, `pwsh scripts/benchmark.ps1`, covering every benchmark the change can reach (find them with `--list flat`, and add a row it cannot reach as the noise reference)
-- [ ] Connector Tester load profile, for risky connector work
-- [ ] Connector Tester chaos profile, for risky connector work
+- [ ] Benchmarks per [Benchmarking](https://github.com/RicoSuter/Namotion.Interceptor/blob/master/docs/benchmarking.md), covering every benchmark the change can reach plus a noise reference
+- [ ] [Connector Tester](https://github.com/RicoSuter/Namotion.Interceptor/blob/master/docs/connector-tester.md) load profile, for risky connector work
+- [ ] [Connector Tester](https://github.com/RicoSuter/Namotion.Interceptor/blob/master/docs/connector-tester.md) chaos profile, for risky connector work
 
 <!-- Say plainly what you did not run and why. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,12 +4,10 @@
 
 ## Summary
 
-<!-- What changed and why it matters to a consumer. A few sentences or bullets. -->
+<!-- What changed and why it matters to a consumer. A few sentences or bullets.
 
-## Issues
-
-<!-- Optional; drop this heading when nothing applies. Three line types, because the first has a
-     mechanical effect on merge and the others do not:
+     Where issues are involved, list them here, one per line. The first form has a mechanical effect
+     on merge and the others do not:
 
      Closes #123          closes the issue on merge. Only GitHub's keywords do this:
                           close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,11 +50,9 @@
 
 ## Diff composition
 
-<!-- Generate with: pwsh scripts/diff-composition.ps1
-     Add -PerProject to break production code down per project on a change that spans several. -->
-
-| Area | Files | Added | Removed | Net |
-|---|---:|---:|---:|---:|
+<!-- Paste the output of: pwsh scripts/diff-composition.ps1
+     It prints the whole table, header included. Add -PerProject to break production code down per
+     project on a change that spans several. -->
 
 ## Verification
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,24 @@
 <!-- Measured numbers, with the benchmark they came from. Include a known regression as readily as an
      improvement. Drop this heading when nothing was measured; an unmeasured claim is worse than silence. -->
 
+## Diff composition
+
+<!-- Generate with: pwsh scripts/diff-composition.ps1
+     Add -PerProject to break production code down per project on a change that spans several. -->
+
+| Area | Files | Added | Removed | Net |
+|---|---:|---:|---:|---:|
+
 ## Verification
 
-<!-- What you ran and what it reported: test suites and counts, integration or connector tester runs,
-     benchmarks, manual checks. Say plainly what you did not run. -->
+<!-- Tick what you ran. Strike an entry through with ~~two tildes~~ and a short reason when it does not
+     apply, so an unticked box always means "not done yet" rather than "not relevant".
+     Where a suite has a count or a number, give it. -->
+
+- [ ] Unit tests, `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
+- [ ] Integration tests, per project, for connector or HomeBlaze UI changes
+- [ ] Benchmarks, `pwsh scripts/benchmark.ps1`, for changes that can affect a hot path
+- [ ] Connector Tester load profile, for risky connector work
+- [ ] Connector Tester chaos profile, for risky connector work
+
+<!-- Say plainly what you did not run and why. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!-- Delete each comment as you fill its section in, so the description reads as prose rather than
+     half boilerplate. Anything left here also reaches the tools that read this body later.
+     Drop any heading that does not apply, except Breaking changes. -->
+
 ## Summary
 
 <!-- What changed and why it matters to a consumer. A few sentences or bullets. -->
@@ -22,12 +26,12 @@
 <!-- Start with a paragraph in plain terms: what the change costs or saves, and where. State a known
      regression as readily as an improvement, and say when a cost was accepted on purpose.
 
-     Then condense the numbers into the table below, one row per benchmark the change can reach. Do not
-     paste raw BenchmarkDotNet output for both arms; a reader cannot diff two 15-column tables by eye.
+     Then condense the numbers into the table, one row per benchmark the change can reach. Do not paste
+     raw BenchmarkDotNet output for both arms; a reader cannot diff two 15-column tables by eye.
 
-     Include at least one row the change cannot reach, marked as the noise reference. A delta means
-     nothing until it clears what that row did in the same run, and picking a reference is subtler than
-     it looks, because [GlobalSetup] is per class. See docs/benchmarking.md.
+     Keep at least one row the change cannot reach, marked as the noise reference. A delta means nothing
+     until it clears what that row did in the same run, and picking a reference is subtler than it looks,
+     because [GlobalSetup] is per class. See docs/benchmarking.md.
 
      Drop this heading when nothing was measured; an unmeasured claim is worse than silence. -->
 
@@ -46,14 +50,18 @@
 
 ## Verification
 
-<!-- Tick what you ran. Strike an entry through with ~~two tildes~~ and a short reason when it does not
-     apply, so an unticked box always means "not done yet" rather than "not relevant".
-     Where a suite has a count or a number, give it. -->
+<!-- Tick what you ran, and give the count where a suite reports one. Strike an entry through with
+     ~~two tildes~~ and a short reason when it does not apply, so an unticked box always means
+     "not done yet" rather than "not relevant". Say plainly what you did not run and why.
 
-- [ ] Unit tests, `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`
-- [ ] Integration tests, per project, for connector or HomeBlaze UI changes
-- [ ] Benchmarks per [Benchmarking](https://github.com/RicoSuter/Namotion.Interceptor/blob/master/docs/benchmarking.md), covering every benchmark the change can reach plus a noise reference
-- [ ] [Connector Tester](https://github.com/RicoSuter/Namotion.Interceptor/blob/master/docs/connector-tester.md) load profile, for risky connector work
-- [ ] [Connector Tester](https://github.com/RicoSuter/Namotion.Interceptor/blob/master/docs/connector-tester.md) chaos profile, for risky connector work
+     Unit tests:        dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"
+     Integration tests: per project, for connector or HomeBlaze UI changes
+     Benchmarks:        docs/benchmarking.md, every benchmark the change can reach plus a noise reference
+     Connector Tester:  docs/connector-tester.md, load and chaos profiles for risky connector work,
+                        agreed while planning because they take hours -->
 
-<!-- Say plainly what you did not run and why. -->
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] Benchmarks
+- [ ] Connector Tester load profile
+- [ ] Connector Tester chaos profile

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -75,4 +75,4 @@
 - [ ] Integration tests
 - [ ] Benchmarks
 - [ ] Load tests
-- [ ] Choas tests
+- [ ] Chaos tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,17 @@
 
 <!-- What changed and why it matters to a consumer. A few sentences or bullets. -->
 
+## Issues
+
+<!-- Optional; drop this heading when nothing applies. Three line types, because the first has a
+     mechanical effect on merge and the others do not:
+
+     Closes #123          closes the issue on merge. Only GitHub's keywords do this:
+                          close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
+     Related to #123      touched but not finished. Avoid the keywords above or it closes anyway,
+                          which is what "addresses" and "supersedes" are for.
+     Follow-up: #123      deliberately left for later, so a reviewer can see where the scope line is. -->
+
 ## Why
 
 <!-- The problem this solves, when the summary does not already make it obvious. Drop this heading if it does. -->
@@ -63,5 +74,5 @@
 - [ ] Unit tests
 - [ ] Integration tests
 - [ ] Benchmarks
-- [ ] Connector Tester load profile
-- [ ] Connector Tester chaos profile
+- [ ] Load tests
+- [ ] Choas tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,14 +6,14 @@
 
 <!-- What changed and why it matters to a consumer. A few sentences or bullets.
 
-     Where issues are involved, list them here, one per line. The first form has a mechanical effect
-     on merge and the others do not:
+     Where issues are involved, close the section with a list of them. The first form has a
+     mechanical effect on merge and the others do not:
 
-     Closes #123          closes the issue on merge. Only GitHub's keywords do this:
+     - Closes #123        closes the issue on merge. Only GitHub's keywords do this:
                           close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
-     Related to #123      touched but not finished. Avoid the keywords above or it closes anyway,
+     - Related to #123    touched but not finished. Avoid the keywords above or it closes anyway,
                           which is what "addresses" and "supersedes" are for.
-     Follow-up: #123      deliberately left for later, so a reviewer can see where the scope line is. -->
+     - Follow-up: #123    deliberately left for later, so a reviewer can see where the scope line is. -->
 
 ## Why
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ The library has specialized support for:
 
 - **Avoid abbreviations** in variable and parameter names unless the name is very long. Use descriptive names (e.g., `attribute` not `attr`).
 - **No em dashes** in docs, READMEs, or PR descriptions. Restructure into plain sentences instead.
+- **No hard wrapping** in markdown. Keep a paragraph on one line instead of breaking at a column.
 
 ## Git Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,6 @@ The library has specialized support for:
 - Fill in [the pull request template](.github/pull_request_template.md). `gh pr create --body-file` bypasses it, so open the file rather than waiting to be shown it.
 - Prefix the title with `fix:`, `feat:`, `perf:`, `docs:`, `refactor:`, `test:` or `chore:`.
 - Apply an `area:` and a `type:` label at creation with `gh pr create --label`, choosing from `gh label list`.
-- Link documentation instead of restating it: the docs describe the behavior, the pull request describes the change.
 
 ## Test Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,16 @@ Always read [Benchmarking](docs/benchmarking.md) before running or interpreting 
 
 ### Project Structure
 ```
-src/
-├── Namotion.Interceptor/           # Core library with base interfaces
-├── Namotion.Interceptor.Generator/ # Source generator for [InterceptorSubject]
-├── Namotion.Interceptor.{Feature}/ # Extension libraries (Tracking, Registry, etc.)
-├── Extensions/                     # Integration packages (AspNetCore, Blazor, etc.)
-├── Samples/                        # Example applications
-└── Tests/                          # Unit test projects
-docs/                               # Feature and connector documentation
-├── design/                         # Internal design documents
+src/                                  # Projects are flat here, grouped by name rather than by folder
+├── Namotion.Interceptor/             # Core library with base interfaces
+├── Namotion.Interceptor.Generator/   # Source generator for [InterceptorSubject]
+├── Namotion.Interceptor.{Feature}/   # Libraries: Tracking, Registry, Connectors, OpcUa, AspNetCore, ...
+├── Namotion.Interceptor.{X}.Tests/   # Test project per library
+├── Namotion.Interceptor.{X}Sample*/  # Example applications
+├── Namotion.Interceptor.Benchmark/   # BenchmarkDotNet project
+└── HomeBlaze/                        # HomeBlaze application and its device libraries
+docs/                                 # Feature and connector documentation
+└── design/                           # Internal design documents
 ```
 
 ## Language Requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,13 @@ The library has specialized support for:
 
 - Never include AI attribution in commit messages, PR descriptions, or GitHub comments. This covers agent names ("Claude", "Codex", "Copilot"), `Co-Authored-By` trailers, and "Generated with" footers.
 
+## Pull Requests
+
+- Fill in [the pull request template](.github/pull_request_template.md). `gh pr create --body-file` bypasses it, so open the file rather than waiting to be shown it.
+- Prefix the title with `fix:`, `feat:`, `perf:`, `docs:`, `refactor:`, `test:` or `chore:`.
+- Apply an `area:` and a `type:` label at creation with `gh pr create --label`, choosing from `gh label list`.
+- Link documentation instead of restating it: the docs describe the behavior, the pull request describes the change.
+
 ## Test Conventions
 
 - **Naming**: `When<Condition>_Then<ExpectedBehavior>` (e.g., `WhenDepthIsZero_ThenReturnsNoChildren`)

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -82,7 +82,7 @@ builder.Services.AddOpcUaSubjectClientSource(
         SubjectFactory = new OpcUaSubjectFactory(DefaultSubjectFactory.Instance),
 
         // Optional
-        RootName = "Machines",
+        RootPath = ["Machines"],
         DefaultNamespaceUri = "http://factory.com/machines",
         ApplicationName = "MyOpcUaClient",
         ReconnectInterval = TimeSpan.FromSeconds(5),

--- a/scripts/diff-composition.ps1
+++ b/scripts/diff-composition.ps1
@@ -41,11 +41,10 @@ function Get-Area {
     if ($Path -match '\.(csproj|slnx|props|targets|yml|yaml)$') { return "Project and CI files" }
 
     if ($PerProject -and $Path -like 'src/*') {
-        # The project is the first segment under src/, except under a grouping folder,
-        # where src/Extensions/Namotion.Interceptor.AspNetCore/... is one project down.
+        # Projects sit directly under src/, except beneath src/HomeBlaze/, where
+        # src/HomeBlaze/HomeBlaze.OpcUa/... is one level further down.
         $segments = $Path -split '/'
-        $grouping = @("Extensions", "Samples", "Tests", "HomeBlaze")
-        $project = if ($segments.Length -gt 3 -and $grouping -contains $segments[1]) { $segments[2] } else { $segments[1] }
+        $project = if ($segments.Length -gt 3 -and $segments[1] -eq "HomeBlaze") { $segments[2] } else { $segments[1] }
         if ($project) { return $project }
     }
 

--- a/scripts/diff-composition.ps1
+++ b/scripts/diff-composition.ps1
@@ -35,6 +35,7 @@ if ($LASTEXITCODE -ne 0) { throw "git diff failed for range '$Range'." }
 function Get-Area {
     param([string] $Path)
 
+    if ($Path -like 'scripts/*' -or $Path -like '.github/*') { return "Scripts and CI" }
     if ($Path -match '\.md$' -or $Path -like 'docs/*') { return "Documentation" }
     if ($Path -match 'Tests|Testing|Benchmark') { return "Tests and benchmarks" }
     if ($Path -match '\.(csproj|slnx|props|targets|yml|yaml)$') { return "Project and CI files" }
@@ -73,7 +74,7 @@ if ($areas.Count -eq 0) {
     return
 }
 
-$order = @("Production code", "Tests and benchmarks", "Documentation", "Project and CI files")
+$order = @("Production code", "Tests and benchmarks", "Documentation", "Scripts and CI", "Project and CI files")
 $sorted = @($areas.Keys | Sort-Object {
     $index = $order.IndexOf($_)
     if ($index -ge 0) { "1-{0:d3}" -f $index } else { "0-$_" }

--- a/scripts/diff-composition.ps1
+++ b/scripts/diff-composition.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Prints a markdown table of lines added, removed, and net per area for a diff range.
+
+.DESCRIPTION
+    Buckets every changed file into production code, tests and benchmarks, documentation,
+    or project and CI files, and totals the line counts of each. The output is the diff
+    composition table used in pull request descriptions.
+
+    Binary files report no line counts and are skipped.
+
+.PARAMETER Range
+    Any range git diff --numstat accepts, for example "origin/master...HEAD" or "v0.9.0 v0.9.1".
+    Defaults to origin/master...HEAD, the changes on the current branch.
+
+.PARAMETER PerProject
+    Break production code down per project instead of reporting it as one row.
+
+.EXAMPLE
+    pwsh scripts/diff-composition.ps1
+
+.EXAMPLE
+    pwsh scripts/diff-composition.ps1 -Range "v0.9.0 v0.9.1" -PerProject
+#>
+param(
+    [string] $Range = "origin/master...HEAD",
+    [switch] $PerProject
+)
+
+$ErrorActionPreference = "Stop"
+
+$numstat = git diff --numstat @($Range -split '\s+')
+if ($LASTEXITCODE -ne 0) { throw "git diff failed for range '$Range'." }
+
+function Get-Area {
+    param([string] $Path)
+
+    if ($Path -match '\.md$' -or $Path -like 'docs/*') { return "Documentation" }
+    if ($Path -match 'Tests|Testing|Benchmark') { return "Tests and benchmarks" }
+    if ($Path -match '\.(csproj|slnx|props|targets|yml|yaml)$') { return "Project and CI files" }
+
+    if ($PerProject -and $Path -like 'src/*') {
+        # The project is the first segment under src/, except under a grouping folder,
+        # where src/Extensions/Namotion.Interceptor.AspNetCore/... is one project down.
+        $segments = $Path -split '/'
+        $grouping = @("Extensions", "Samples", "Tests", "HomeBlaze")
+        $project = if ($segments.Length -gt 3 -and $grouping -contains $segments[1]) { $segments[2] } else { $segments[1] }
+        if ($project) { return $project }
+    }
+
+    return "Production code"
+}
+
+$areas = [ordered] @{}
+foreach ($line in $numstat) {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+    $added, $removed, $path = $line -split "`t", 3
+    if ($added -eq '-' -or $removed -eq '-') { continue }
+
+    $area = Get-Area -Path $path
+    if (-not $areas.Contains($area)) {
+        $areas[$area] = [pscustomobject] @{ Files = 0; Added = 0; Removed = 0 }
+    }
+
+    $areas[$area].Files++
+    $areas[$area].Added += [int] $added
+    $areas[$area].Removed += [int] $removed
+}
+
+if ($areas.Count -eq 0) {
+    Write-Output "No changes in range '$Range'."
+    return
+}
+
+$order = @("Production code", "Tests and benchmarks", "Documentation", "Project and CI files")
+$sorted = @($areas.Keys | Sort-Object {
+    $index = $order.IndexOf($_)
+    if ($index -ge 0) { "1-{0:d3}" -f $index } else { "0-$_" }
+})
+
+"| Area | Files | Added | Removed | Net |"
+"|---|---:|---:|---:|---:|"
+foreach ($area in $sorted) {
+    $row = $areas[$area]
+    "| {0} | {1} | {2:n0} | {3:n0} | {4:+#,##0;-#,##0;0} |" -f $area, $row.Files, $row.Added, $row.Removed, ($row.Added - $row.Removed)
+}
+
+$files = ($areas.Values | Measure-Object -Property Files -Sum).Sum
+$added = ($areas.Values | Measure-Object -Property Added -Sum).Sum
+$removed = ($areas.Values | Measure-Object -Property Removed -Sum).Sum
+"| **Total** | **{0}** | **{1:n0}** | **{2:n0}** | **{3:+#,##0;-#,##0;0}** |" -f $files, $added, $removed, ($added - $removed)


### PR DESCRIPTION
Adds a `release-notes` skill, a pull request template, a script that generates the diff composition table, and a short pull request section in `AGENTS.md`, plus one stale documentation fix found along the way.

The release description format that every release from v0.5.0 onward now uses was only discoverable by reading the releases themselves. That carries the shape but not the process, so the skill records what the output cannot show: that the existing description is the source to restructure, that the change list is derived from git rather than from GitHub's generated list, that doc links are pinned to the release's own tag and verified to exist there, and that HomeBlaze belongs only under its subheading in What's Changed.

The template settles the heading names already in use and closes the gaps the release notes kept hitting.

- Related to #444, which wrote the benchmarking guide this leans on

## Why

Four problems showed up while rewriting the notes for v0.5.0 through v0.9.2.

**GitHub's generated change list silently omits merged pull requests**, six on v0.5.0 and two on v0.6.1. Anything derived from it inherits the omission, so the skill derives the list from `git log <previous>..<tag>`. Both lists have since been regenerated and now account for every merged pull request in their range, plus the two commits that carried no pull request at all.

**Pull request descriptions drift from what ships.** Three claims in this repository's history were true when written and false by merge: a rename to a member that never existed at the base tag, a removal of helpers that were private all along, and diagnostics counters described as new that already existed. In the other direction, the `sourceName` to `connectorName` rename across the OPC UA registrations shipped with no description mentioning it. The skill now checks claims against the tree in both directions and reports what does not hold, rather than correcting descriptions on the author's behalf.

**One kind of breaking change announces itself and two do not.** An API change fails the build or shows in the public API snapshot. A behavior change compiles and runs and does something different. A contract change compiles, runs, and leaves the caller silently wrong, which is what `LastSynchronizedAt` becoming a correctness obligation and `WriteChangesAsync` no longer permitted to read the model both were. Template and skill now name all three, and the release notes badge each breaking bullet with its kind.

**Documentation goes stale quietly.** `RootName` sat in the OPC UA client configuration sample for four months after v0.6.1 renamed it to `RootPath`, and the release notes link these pages.

Of the last 60 merged pull requests, only one had no headings and 37 had four or more, so the template codifies existing practice rather than imposing a new shape. It settles one spelling per family, since verification appears as Verification, Test plan, Tests and Testing, and a contract section appears as Contract, Contract notes and Contract and compatibility notes. Breaking changes is the gap: described in 10 of those 60, while the release notes needed that section in 7 of the last 10 releases.

## Breaking changes

None. No compiled code changes in this branch.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Documentation | 3 | 183 | 10 | +173 |
| Scripts and CI | 2 | 181 | 0 | +181 |
| **Total** | **5** | **364** | **10** | **+354** |

## Verification

- [x] Documentation updated, the stale `RootName` sample in `docs/connectors-opcua-client.md`
- [ ] ~~Unit tests~~ no compiled code changed; the branch touches documentation, a skill, a template, and one PowerShell script
- [ ] ~~Integration tests~~ same
- [ ] ~~Benchmarks~~ same
- [ ] ~~Load tests~~ same
- [ ] ~~Chaos tests~~ same

`scripts/diff-composition.ps1` was exercised on four ranges instead: `v0.8.0 v0.9.0`, `v0.9.1 origin/master`, and this branch before and after its own bucketing fix. Totals reconcile between flat and `-PerProject` mode, and three bugs were found that way and fixed: `-PerProject` reported subfolder names such as "Diagnostics" instead of project names, repository tooling under `scripts/` was filed as production code, and the per-project rule carried grouping folders that have no tracked files.

The documentation fix was checked against the tree: `RootPath` is `string[]?` on `OpcUaClientConfiguration`, and no client-side `RootName` remains under `docs/`. The remaining occurrences are server configuration, which legitimately kept that name.

Both artefacts were applied to real work rather than reviewed on paper. The skill produced the ten reformatted releases from v0.5.0 to v0.9.2, and badging the three most recent ones surfaced the two bullet kinds that take no badge. This description follows the template it adds, with `## Contract` dropped because the branch establishes no runtime guarantee.
