### PR TITLE
Set up the handoff state the drain re-check test claims to test

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/SourceSubscriptionTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceSubscriptionTests.cs
@@ -201,8 +201,11 @@ public class SourceSubscriptionHandoffTests
     {
         // Arrange
         // The handoff is a few nanoseconds wide inside a running drain, so it is exercised directly:
-        // deleting the whole re-check loop leaves every other test in the suite green.
+        // deleting the whole re-check loop leaves every other test in the suite green. The flag is set
+        // because that is the state a drain calls this in, and the release it performs is half of what
+        // is under test.
         var subscription = CreateSubscription();
+        MarkDraining(subscription);
 
         // Act
         var keepDraining = subscription.TryReacquireForPendingEvents();
@@ -219,7 +222,13 @@ public class SourceSubscriptionHandoffTests
         // This is the stranded-event case: a producer that enqueued while _draining was still 1
         // declined to schedule a new drain, so this thread must notice the queue is non-empty and
         // take the flag straight back. Without the re-check the event is never delivered.
+        //
+        // The flag has to be set before the enqueue, and that is the whole scenario rather than test
+        // scaffolding: it is what makes the producer decline. Enqueueing with it clear instead has
+        // Enqueue schedule a real drain, which empties the queue from the thread pool and races this
+        // thread, so the assertion below could only hold while the pool was too busy to run it.
         var subscription = CreateSubscription();
+        MarkDraining(subscription);
         subscription.Enqueue(CreateEvent());
 
         // Act
@@ -233,11 +242,18 @@ public class SourceSubscriptionHandoffTests
     private static SourceSubscription CreateSubscription() =>
         new(_ => { }, ImmutableArray<ISubjectSource>.Empty, _ => { }, new SourceMonitor());
 
-    private static int GetDrainingFlag(SourceSubscription subscription)
-    {
-        var field = typeof(SourceSubscription).GetField("_draining", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        return (int)field.GetValue(subscription)!;
-    }
+    private static readonly FieldInfo DrainingField =
+        typeof(SourceSubscription).GetField("_draining", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static int GetDrainingFlag(SourceSubscription subscription) =>
+        (int)DrainingField.GetValue(subscription)!;
+
+    /// <summary>
+    /// Puts the subscription in the state the handoff runs in, a drain already in progress, which is
+    /// the precondition both tests describe and neither could reach through the public surface.
+    /// </summary>
+    private static void MarkDraining(SourceSubscription subscription) =>
+        DrainingField.SetValue(subscription, 1);
 
     private static SourceEvent CreateEvent() => new(
         SourceEventKind.SourceRegistered, new HandoffTestSource(), null,


### PR DESCRIPTION
`SourceSubscriptionTests.WhenAnEventArrivedDuringHandoff_ThenTheDrainReacquiresAndKeepsGoing` fails 11 of 12 isolated runs and passes every time in the full suite, which is the signature of a test racing its own setup rather than a flaky product.

The test enqueued with `_draining` clear, which is the one state where `Enqueue` schedules a real drain. That drain emptied the queue from the thread pool while the test raced it to read the queue, so the assertion held only while the pool was too busy to run it. Under full-suite load the pool always was.

The flag belongs before the enqueue, and it is the scenario rather than scaffolding: the test's own comment describes a producer that enqueued while `_draining` was still 1 and therefore declined to schedule, which is the case that can strand an event. That precondition was never established. Setting it makes the enqueue decline as described and removes the background drain entirely.

## Verification

- Twelve isolated runs pass, against 1 of 12 before.
- Replacing the re-check in `SourceSubscription.TryReacquireForPendingEvents` with a bare `false` still fails the test, so nothing was unpinned by the change.
- Full `Namotion.Interceptor.Connectors.Tests` suite green, 728 passed.

Test-only change, no production code touched.