### PR TITLE
fix: repair four flaky CI failures

### DIFF
--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/WebTestingHostFactory.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/WebTestingHostFactory.cs
@@ -1,11 +1,3 @@
-using HomeBlaze.Components;
-using HomeBlaze.Plugins;
-using HomeBlaze.Samples;
-using HomeBlaze.OpcUa;
-using HomeBlaze.OpcUa.Blazor;
-using HomeBlaze.Services;
-using HomeBlaze.Storage;
-using HomeBlaze.Storage.Blazor.Files;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -73,27 +65,10 @@ public class WebTestingHostFactory<TProgram> : WebApplicationFactory<TProgram>
         // Build and start the Kestrel host
         _kestrelHost = builder.Build();
 
-        // Configure TypeProvider with essential assemblies for E2E tests
-        var typeProvider = _kestrelHost.Services.GetRequiredService<TypeProvider>();
-        typeProvider
-            .AddAssembly(typeof(FluentStorageContainer).Assembly)      // HomeBlaze.Storage
-            .AddAssembly(typeof(Motor).Assembly)                       // HomeBlaze.Samples (for test subjects)
-            .AddAssembly(typeof(PluginManager).Assembly);              // HomeBlaze.Plugins
-
-        // Load runtime plugins and register their assemblies.
-        // Use Task.Run to avoid deadlocking the synchronous CreateHost call.
-        var pluginLoader = _kestrelHost.Services.GetRequiredService<PluginLoader>();
-        var pluginResult = Task.Run(() => pluginLoader.LoadPluginsAsync(CancellationToken.None)).GetAwaiter().GetResult();
-        if (pluginResult != null)
-        {
-            foreach (var plugin in pluginResult.LoadedPlugins)
-            {
-                foreach (var assembly in plugin.Assemblies)
-                {
-                    typeProvider.AddAssembly(assembly);
-                }
-            }
-        }
+        // TypeProvider is deliberately not populated here. The entry point already registers every
+        // assembly this factory used to add, and loads the same plugins, against the same singleton.
+        // Doing it again from this thread while the entry point runs on its own put two writers into
+        // one provider at once, which is what made the E2E fixture fail to initialise.
 
         _kestrelHost.Start();
 

--- a/src/HomeBlaze/HomeBlaze.Services/TypeProvider.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/TypeProvider.cs
@@ -7,28 +7,35 @@ namespace HomeBlaze.Services;
 /// </summary>
 public class TypeProvider
 {
-    private readonly List<Type> _types = [];
+    private readonly Lock _lock = new();
+
+    // Copy-on-write: readers take the current array without a lock, writers publish a replacement.
+    // Registration is a short burst at startup while the lookups below run for the life of the process
+    // and sit on request paths, so the cost belongs on the write side. Publishing a new array also means
+    // a reader that is midway through an enumeration keeps walking the snapshot it started on.
+    private Type[] _types = [];
 
     /// <summary>
     /// Gets all collected types.
     /// </summary>
-    public IReadOnlyCollection<Type> Types => _types;
+    public IReadOnlyCollection<Type> Types => Volatile.Read(ref _types);
 
     /// <summary>
     /// Adds exported types from an assembly.
     /// </summary>
     public TypeProvider AddAssembly(Assembly assembly)
     {
+        Type[] exportedTypes;
         try
         {
-            _types.AddRange(assembly.GetExportedTypes());
+            exportedTypes = assembly.GetExportedTypes();
         }
         catch (ReflectionTypeLoadException exception)
         {
-            var loadedTypes = exception.Types.Where(type => type != null);
-            _types.AddRange(loadedTypes!);
+            exportedTypes = exception.Types.Where(type => type is not null).ToArray()!;
         }
 
+        AddTypes(exportedTypes);
         return this;
     }
 
@@ -37,6 +44,21 @@ public class TypeProvider
     /// </summary>
     public void AddTypes(IEnumerable<Type> types)
     {
-        _types.AddRange(types);
+        var addedTypes = types as Type[] ?? types.ToArray();
+        if (addedTypes.Length == 0)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            var existingTypes = _types;
+            var combinedTypes = new Type[existingTypes.Length + addedTypes.Length];
+
+            existingTypes.CopyTo(combinedTypes, 0);
+            addedTypes.CopyTo(combinedTypes, existingTypes.Length);
+
+            Volatile.Write(ref _types, combinedTypes);
+        }
     }
 }

--- a/src/Namotion.Interceptor.Connectors.Tests/ChangeMergerTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/ChangeMergerTests.cs
@@ -341,7 +341,7 @@ public class ChangeMergerTests
 
         // Warm up: the JIT, the property index capacity, the pooled buffer and the sticky written-out
         // mark are all one-time costs that would otherwise land inside the measurement.
-        for (var warmup = 0; warmup < 5; warmup++)
+        for (var warmup = 0; warmup < AllocationWarmupRounds; warmup++)
         {
             merger.Merge(changes, ChangeDeliveryRule.SourceValuesMayBeStale);
             merger.Reset();
@@ -574,7 +574,7 @@ public class ChangeMergerTests
         using var merger = new ChangeMerger();
         var changes = CreateWideBatch(changeCount: 4096, distinctProperties: 8);
 
-        for (var warmup = 0; warmup < 5; warmup++)
+        for (var warmup = 0; warmup < AllocationWarmupRounds; warmup++)
         {
             merger.Merge(changes);
             merger.Reset();
@@ -589,6 +589,13 @@ public class ChangeMergerTests
         // Assert
         Assert.Equal(0, allocated);
     }
+
+    // Deep enough that the measured call runs fully promoted code. Tier-0 has runtime work billed to
+    // the calling thread, and a five round warmup left the single measured call still in tier-0, which
+    // is what made these tests report a few thousand stray bytes under CI load. The count is kept
+    // congruent to the old one modulo the buffer's four batch trim cycle, so the measured call still
+    // lands off a re-rent exactly as it did at five rounds.
+    private const int AllocationWarmupRounds = 101;
 
     private const int PropertyIndexMaximum = 1024;
 

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
@@ -303,11 +303,24 @@ public class SourceMonitorTests
         reachedStateRead.Reset();
         releaseStateRead.Reset();
 
-        var actTask = Task.Run(() => act(monitor, source));
+        // Both race participants park on locks and gates, so they run on dedicated threads rather than
+        // the pool: the full assembly runs its collections in parallel, and a queued work item can then
+        // wait seconds before it is ever scheduled. That starvation is what makes the State read time out
+        // below, and it also lets the blocked-Subscribe assertion pass for the wrong reason, since a
+        // Subscribe that was never scheduled has not completed either.
+        var actTask = RunOnDedicatedThread(() => act(monitor, source));
         Assert.True(reachedStateRead.Wait(TimeSpan.FromSeconds(10)),
             "The racing action should have reached the State read before the timeout.");
 
-        var subscribeTask = Task.Run(() => monitor.Subscribe(sourceEvent => received.Enqueue(sourceEvent)));
+        var subscribeEntered = new ManualResetEventSlim(false);
+        var subscribeTask = RunOnDedicatedThread(() =>
+        {
+            subscribeEntered.Set();
+            return monitor.Subscribe(sourceEvent => received.Enqueue(sourceEvent));
+        });
+
+        Assert.True(subscribeEntered.Wait(TimeSpan.FromSeconds(10)),
+            "The racing Subscribe should have started before the timeout.");
 
         // Subscribe must be BLOCKED here, on the lock the paused action still holds. Asserted
         // directly rather than by catching a timeout as the pass path: under load that catch fires
@@ -337,6 +350,41 @@ public class SourceMonitorTests
 
         return (wasInSnapshot, wasDelivered);
     }
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on its own thread and surfaces it as a task. Race participants here
+    /// block on locks and gates for as long as the test holds them, so they must not be queued behind the
+    /// rest of the assembly on the thread pool.
+    /// </summary>
+    private static Task<T> RunOnDedicatedThread<T>(Func<T> body)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                completion.SetResult(body());
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "SourceMonitorTests race participant"
+        };
+
+        thread.Start();
+        return completion.Task;
+    }
+
+    private static Task RunOnDedicatedThread(Action body) =>
+        RunOnDedicatedThread<object?>(() =>
+        {
+            body();
+            return null;
+        });
 
     [Fact]
     public void WhenNoMonitorIsConfigured_ThenGetSourceMonitorThrowsWithGuidance()

--- a/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SourceMonitorTests.cs
@@ -308,12 +308,12 @@ public class SourceMonitorTests
         // wait seconds before it is ever scheduled. That starvation is what makes the State read time out
         // below, and it also lets the blocked-Subscribe assertion pass for the wrong reason, since a
         // Subscribe that was never scheduled has not completed either.
-        var actTask = RunOnDedicatedThread(() => act(monitor, source));
+        var actTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() => act(monitor, source));
         Assert.True(reachedStateRead.Wait(TimeSpan.FromSeconds(10)),
             "The racing action should have reached the State read before the timeout.");
 
         var subscribeEntered = new ManualResetEventSlim(false);
-        var subscribeTask = RunOnDedicatedThread(() =>
+        var subscribeTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() =>
         {
             subscribeEntered.Set();
             return monitor.Subscribe(sourceEvent => received.Enqueue(sourceEvent));
@@ -350,41 +350,6 @@ public class SourceMonitorTests
 
         return (wasInSnapshot, wasDelivered);
     }
-
-    /// <summary>
-    /// Runs <paramref name="body"/> on its own thread and surfaces it as a task. Race participants here
-    /// block on locks and gates for as long as the test holds them, so they must not be queued behind the
-    /// rest of the assembly on the thread pool.
-    /// </summary>
-    private static Task<T> RunOnDedicatedThread<T>(Func<T> body)
-    {
-        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var thread = new Thread(() =>
-        {
-            try
-            {
-                completion.SetResult(body());
-            }
-            catch (Exception exception)
-            {
-                completion.SetException(exception);
-            }
-        })
-        {
-            IsBackground = true,
-            Name = "SourceMonitorTests race participant"
-        };
-
-        thread.Start();
-        return completion.Task;
-    }
-
-    private static Task RunOnDedicatedThread(Action body) =>
-        RunOnDedicatedThread<object?>(() =>
-        {
-            body();
-            return null;
-        });
 
     [Fact]
     public void WhenNoMonitorIsConfigured_ThenGetSourceMonitorThrowsWithGuidance()
@@ -444,7 +409,8 @@ public class SourceMonitorTests
         // Act - pause StartAsync exactly where it reads RootSubject to resolve which monitors to
         // register with, so Dispose can run to completion (transitioning to Stopped and finding
         // nothing yet in _registeredMonitors to unregister) before StartAsync ever registers.
-        var startTask = Task.Run(() => source.StartAsync(CancellationToken.None));
+        var startTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => source.StartAsync(CancellationToken.None));
         Assert.True(reachedRootRead.Wait(TimeSpan.FromSeconds(10)));
 
         source.Dispose();
@@ -480,12 +446,14 @@ public class SourceMonitorTests
             var source = new TestStateSource(new Person(context));
 
             using var bothReady = new Barrier(2);
-            var startTask = Task.Run(() =>
+            // A Barrier both sides must reach, so a participant the pool never schedules hangs the
+            // test outright rather than failing it.
+            var startTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() =>
             {
                 bothReady.SignalAndWait();
                 return source.StartAsync(CancellationToken.None);
             });
-            var disposeTask = Task.Run(() =>
+            var disposeTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() =>
             {
                 bothReady.SignalAndWait();
                 source.Dispose();
@@ -522,11 +490,11 @@ public class SourceMonitorTests
         // Act - Register attaches the StateChanged forwarder BEFORE it publishes SourceRegistered,
         // and is pinned here on the State read it performs to build that event, still holding the
         // monitor lock.
-        var register = Task.Run(() => monitor.Register(source));
+        var register = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() => monitor.Register(source));
         Assert.True(reachedStateRead.Wait(TimeSpan.FromSeconds(10)));
 
         using var transitionStarted = new ManualResetEventSlim(false);
-        var transition = Task.Run(() =>
+        var transition = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() =>
         {
             transitionStarted.Set();
             source.RaiseStateChanged(SourceState.Synchronizing, SourceState.Synchronized);

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceExtensionsTests.cs
@@ -356,6 +356,27 @@ public class SubjectSourceExtensionsTests
         Assert.Contains("Property5", failedNames);
     }
 
+    /// <summary>
+    /// Records a new maximum seen by several callers at once. A plain read-modify-write loses updates
+    /// when the writes overlap, which is the very situation these tests manufacture: the concurrent case
+    /// can then observe two of its three overlapping calls and fail for no reason, and the serialized
+    /// case can drop the evidence that serialization leaked.
+    /// </summary>
+    private static void RecordMaximum(ref int maximum, int candidate)
+    {
+        var observed = Volatile.Read(ref maximum);
+        while (candidate > observed)
+        {
+            var previous = Interlocked.CompareExchange(ref maximum, candidate, observed);
+            if (previous == observed)
+            {
+                return;
+            }
+
+            observed = previous;
+        }
+    }
+
     [Fact]
     public async Task WriteChangesInBatchesAsync_RegularSource_SerializesWrites()
     {
@@ -370,7 +391,7 @@ public class SubjectSourceExtensionsTests
             .Returns(async (ReadOnlyMemory<SubjectPropertyChange> _, CancellationToken ct) =>
             {
                 var current = Interlocked.Increment(ref concurrentCalls);
-                maxConcurrentCalls = Math.Max(maxConcurrentCalls, current);
+                RecordMaximum(ref maxConcurrentCalls, current);
 
                 // Wait a bit to allow potential concurrent calls to overlap
                 await Task.Delay(50, ct);
@@ -407,7 +428,7 @@ public class SubjectSourceExtensionsTests
         var source = new ConcurrentTestSource(async () =>
         {
             var current = Interlocked.Increment(ref concurrentCalls);
-            maxConcurrentCalls = Math.Max(maxConcurrentCalls, current);
+            RecordMaximum(ref maxConcurrentCalls, current);
 
             // Signal when all 3 calls have started
             if (current >= 3)
@@ -432,10 +453,11 @@ public class SubjectSourceExtensionsTests
             source.WriteChangesInBatchesAsync(changes, CancellationToken.None).AsTask()
         };
 
-        // Wait for all calls to start (or timeout)
-        var allStartedTask = allStarted.Task;
-        var timeoutTask = Task.Delay(1000);
-        await Task.WhenAny(allStartedTask, timeoutTask);
+        // Wait for all three calls to be in flight, and fail here if they never are. Letting a bounded
+        // wait expire silently opens the gate below while the calls are still queued, and the assertion
+        // then fails because they ran one after another rather than because the source refused to run
+        // them together.
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
         // Allow all to complete
         canContinue.SetResult();

--- a/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerLivenessTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerLivenessTests.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
 using MQTTnet;
+using MQTTnet.Exceptions;
 using MQTTnet.Formatter;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
@@ -291,10 +292,7 @@ public partial class MqttServerLivenessTests
         }
         finally
         {
-            if (client.IsConnected)
-            {
-                await client.DisconnectAsync();
-            }
+            await DisconnectForTeardownAsync(client);
 
             await server.StopAsync(CancellationToken.None);
         }
@@ -386,10 +384,7 @@ public partial class MqttServerLivenessTests
                 await staleCallback.WaitAsync(TimeSpan.FromSeconds(10));
             }
 
-            if (subscriber.IsConnected)
-            {
-                await subscriber.DisconnectAsync();
-            }
+            await DisconnectForTeardownAsync(subscriber);
 
             await server.StopAsync(CancellationToken.None);
         }
@@ -531,15 +526,9 @@ public partial class MqttServerLivenessTests
                 await stopTask.WaitAsync(TimeSpan.FromSeconds(10));
             }
 
-            if (publisher.IsConnected)
-            {
-                await publisher.DisconnectAsync();
-            }
+            await DisconnectForTeardownAsync(publisher);
 
-            if (subscriber.IsConnected)
-            {
-                await subscriber.DisconnectAsync();
-            }
+            await DisconnectForTeardownAsync(subscriber);
 
             await server.StopAsync(CancellationToken.None);
         }
@@ -778,6 +767,30 @@ public partial class MqttServerLivenessTests
         }
 
         throw new InvalidOperationException("The MQTT broker does not expose its disposal state.");
+    }
+
+    /// <summary>
+    /// Disconnects a client during test teardown. These tests deliberately retire the broker while
+    /// clients are still attached, so by the time teardown runs the socket may already be gone and the
+    /// DISCONNECT packet fails to send. IsConnected cannot guard against it: it is a snapshot that can
+    /// go stale between the check and the send. Teardown failures must not decide the test, so the
+    /// transport-level failure is swallowed here while every assertion above stays untouched.
+    /// </summary>
+    private static async Task DisconnectForTeardownAsync(IMqttClient client)
+    {
+        if (!client.IsConnected)
+        {
+            return;
+        }
+
+        try
+        {
+            await client.DisconnectAsync();
+        }
+        catch (MqttCommunicationException)
+        {
+            // The broker is already gone, which is what the test asserted in the first place.
+        }
     }
 
     private static int GetFreeTcpPort()

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaClientDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaClientDiagnosticsTests.cs
@@ -381,8 +381,11 @@ public class OpcUaClientDiagnosticsTests
         using var gettersStarted = new CountdownEvent(cases.Length);
         using var gettersCompleted = new CountdownEvent(cases.Length);
 
+        // Every holder blocks while holding a lock and every getter then blocks on one of those
+        // locks, so up to twice the case count is parked at once. The pool cannot promise that many
+        // threads on a low core agent, and a holder that is never scheduled hangs locksAcquired.
         var lockHolders = cases
-            .Select(testCase => Task.Run(() =>
+            .Select(testCase => DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() =>
             {
                 lock (GetFirstConcurrentDictionaryLock(testCase.Owner, testCase.FieldName))
                 {
@@ -401,7 +404,7 @@ public class OpcUaClientDiagnosticsTests
         {
             Assert.True(locksAcquired.Wait(TimeSpan.FromSeconds(5)), "The dictionary locks were not acquired.");
             getterTasks = cases
-                .Select(testCase => Task.Run(() =>
+                .Select(testCase => DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() =>
                 {
                     gettersStarted.Signal();
                     try

--- a/src/Namotion.Interceptor.Testing/DedicatedThreadTestHelpers.cs
+++ b/src/Namotion.Interceptor.Testing/DedicatedThreadTestHelpers.cs
@@ -1,0 +1,64 @@
+namespace Namotion.Interceptor.Testing;
+
+/// <summary>
+/// Helpers for tests that park a thread on a gate or a lock to manufacture a race.
+/// </summary>
+public static class DedicatedThreadTestHelpers
+{
+    /// <summary>
+    /// Runs <paramref name="body"/> on its own thread and surfaces it as a task.
+    /// </summary>
+    /// <remarks>
+    /// A race participant that blocks must not be queued on the thread pool. Test assemblies run their
+    /// collections in parallel, CI agents size the pool from a low core count, and the pool only injects
+    /// extra threads gradually, so a queued work item can wait seconds before it is scheduled at all.
+    /// A test that then bounds how long it waits for that body to reach its gate fails for a reason that
+    /// has nothing to do with what it is testing. Worse, a body that was never scheduled has also never
+    /// completed, so an assertion phrased as "this has not finished yet" passes without proving anything.
+    /// </remarks>
+    /// <param name="body">The work to run. Expected to block.</param>
+    /// <param name="name">Optional thread name, to make a hung test readable in a dump.</param>
+    public static Task<T> RunOnDedicatedThreadAsync<T>(Func<T> body, string? name = null)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                completion.SetResult(body());
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = name ?? "dedicated test thread"
+        };
+
+        thread.Start();
+        return completion.Task;
+    }
+
+    /// <inheritdoc cref="RunOnDedicatedThreadAsync{T}(Func{T}, string)"/>
+    public static Task RunOnDedicatedThreadAsync(Action body, string? name = null) =>
+        RunOnDedicatedThreadAsync<object?>(
+            () =>
+            {
+                body();
+                return null;
+            },
+            name);
+
+    /// <summary>
+    /// Starts <paramref name="body"/> on its own thread and surfaces the resulting task.
+    /// </summary>
+    /// <remarks>
+    /// Only the part before the first suspension point is guaranteed to run on the dedicated thread,
+    /// which is what matters here: the gate a race participant parks on is reached synchronously.
+    /// See <see cref="RunOnDedicatedThreadAsync{T}(Func{T}, string)"/> for why the pool is unsuitable.
+    /// </remarks>
+    public static Task RunOnDedicatedThreadAsync(Func<Task> body, string? name = null) =>
+        RunOnDedicatedThreadAsync<Task>(body, name).Unwrap();
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/DerivedPropertyWriteGenerationTests.cs
@@ -1,4 +1,5 @@
 using Namotion.Interceptor.Interceptors;
+using Namotion.Interceptor.Testing;
 using Namotion.Interceptor.Tracking.Tests.Models;
 
 namespace Namotion.Interceptor.Tracking.Tests.Change;
@@ -21,7 +22,8 @@ public class DerivedPropertyWriteGenerationTests
         var vetoedSubject = new Person(vetoContext);
 
         // Act
-        var trigger = Task.Run(() => subject.First = 1);
+        // The write parks in the derived getter, so it must not wait for a pool thread.
+        var trigger = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(() => { subject.First = 1; });
         try
         {
             Assert.True(

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionLifecycleTests.cs
@@ -1,6 +1,7 @@
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Testing;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Transactions;
 using Namotion.Interceptor.Tracking.Tests.Models;
@@ -517,7 +518,9 @@ public class PerPropertySubscriptionLifecycleTests
         var hits = 0;
 
         // Act: start the write, install both consumers while it is parked, then release it.
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocking.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         using var listener = new PropertyReference(person, nameof(Person.FirstName))

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PerPropertySubscriptionTests.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Testing;
 using System.Linq.Expressions;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
@@ -122,7 +123,9 @@ public class PerPropertySubscriptionTests
         var person = new Person(context);
         var received = new List<(string? OldValue, string? NewValue)>();
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Act: install while the write is in flight (post-gate, pre-commit), then release the commit.

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeInterceptorTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeInterceptorTests.cs
@@ -173,7 +173,9 @@ public class PropertyChangeInterceptorTests
         var person = new Person(context);
         using var existing = context.CreatePropertyChangeQueueSubscription();
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Act: subscribe while the write is in flight, then release the commit.
@@ -203,7 +205,9 @@ public class PropertyChangeInterceptorTests
         using var existing = observable
             .Subscribe(change => first = change);
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Act: a second observer joins the same observable mid-write. Its subscription must reach

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeLateChannelDeliveryTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeLateChannelDeliveryTests.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Testing;
 using System.Reactive.Concurrency;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
@@ -21,7 +22,9 @@ public class PropertyChangeLateChannelDeliveryTests
         context.WithService(() => blocker);
         var person = new Person(context);
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Act: create the first queue subscription while the write is in flight, then release.
@@ -46,7 +49,9 @@ public class PropertyChangeLateChannelDeliveryTests
         var person = new Person(context);
         SubjectPropertyChange? captured = null;
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Act: the first observer joins while the write is in flight, then the commit is released.

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeRevisionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/PropertyChangeRevisionTests.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Testing;
 using System.Reactive.Concurrency;
 using Namotion.Interceptor.Tracking.Change;
 using Namotion.Interceptor.Tracking.Tests.Models;
@@ -50,7 +51,9 @@ public class PropertyChangeRevisionTests
         var interceptor = context.GetService<PropertyChangeInterceptor>();
         var person = new Person(context);
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Guards that the write really took the idle branch, so this test covers the late dispatch

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/RecalculateDerivedPropertyTests.cs
@@ -587,7 +587,8 @@ public class RecalculateDerivedPropertyTests
             .Subscribe(change => secondTrackedValue = change.GetNewValue<string?>());
 
         // Act
-        var firstTask = Task.Run(async () =>
+        // Both evaluations must be in flight together for the overlap this test needs.
+        var firstTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(async () =>
         {
             using (await firstContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
             {
@@ -595,7 +596,7 @@ public class RecalculateDerivedPropertyTests
                 new PropertyReference(first, nameof(TransactionCascadeSubject.Probe)).RecalculateDerivedProperty();
             }
         });
-        var secondTask = Task.Run(async () =>
+        var secondTask = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(async () =>
         {
             using (await secondContext.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
             {

--- a/src/Namotion.Interceptor.Tracking.Tests/Change/ScheduledPropertySubscriptionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Change/ScheduledPropertySubscriptionTests.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Testing;
 using System.Linq.Expressions;
 using System.Reactive.Concurrency;
 
@@ -174,7 +175,9 @@ public class ScheduledPropertySubscriptionTests
         var scheduler = new ControllableScheduler();
         var received = new List<string?>();
 
-        var writer = Task.Run(() => person.FirstName = "John");
+        // The write parks in the interceptor chain, so it must not wait for a pool thread.
+        var writer = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(
+            () => { person.FirstName = "John"; });
         Assert.True(blocker.EnteredInnerChain.Wait(TimeSpan.FromSeconds(10)));
 
         // Act

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -2,6 +2,7 @@ using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Connectors;
 using Namotion.Interceptor.Interceptors;
 using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Testing;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using Namotion.Interceptor.Tracking.Change;
@@ -442,7 +443,9 @@ public class SubjectTransactionTests
         var task2Waiting = new ManualResetEventSlim(false);
 
         // Act
-        var task1 = Task.Run(async () =>
+        // Both sides block until the other reaches its gate, and the waits below are unbounded, so a
+        // participant left in the pool queue would hang the run rather than fail it.
+        var task1 = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(async () =>
         {
             using (var t = await context.BeginTransactionAsync(
                 TransactionFailureHandling.BestEffort,
@@ -456,7 +459,7 @@ public class SubjectTransactionTests
         });
 
         task2Waiting.Wait();
-        var task2 = Task.Run(async () =>
+        var task2 = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(async () =>
         {
             task1CanCommit.Set();
             using (var t = await context.BeginTransactionAsync(
@@ -482,7 +485,8 @@ public class SubjectTransactionTests
         var bothStarted = new CountdownEvent(2);
 
         // Act
-        var task1 = Task.Run(async () =>
+        // Neither side can reach the countdown unless both are actually running.
+        var task1 = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(async () =>
         {
             using (var t = await context.BeginTransactionAsync(
                 TransactionFailureHandling.BestEffort,
@@ -495,7 +499,7 @@ public class SubjectTransactionTests
             }
         });
 
-        var task2 = Task.Run(async () =>
+        var task2 = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(async () =>
         {
             using (var t = await context.BeginTransactionAsync(
                 TransactionFailureHandling.BestEffort,

--- a/src/Namotion.Interceptor.WebSocket.Tests/Integration/WebSocketTransactionTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Integration/WebSocketTransactionTests.cs
@@ -45,7 +45,7 @@ public class WebSocketTransactionTests
             () => client.Root!.Name == "Initial",
             message: "Client should receive initial state");
 
-        AssertSourceOwns(client.Root!, nameof(TestRoot.Name));
+        await AssertSourceOwnsAsync(client.Root!, nameof(TestRoot.Name));
 
         // Act
         using (var transaction = await client.Context!.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
@@ -82,7 +82,7 @@ public class WebSocketTransactionTests
             () => client.Root!.Name == "Initial",
             message: "Client should receive initial state");
 
-        AssertSourceOwns(client.Root!, nameof(TestRoot.Number));
+        await AssertSourceOwnsAsync(client.Root!, nameof(TestRoot.Number));
 
         // Act
         using (var transaction = await client.Context!.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
@@ -127,7 +127,7 @@ public class WebSocketTransactionTests
             () => client.Root!.Child?.Label == "ServerChild",
             message: "Client should receive the initial child state");
 
-        AssertSourceOwns(client.Root!.Child!, nameof(TestItem.Label));
+        await AssertSourceOwnsAsync(client.Root!.Child!, nameof(TestItem.Label));
 
         // Act
         using (var transaction = await client.Context!.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
@@ -147,10 +147,14 @@ public class WebSocketTransactionTests
     /// The commit only writes to sources that own the changed property, so an ownership regression
     /// would silently downgrade these tests to covering plain non-transactional propagation.
     /// </summary>
-    private static void AssertSourceOwns(IInterceptorSubject subject, string propertyName)
-    {
-        Assert.True(
-            new PropertyReference(subject, propertyName).TryGetSource(out _),
-            $"The WebSocket client source must own {propertyName} for the commit to write through it");
-    }
+    /// <remarks>
+    /// Settled rather than sampled. The waits above only establish that a value arrived, and ownership
+    /// is registered on its own schedule as the subject is attached, so sampling it the instant a value
+    /// lands fails on timing rather than on ownership. A real regression still fails here, on the
+    /// timeout, with the same message.
+    /// </remarks>
+    private static Task AssertSourceOwnsAsync(IInterceptorSubject subject, string propertyName) =>
+        AsyncTestHelpers.WaitUntilAsync(
+            () => new PropertyReference(subject, propertyName).TryGetSource(out _),
+            message: $"The WebSocket client source must own {propertyName} for the commit to write through it");
 }


### PR DESCRIPTION
Four failures were turning CI red across recent runs, including attempts 1 and 2 of the v0.9.2 release run. Each has a different cause, and none of them were a product defect in the connectors.

- The HomeBlaze E2E fixture died at initialisation with `Source array was not long enough` out of `TypeProvider.AddAssembly`, taking every E2E test with it. Two threads were registering into one provider at once.
- Two MQTT liveness tests failed with a broken pipe raised by their own teardown, after their assertions had already passed.
- `SourceMonitorTests.WhenRegisterAndSubscribeRaceConcurrently` timed out waiting for a racing action that the thread pool had not scheduled.
- Both `ChangeMerger` allocation tests measured a call that was still in tier-0, so they occasionally counted runtime work the merge never did.
- The batched write concurrency tests raced a one second window they then ignored, and tracked their high water mark with a read-modify-write from the very calls they run concurrently.
- The WebSocket transaction tests sampled source ownership the instant a value arrived, racing the registration that establishes it. This one failed on CI while the branch was being verified.

The source monitor timeout turned out to be one instance of a shape that appears sixteen times across three test projects, so the rest are fixed here too. Two of those were worse than a timeout: the exclusive locking transaction test waits on its gates without a bound, so a participant left in the pool queue hangs the run rather than failing it, and the OPC UA diagnostics test parks up to twice its case count at once because every getter blocks on a lock a holder is already holding.

`TypeProvider` is the only production change. It now publishes its types copy-on-write, so readers take a snapshot without a lock and writers serialise on one. Reads sit on request paths and registration is a short burst at startup, so the cost sits on the write side.

## Why

The `TypeProvider` race was reproduced directly rather than inferred. Instrumenting `AddAssembly` caught both writers in the same millisecond on the same instance:

```
[22:51:09.653] tid=12 provider=45011471 asm=MyCompany.SamplePlugin2.HomeBlaze
   at WebTestingHostFactory`1.CreateHost(...) WebTestingHostFactory.cs:line 93
[22:51:09.653] tid=17 provider=45011471 asm=MyCompany.SamplePlugin2.HomeBlaze
   at Program.<Main>$(String[] args) Program.cs:line 93
```

The entry point registers its assembly chain and loads its plugins, and the test factory was repeating that same work from the thread that builds the Kestrel host. `List<T>.AddRange` from two threads is what produced the exception. The factory's registrations were all redundant, so it no longer registers anything.

The two scheduling failures share a shape: a test that parks a thread and then depends on the pool to schedule another. Under a saturated pool a queued work item waits, and in the source monitor case that also let the blocked-Subscribe assertion pass without proving anything, since a Subscribe that was never scheduled has not completed either.

For the allocation tests, instrumenting `Merge` showed it has exactly two allocation sources, both on the first call only: the property index growing its capacity, and the pooled buffer being rented. Neither matches what the failing measurement reported. Replaying the test's exact shape 1200 times under the contention that reproduces the failure allocated zero every time, so the stray bytes came from the runtime rather than the merge. The warmup is now deep enough that the measured call runs promoted code, matching how the tracking tests measure rollback allocations.

## Contract

- `TypeProvider` accepts registrations from several threads at once. `Types` returns a snapshot, so an enumeration in progress is unaffected by a concurrent registration and will not observe types added after it started.
- Registration order across concurrent writers is unspecified; a single writer still appends in call order.

## Breaking changes

None.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 1 | 28 | 6 | +22 |
| Tests and benchmarks | 17 | 218 | 86 | +132 |
| **Total** | **18** | **246** | **92** | **+154** |

## Verification

Each failure was reproduced before it was fixed, and the fix was checked against that reproduction. The two scheduling and allocation failures reproduce when the assembly is pinned to two cores, which sizes the thread pool the way a CI runner does; the `ChangeMerger` one needed a second test process competing for those cores and then failed about 40 percent of the time. After the change, ten such rounds were clean, and a further twelve full solution runs under four core contention found nothing new. The `TypeProvider` race was caught with instrumentation rather than by waiting for it, so the evidence there is the collision itself, not a passing run count.

- [x] ~~Documentation updated~~ no documented behavior changes
- [x] Unit tests, full solution green, plus the touched assemblies under two core contention
- [x] Integration tests, MQTT 103/103 and HomeBlaze E2E 23/23
- [x] ~~Benchmarks~~ no performance claim is made
- [x] ~~Load tests~~ no connector protocol change
- [x] ~~Chaos tests~~ no connector protocol change
