### PR TITLE
feat: expose unavailable connector diagnostics

### DIFF
--- a/docs/connectors-monitoring.md
+++ b/docs/connectors-monitoring.md
@@ -207,7 +207,7 @@ Reading `State` and `StateChangeTime` in sequence is two separate snapshots. Eac
 
 The outbound backlog is the clearest case of the split: `Diagnostics.OutboundRetries.Depth` can be non-zero during entirely normal synchronized operation, because a queued write says nothing about whether the model mirrors the external system.
 
-Read the two together to tell a reported network outage from a connected source that is still loading: the first is `IsOperational == false`, the second is `IsOperational == true` with a state of `Synchronizing`. `IsOperational == null` means transport liveness has not been published, so it identifies neither condition and does not change the source's synchronization state.
+Read the two together to tell a reported network outage from a connected source that is still loading: the first is `IsOperational == false`, the second is `IsOperational == true` with a state of `Synchronizing`. `IsOperational == null` means the source is running and has not published liveness, so it identifies neither condition and does not change the source's synchronization state. A stopped source always reads `false`.
 
 ### The Event Stream
 

--- a/docs/connectors-monitoring.md
+++ b/docs/connectors-monitoring.md
@@ -207,7 +207,7 @@ Reading `State` and `StateChangeTime` in sequence is two separate snapshots. Eac
 
 The outbound backlog is the clearest case of the split: `Diagnostics.OutboundRetries.Depth` can be non-zero during entirely normal synchronized operation, because a queued write says nothing about whether the model mirrors the external system.
 
-Read the two together to tell a network outage from a connected source that is still loading: the first is `IsOperational` false, the second is `IsOperational` true with a state of `Synchronizing`.
+Read the two together to tell a reported network outage from a connected source that is still loading: the first is `IsOperational == false`, the second is `IsOperational == true` with a state of `Synchronizing`. `IsOperational == null` means transport liveness has not been published, so it identifies neither condition and does not change the source's synchronization state.
 
 ### The Event Stream
 

--- a/docs/connectors-mqtt.md
+++ b/docs/connectors-mqtt.md
@@ -340,7 +340,7 @@ new MqttClientConfiguration
 
 ## Diagnostics
 
-Both MQTT connectors report through the shared model: the member tree, the three buffers, `LastError` stickiness and the read guarantees are described once in [Connector Diagnostics](connectors.md#connector-diagnostics). What follows is what is specific to MQTT.
+Both built-in MQTT connectors implement liveness monitoring and report through the shared model: the member tree, the three buffers, `LastError` stickiness and the read guarantees are described once in [Connector Diagnostics](connectors.md#connector-diagnostics). Before the first protocol-specific liveness observation, `IsOperational` can be `null`; after that observation, the connectors publish explicit `true` or `false` values. What follows is what is specific to MQTT.
 
 **`IsOperational` for the client means the connection to the broker is up.** It is set as soon as the connect returns, before the property subscriptions are established, so on the first connect it leads them by the duration of the subscribe. After a reconnect it is raised only once resubscription and the initial-state reload have both succeeded, because a client that reconnected but could not resubscribe is not serving anything. It drops on every disconnect, including one the connection monitor is about to recover from, and on teardown.
 
@@ -348,7 +348,7 @@ Both MQTT connectors report through the shared model: the member tree, the three
 
 Neither connector measures throughput, so `Throughput.IncomingPerSecond` and `Throughput.OutgoingPerSecond` are both `null` rather than `0.0`.
 
-The client's diagnostics are a plain `SourceDiagnostics` with no MQTT specific additions. `OutboundRetries.Capacity` echoes `WriteRetryQueueSize`, and is `0` when the queue is disabled; in that configuration read `TotalDropped` as a floor rather than the whole loss (see [Known Limitations](connectors.md#known-limitations)). `ClaimedPropertyCount` rises as topics are claimed during the subscribe step of the connect, which runs before the initial state is loaded, and falls as subjects detach.
+The client's diagnostics are a plain `SourceDiagnostics` with no MQTT specific additions. `OutboundRetries.Capacity` echoes `WriteRetryQueueSize`, and is `0` when the queue is disabled; in that configuration read `TotalDropped` as a floor rather than the whole loss (see [Known Limitations](connectors.md#known-limitations)). The built-in client registers the `ClaimedPropertyCount` gauge, so it reports a measured value, including zero. The count rises as topics are claimed during the subscribe step of the connect, which runs before the initial state is loaded, and falls as subjects detach.
 
 The server's diagnostics are an `MqttServerDiagnostics`, which adds one member:
 

--- a/docs/connectors-opcua-client.md
+++ b/docs/connectors-opcua-client.md
@@ -649,11 +649,13 @@ When a batch write to the OPC UA server partially fails, the client throws an `O
 
 `OpcUaClientDiagnostics` derives from `SourceDiagnostics`, whose members, buffer semantics and read guarantees are described once in [Connector Diagnostics](connectors.md#connector-diagnostics). What follows is what is specific to this client.
 
-**`IsOperational` here means the client has a live session with its subscriptions set up.** It stays false for the whole address space browse and subscription creation, which on a large server takes minutes. Which step raises it depends on how the session came about: the first health check tick on an initial connect, the completed subscription transfer on an SDK reconnect, and the completed state reload on a manual reconnect. It drops whenever the session is lost, killed or torn down, and whenever a connect attempt ends, so a client sitting in its retry delay never reports itself as serving.
+**`IsOperational` here means the client has a live session with its subscriptions set up.** This built-in client implements liveness monitoring, but `IsOperational` is `null` before its first protocol-specific observation. It then publishes false for the whole address space browse and subscription creation, which on a large server takes minutes. Which step raises it depends on how the session came about: the first health check tick on an initial connect, the completed subscription transfer on an SDK reconnect, and the completed state reload on a manual reconnect. It drops whenever the session is lost, killed or torn down, and whenever a connect attempt ends, so a client sitting in its retry delay reports an explicit false rather than serving.
 
 It is not a claim that the model is in sync, and the two are not ordered against each other: the initial value read can run either side of the rise on an initial connect, and on a manual reconnect the reload always finishes first. While that read runs, `ISubjectSource.State` is `Synchronizing`, so reading it together with `IsOperational` is how a dropped network is told apart from a connected client that is still loading. See [Diagnostics and State answer different questions](connectors-monitoring.md#diagnostics-and-state-answer-different-questions).
 
 This client measures both throughput directions, so `Throughput.IncomingPerSecond` and `Throughput.OutgoingPerSecond` are never `null` here.
+
+This built-in client registers the `ClaimedPropertyCount` gauge, so it reports the measured number of currently owned properties, including zero.
 
 | Member | Meaning |
 |---|---|

--- a/docs/connectors-opcua-server.md
+++ b/docs/connectors-opcua-server.md
@@ -258,7 +258,7 @@ The `LoadNodeSetFromEmbeddedResource<T>()` helper loads NodeSet XML files embedd
 
 `OpcUaServerDiagnostics` derives from `ConnectorDiagnostics`, whose members, buffer semantics and read guarantees are described once in [Connector Diagnostics](connectors.md#connector-diagnostics). What follows is what is specific to this server.
 
-**`IsOperational` here means the server has started and is accepting client connections.** The server restarts itself internally on failure, and the two timestamps split along that line: `OperationalChangeTime` moves on every internal restart, while the inherited `StartTime` marks the current run of the hosted service and does not.
+**`IsOperational` here means the server has started and is accepting client connections.** This built-in server implements liveness monitoring, but `IsOperational` is `null` before its first protocol-specific observation. It then publishes explicit true or false values. The server restarts itself internally on failure, and the two timestamps split along that line: `OperationalChangeTime` moves on every internal restart, while the inherited `StartTime` marks the current run of the hosted service and does not.
 
 This server measures both throughput directions, so `Throughput.IncomingPerSecond` (client writes to the server) and `Throughput.OutgoingPerSecond` (subject changes pushed to OPC UA nodes) are never `null` here. `OutboundChanges` is the change queue feeding the address space, and its `Capacity` is `null` because that queue is unbounded.
 

--- a/docs/connectors-opcua.md
+++ b/docs/connectors-opcua.md
@@ -2,6 +2,8 @@
 
 The `Namotion.Interceptor.OpcUa` package provides integration between Namotion.Interceptor and OPC UA (Open Platform Communications Unified Architecture), enabling bidirectional synchronization between C# objects and industrial automation systems. It supports both client and server modes.
 
+Both built-in OPC UA connectors implement liveness monitoring. Before their first protocol-specific liveness observation, `IsOperational` can be `null`; after that observation, they publish explicit `true` or `false` values. The client registers the `ClaimedPropertyCount` gauge, so its count is measured, including zero.
+
 - [OPC UA Client](connectors-opcua-client.md) - Configuration, authentication, monitoring, resilience, extensibility
 - [OPC UA Server](connectors-opcua-server.md) - Configuration, security, companion specs, diagnostics
 - [OPC UA Mapping](connectors-opcua-mapping.md) - Attributes, fluent configuration, companion spec patterns

--- a/docs/connectors-websocket.md
+++ b/docs/connectors-websocket.md
@@ -428,7 +428,7 @@ Tiered error handling preserves connections when possible:
 
 ## Diagnostics
 
-Both WebSocket connectors report through the shared model: the member tree, the three buffers, `LastError` stickiness and the read guarantees are described once in [Connector Diagnostics](connectors.md#connector-diagnostics). What follows is what is specific to WebSocket.
+Both built-in WebSocket connectors implement liveness monitoring and report through the shared model: the member tree, the three buffers, `LastError` stickiness and the read guarantees are described once in [Connector Diagnostics](connectors.md#connector-diagnostics). Before the first protocol-specific liveness observation, `IsOperational` can be `null`; after that observation, the connectors publish explicit `true` or `false` values. What follows is what is specific to WebSocket.
 
 **`IsOperational` for the standalone server means the listener is accepting connections.** It is set once Kestrel has started and drops first in the teardown, so a server that has stopped accepting connections never reports that it is still serving. It also drops and rises again on every internal restart, where the inherited `StartTime` marks the current run of the hosted service and does not move.
 
@@ -436,7 +436,7 @@ Both WebSocket connectors report through the shared model: the member tree, the 
 
 Neither connector measures throughput, so `Throughput.IncomingPerSecond` and `Throughput.OutgoingPerSecond` are both `null` rather than `0.0`.
 
-The client's diagnostics are a plain `SourceDiagnostics` with no WebSocket specific additions. `OutboundRetries.Capacity` echoes `WriteRetryQueueSize`, and is `0` when the queue is disabled; in that configuration read `TotalDropped` as a floor rather than the whole loss (see [Known Limitations](connectors.md#known-limitations)).
+The client's diagnostics are a plain `SourceDiagnostics` with no WebSocket specific additions. `OutboundRetries.Capacity` echoes `WriteRetryQueueSize`, and is `0` when the queue is disabled; in that configuration read `TotalDropped` as a floor rather than the whole loss (see [Known Limitations](connectors.md#known-limitations)). The built-in client registers the `ClaimedPropertyCount` gauge, so it reports a measured value, including zero.
 
 The standalone server's diagnostics are a `WebSocketServerDiagnostics`, which adds two members:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -925,8 +925,8 @@ What the base provides around that call:
 | Stamps the start epoch that every `Total` counter and `StartTime` are measured from, clears `LastError`, and resets the registered metrics | `MarkStarted()`, once per `ExecuteAsync` entry |
 | Records a fault that escapes `RunAsync` into `LastError` | the catch around the `RunAsync` call |
 | Leaves an expected shutdown unrecorded, so a graceful stop does not overwrite the genuine error that made the connector fail | the `OperationCanceledException` filter on the stopping token |
-| Forces liveness false when `RunAsync` exits, on every path | `MarkStopped()` in the `finally` |
-| Forces liveness false on disposal, because `BackgroundService.Dispose` cancels the token without awaiting `ExecuteAsync` | the `Dispose` override |
+| Terminally latches liveness when `RunAsync` exits, converting observed `true` to `false`, preserving existing `false` or unavailable `null`, and rejecting late reports until `MarkStarted()` | `MarkStopped()` in the `finally` |
+| Terminally latches liveness on disposal with the same tri-state behavior, because `BackgroundService.Dispose` cancels the token without awaiting `ExecuteAsync` | the `Dispose` override |
 | Runs one restart-loop iteration under its own `ConnectorRunAttempt`, publishing it while the body runs and clearing it before disposal, so an injected kill cancels exactly the iteration that is running and one arriving between iterations finds nothing to cancel | `RunAttemptAsync()`, paired with `ForceKillCurrentAttemptAsync()` |
 
 What a server author must implement:

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -302,7 +302,7 @@ The `SourceMetrics` instance is the writable side and stays private to the sourc
 
 A direct source may register `ClaimedPropertyCount`; registering it is required only when the source must expose a non-null ownership count. A registered gauge can measure zero, while an unregistered gauge remains `null`. A direct source must register all queue gauges it owns: `OutboundChanges`, `OutboundRetries`, and `InboundBuffer`. Give a disabled queue a capacity of `0`; use a `null` capacity only when the queue is actually unbounded. If the source owns custom `IResettableMetrics` instances, register each one once before `MarkStarted()` so its totals join the run's first epoch.
 
-Deriving from `SubjectSourceBase` instead gets both members, the start epoch, the recording of a failed connect attempt, and the terminal handling of any liveness the derived source has published. **Publishing liveness is the derived class's job**: the base never calls `MarkOperational()` or `MarkNotOperational()`, because each protocol becomes usable or unavailable at different points and those points are what `IsOperational` means for that connector. Calling either method opts the source into liveness reporting. A simple source that calls neither continues to expose `IsOperational == null` while its `State` can still reach `Synchronized`. The three in-tree clients show where to put the calls: the MQTT client reports serving once `ConnectAsync` returns, the WebSocket client once the server's Welcome has been accepted, and the OPC UA client only once a session it has already created is confirmed usable, which is several steps later and which step depends on how that session came about (see [OPC UA Client](connectors-opcua-client.md#diagnostics)). Each reports the explicit down value from the path that detects the loss.
+Deriving from `SubjectSourceBase` instead gets both members, the start epoch, the recording of a failed connect attempt, and the terminal handling of any liveness the derived source has published. **Publishing liveness is the derived class's job**: the base never calls `MarkOperational()` or `MarkNotOperational()`, because each protocol becomes usable or unavailable at different points and those points are what `IsOperational` means for that connector. Calling either method opts the source into liveness reporting. A simple source that calls neither exposes `IsOperational == null` for as long as it runs, while its `State` can still reach `Synchronized`, and `false` once it stops. The three in-tree clients show where to put the calls: the MQTT client reports serving once `ConnectAsync` returns, the WebSocket client once the server's Welcome has been accepted, and the OPC UA client only once a session it has already created is confirmed usable, which is several steps later and which step depends on how that session came about (see [OPC UA Client](connectors-opcua-client.md#diagnostics)). Each reports the explicit down value from the path that detects the loss.
 
 `StateChangeTime` and `LastSynchronizedAt` are both required, and neither can answer the other's question. `StateChangeTime` moves on every transition, so read with `State` it says how long the current state has lasted: `Synchronizing` plus T reads as stale since T. `LastSynchronizedAt` is stamped only on the way into `Synchronized` and never cleared, so it says whether a good period ever began, and it cannot say when synchronization was lost.
 
@@ -648,8 +648,8 @@ Every connector reports what its transport is doing through `ISubjectConnector.D
 
 ```
 ConnectorDiagnostics
-  IsOperational          bool?              null = not reported, true = serving, false = reported down
-  OperationalChangeTime  DateTimeOffset?    when IsOperational last changed, null until it first does
+  IsOperational          bool?              null = running and not measured, true = serving, false = down
+  OperationalChangeTime  DateTimeOffset?    when IsOperational last changed, null until it first does in this run
   LastError              Exception?         the most recent error in either direction, null if there has been none
   StartTime              DateTimeOffset?    when the current run began, the epoch for every Total below
   Throughput
@@ -666,7 +666,7 @@ SourceDiagnostics : ConnectorDiagnostics
   InboundBuffer          inbound updates held while the initial state loads, same three members
 ```
 
-`IsOperational` is the one optional liveness spelling every connector uses. `null` means no liveness observation is available, `true` means the connector explicitly reports serving, and `false` means it explicitly reports down. What the explicit values mean is decided per connector and documented on that connector's own diagnostics type: for a client it is roughly "connected and usable", for a server "listening and accepting connections". It is not a claim about the model being in sync, which is a separate question answered by `ISubjectSource.State`; see [Diagnostics and State answer different questions](connectors-monitoring.md#diagnostics-and-state-answer-different-questions).
+`IsOperational` is the one optional liveness spelling every connector uses. `true` means the connector reports serving and `false` means it reports down. `null` means the connector is running and has not reported liveness, so it appears only between a start and the connector's first report, and never on a connector that has stopped: the base publishes `false` on the way out whether or not the connector measures liveness itself. What the explicit values mean is decided per connector and documented on that connector's own diagnostics type: for a client it is roughly "connected and usable", for a server "listening and accepting connections". It is not a claim about the model being in sync, which is a separate question answered by `ISubjectSource.State`; see [Diagnostics and State answer different questions](connectors-monitoring.md#diagnostics-and-state-answer-different-questions).
 
 Direction is stated once, from the subject tree's point of view, and means the same for clients and servers: incoming is changes flowing into the tree, outgoing is changes flowing out of it. Both rates are averaged over a 60-second sliding window. A `null` rate means the connector does not measure that direction at all, decided at construction and never changing, which is different from a measured `0.0`.
 
@@ -922,11 +922,11 @@ What the base provides around that call:
 
 | Behaviour | Where |
 |---|---|
-| Stamps the start epoch that every `Total` counter and `StartTime` are measured from, clears `LastError`, and resets the registered metrics | `MarkStarted()`, once per `ExecuteAsync` entry |
+| Stamps the start epoch that every `Total` counter and `StartTime` are measured from, clears `LastError`, returns liveness to `null` so the new run carries nothing from the previous one, and resets the registered metrics | `MarkStarted()`, once per `ExecuteAsync` entry |
 | Records a fault that escapes `RunAsync` into `LastError` | the catch around the `RunAsync` call |
 | Leaves an expected shutdown unrecorded, so a graceful stop does not overwrite the genuine error that made the connector fail | the `OperationCanceledException` filter on the stopping token |
-| Terminally latches liveness when `RunAsync` exits, converting observed `true` to `false`, preserving existing `false` or unavailable `null`, and rejecting late reports until `MarkStarted()` | `MarkStopped()` in the `finally` |
-| Terminally latches liveness on disposal with the same tri-state behavior, because `BackgroundService.Dispose` cancels the token without awaiting `ExecuteAsync` | the `Dispose` override |
+| Publishes liveness `false` when `RunAsync` exits, on every path, and rejects late reports until the next `MarkStarted()` | `MarkStopped()` in the `finally` |
+| Publishes liveness `false` on disposal, because `BackgroundService.Dispose` cancels the token without awaiting `ExecuteAsync` | the `Dispose` override |
 | Runs one restart-loop iteration under its own `ConnectorRunAttempt`, publishing it while the body runs and clearing it before disposal, so an injected kill cancels exactly the iteration that is running and one arriving between iterations finds nothing to cancel | `RunAttemptAsync()`, paired with `ForceKillCurrentAttemptAsync()` |
 
 What a server author must implement:

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -300,9 +300,9 @@ public MySource() => Diagnostics = new SourceDiagnostics(_metrics);
 
 The `SourceMetrics` instance is the writable side and stays private to the source: it is what the source calls `MarkStarted()`, `MarkOperational()`, `ReportError()` and the queue registrations on, and nothing outside the source can reach it through the returned view. See [Connector Diagnostics](#connector-diagnostics).
 
-A direct source must register `ClaimedPropertyCount` and all queue gauges: `OutboundChanges`, `OutboundRetries`, and `InboundBuffer`. Give a disabled queue a capacity of `0`; use a `null` capacity only when the queue is actually unbounded. If the source owns custom `IResettableMetrics` instances, register each one once before `MarkStarted()` so its totals join the run's first epoch.
+A direct source may register `ClaimedPropertyCount`; registering it is required only when the source must expose a non-null ownership count. A registered gauge can measure zero, while an unregistered gauge remains `null`. A direct source must register all queue gauges it owns: `OutboundChanges`, `OutboundRetries`, and `InboundBuffer`. Give a disabled queue a capacity of `0`; use a `null` capacity only when the queue is actually unbounded. If the source owns custom `IResettableMetrics` instances, register each one once before `MarkStarted()` so its totals join the run's first epoch.
 
-Deriving from `SubjectSourceBase` instead gets both members, the start epoch, the recording of a failed connect attempt, and the drop of liveness on the way out. **Raising liveness is the derived class's job**: the base never calls `MarkOperational()`, because each protocol becomes usable at a different point and that point is what `IsOperational` means for that connector. A source that never calls it reports not operational for its entire life while its `State` reaches `Synchronized`. The three in-tree clients show where to put the call: the MQTT client raises it once `ConnectAsync` returns, the WebSocket client once the server's Welcome has been accepted, and the OPC UA client only once a session it has already created is confirmed usable, which is several steps later and which step depends on how that session came about (see [OPC UA Client](connectors-opcua-client.md#diagnostics)). Each drops it again from the path that detects the loss.
+Deriving from `SubjectSourceBase` instead gets both members, the start epoch, the recording of a failed connect attempt, and the terminal handling of any liveness the derived source has published. **Publishing liveness is the derived class's job**: the base never calls `MarkOperational()` or `MarkNotOperational()`, because each protocol becomes usable or unavailable at different points and those points are what `IsOperational` means for that connector. Calling either method opts the source into liveness reporting. A simple source that calls neither continues to expose `IsOperational == null` while its `State` can still reach `Synchronized`. The three in-tree clients show where to put the calls: the MQTT client reports serving once `ConnectAsync` returns, the WebSocket client once the server's Welcome has been accepted, and the OPC UA client only once a session it has already created is confirmed usable, which is several steps later and which step depends on how that session came about (see [OPC UA Client](connectors-opcua-client.md#diagnostics)). Each reports the explicit down value from the path that detects the loss.
 
 `StateChangeTime` and `LastSynchronizedAt` are both required, and neither can answer the other's question. `StateChangeTime` moves on every transition, so read with `State` it says how long the current state has lasted: `Synchronizing` plus T reads as stale since T. `LastSynchronizedAt` is stamped only on the way into `Synchronized` and never cleared, so it says whether a good period ever began, and it cannot say when synchronization was lost.
 
@@ -648,7 +648,7 @@ Every connector reports what its transport is doing through `ISubjectConnector.D
 
 ```
 ConnectorDiagnostics
-  IsOperational          bool               the transport is up and serving
+  IsOperational          bool?              null = not reported, true = serving, false = reported down
   OperationalChangeTime  DateTimeOffset?    when IsOperational last changed, null until it first does
   LastError              Exception?         the most recent error in either direction, null if there has been none
   StartTime              DateTimeOffset?    when the current run began, the epoch for every Total below
@@ -661,12 +661,12 @@ ConnectorDiagnostics
     TotalDropped         long               items thrown away since StartTime
 
 SourceDiagnostics : ConnectorDiagnostics
-  ClaimedPropertyCount   int                properties this source currently owns
+  ClaimedPropertyCount   int?               null = not measured, otherwise properties currently owned
   OutboundRetries        writes parked for retry, same three members
   InboundBuffer          inbound updates held while the initial state loads, same three members
 ```
 
-`IsOperational` is the one liveness spelling every connector uses. What it means is decided per connector and documented on that connector's own diagnostics type: for a client it is roughly "connected and usable", for a server "listening and accepting connections". It is not a claim about the model being in sync, which is a separate question answered by `ISubjectSource.State`; see [Diagnostics and State answer different questions](connectors-monitoring.md#diagnostics-and-state-answer-different-questions).
+`IsOperational` is the one optional liveness spelling every connector uses. `null` means no liveness observation is available, `true` means the connector explicitly reports serving, and `false` means it explicitly reports down. What the explicit values mean is decided per connector and documented on that connector's own diagnostics type: for a client it is roughly "connected and usable", for a server "listening and accepting connections". It is not a claim about the model being in sync, which is a separate question answered by `ISubjectSource.State`; see [Diagnostics and State answer different questions](connectors-monitoring.md#diagnostics-and-state-answer-different-questions).
 
 Direction is stated once, from the subject tree's point of view, and means the same for clients and servers: incoming is changes flowing into the tree, outgoing is changes flowing out of it. Both rates are averaged over a 60-second sliding window. A `null` rate means the connector does not measure that direction at all, decided at construction and never changing, which is different from a measured `0.0`.
 

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -87,7 +87,8 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
     public partial string? StatusMessage { get; set; }
 
     /// <summary>
-    /// Whether the client is currently connected. Null when not running.
+    /// Whether the client is currently connected. Null when not running or before the client has
+    /// reported its liveness.
     /// </summary>
     [State]
     public partial bool? IsConnected { get; set; }
@@ -218,7 +219,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
         if (_clientSource is { } source)
         {
             var diagnostics = source.Diagnostics;
-            IsConnected = diagnostics.IsOperational == true;
+            IsConnected = diagnostics.IsOperational;
             IncomingChangesPerSecond = diagnostics.Throughput.IncomingPerSecond;
             OutgoingChangesPerSecond = diagnostics.Throughput.OutgoingPerSecond;
             MonitoredItemCount = diagnostics.MonitoredItemCount;

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaClient.cs
@@ -218,7 +218,7 @@ public partial class OpcUaClient : BackgroundService, IConfigurable, ITitleProvi
         if (_clientSource is { } source)
         {
             var diagnostics = source.Diagnostics;
-            IsConnected = diagnostics.IsOperational;
+            IsConnected = diagnostics.IsOperational == true;
             IncomingChangesPerSecond = diagnostics.Throughput.IncomingPerSecond;
             OutgoingChangesPerSecond = diagnostics.Throughput.OutgoingPerSecond;
             MonitoredItemCount = diagnostics.MonitoredItemCount;

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/observability.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/observability.md
@@ -52,7 +52,7 @@ When health status transitions (e.g., Healthy→Degraded), the subject publishes
 
 Several patterns already exist that would implement this interface:
 
-Built-in connectors publish `IsOperational == true` only after their protocol-specific serving observation and `IsOperational == false` after a reported outage. Before their first liveness observation, the value can be `null`; health mapping should treat that as unknown rather than as an explicit outage.
+Built-in connectors publish `IsOperational == true` only after their protocol-specific serving observation and `IsOperational == false` after a reported outage or once they stop. The value is `null` only while a connector runs before its first liveness observation; health mapping should treat that as unknown rather than as an explicit outage.
 
 | Subject | Current Health Reporting | Maps To |
 |---------|------------------------|---------|

--- a/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/observability.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/architecture/design/observability.md
@@ -52,11 +52,13 @@ When health status transitions (e.g., Healthy→Degraded), the subject publishes
 
 Several patterns already exist that would implement this interface:
 
+Built-in connectors publish `IsOperational == true` only after their protocol-specific serving observation and `IsOperational == false` after a reported outage. Before their first liveness observation, the value can be `null`; health mapping should treat that as unknown rather than as an explicit outage.
+
 | Subject | Current Health Reporting | Maps To |
 |---------|------------------------|---------|
-| OPC UA client | `OpcUaClientDiagnostics`: IsOperational, OperationalChangeTime, IsReconnecting, Reconnects.TotalFailed, LastError | Unhealthy when not operational, Degraded when reconnecting or items failing |
-| OPC UA server | `OpcUaServerDiagnostics`: IsOperational, OperationalChangeTime, LastError, ConsecutiveFailures | Unhealthy when not operational or consecutive failures |
-| MQTT and WebSocket clients/servers | The same `ConnectorDiagnostics` base: IsOperational, OperationalChangeTime, LastError | Unhealthy when not operational |
+| OPC UA client | `OpcUaClientDiagnostics`: IsOperational, OperationalChangeTime, IsReconnecting, Reconnects.TotalFailed, LastError | Unhealthy when `IsOperational == false`, Degraded when reconnecting or items failing, unknown when `IsOperational == null` |
+| OPC UA server | `OpcUaServerDiagnostics`: IsOperational, OperationalChangeTime, LastError, ConsecutiveFailures | Unhealthy when `IsOperational == false` or consecutive failures, unknown when `IsOperational == null` |
+| MQTT and WebSocket clients/servers | The same `ConnectorDiagnostics` base: IsOperational, OperationalChangeTime, LastError | Unhealthy when `IsOperational == false`, unknown when `IsOperational == null` |
 | Storage containers | `StorageStatus` enum (Connected/Disconnected/Error) | Maps directly to health status |
 | Background services | `ServiceStatus` enum (Running/Error/Unavailable) | Maps directly to health status |
 | Network subjects | `IConnectionState.IsConnected` | Unhealthy when disconnected |

--- a/src/Namotion.Interceptor.Connectors.Tests/Diagnostics/ConnectorMetricsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Diagnostics/ConnectorMetricsTests.cs
@@ -5,19 +5,19 @@ namespace Namotion.Interceptor.Connectors.Tests.Diagnostics;
 public class ConnectorMetricsTests
 {
     [Fact]
-    public void WhenNeverStarted_ThenNotOperationalAndNoTimestamps()
+    public void WhenLivenessIsNeverReported_ThenOperationalStateAndTimestampAreNull()
     {
         // Arrange
         var metrics = new ConnectorMetrics();
 
         // Act
         var diagnostics = new ConnectorDiagnostics(metrics);
+        metrics.MarkStarted();
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
-        Assert.Null(diagnostics.StartTime);
-        Assert.Null(diagnostics.LastError);
+        Assert.NotNull(diagnostics.StartTime);
     }
 
     [Fact]
@@ -33,6 +33,21 @@ public class ConnectorMetricsTests
 
         // Assert
         Assert.True(diagnostics.IsOperational);
+        Assert.NotNull(diagnostics.OperationalChangeTime);
+    }
+
+    [Fact]
+    public void WhenMarkedNotOperationalFirst_ThenFalseAndTimestampArePublished()
+    {
+        // Arrange
+        var metrics = new ConnectorMetrics();
+        var diagnostics = new ConnectorDiagnostics(metrics);
+
+        // Act
+        metrics.MarkNotOperational();
+
+        // Assert
+        Assert.False(diagnostics.IsOperational);
         Assert.NotNull(diagnostics.OperationalChangeTime);
     }
 
@@ -127,7 +142,7 @@ public class ConnectorMetricsTests
     }
 
     [Fact]
-    public void WhenStoppedWithoutEverBeingOperational_ThenNoTransitionTimestampIsInvented()
+    public void WhenUnmonitoredConnectorIsStopped_ThenLivenessStaysNullAndLateReportsAreIgnored()
     {
         // Arrange
         var metrics = new ConnectorMetrics();
@@ -135,9 +150,26 @@ public class ConnectorMetricsTests
 
         // Act
         metrics.MarkStopped();
+        metrics.MarkOperational();
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
+        Assert.Null(diagnostics.OperationalChangeTime);
+    }
+
+    [Fact]
+    public void WhenUnmonitoredConnectorIsRestarted_ThenLivenessRemainsNullUntilExplicitlyReported()
+    {
+        // Arrange
+        var metrics = new ConnectorMetrics();
+        var diagnostics = new ConnectorDiagnostics(metrics);
+        metrics.MarkStopped();
+
+        // Act
+        metrics.MarkStarted();
+
+        // Assert
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
     }
 
@@ -196,7 +228,7 @@ public class ConnectorMetricsTests
 
         // Assert
         Assert.NotEqual(firstStart, diagnostics.StartTime);
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Equal(0, diagnostics.OutboundChanges.TotalDropped);
         Assert.Equal(0, diagnostics.OutboundRetries.TotalDropped);
         Assert.Equal(0, diagnostics.InboundBuffer.TotalDropped);
@@ -268,7 +300,7 @@ public class ConnectorMetricsTests
     }
 
     [Fact]
-    public void WhenNoClaimedPropertyProviderIsRegistered_ThenCountIsZero()
+    public void WhenNoClaimedPropertyProviderIsRegistered_ThenCountIsUnavailable()
     {
         // Arrange
         var metrics = new SourceMetrics();
@@ -277,7 +309,7 @@ public class ConnectorMetricsTests
         var diagnostics = new SourceDiagnostics(metrics);
 
         // Assert
-        Assert.Equal(0, diagnostics.ClaimedPropertyCount);
+        Assert.Null(diagnostics.ClaimedPropertyCount);
     }
 
     [Fact]
@@ -297,7 +329,7 @@ public class ConnectorMetricsTests
     }
 
     [Fact]
-    public void WhenClaimedPropertyProviderThrows_ThenCountIsZeroInsteadOfThrowing()
+    public void WhenClaimedPropertyProviderThrows_ThenCountIsUnavailableInsteadOfThrowing()
     {
         // Arrange
         var metrics = new SourceMetrics();
@@ -308,7 +340,7 @@ public class ConnectorMetricsTests
         var count = diagnostics.ClaimedPropertyCount;
 
         // Assert
-        Assert.Equal(0, count);
+        Assert.Null(count);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Connectors.Tests/Diagnostics/ConnectorMetricsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Diagnostics/ConnectorMetricsTests.cs
@@ -142,7 +142,7 @@ public class ConnectorMetricsTests
     }
 
     [Fact]
-    public void WhenUnmonitoredConnectorIsStopped_ThenLivenessStaysNullAndLateReportsAreIgnored()
+    public void WhenUnmonitoredConnectorIsStopped_ThenLivenessBecomesFalseAndLateReportsAreIgnored()
     {
         // Arrange
         var metrics = new ConnectorMetrics();
@@ -152,7 +152,25 @@ public class ConnectorMetricsTests
         metrics.MarkStopped();
         metrics.MarkOperational();
 
-        // Assert
+        // Assert: a stopped connector is known not to be serving even though it never measured that.
+        Assert.False(diagnostics.IsOperational);
+        Assert.NotNull(diagnostics.OperationalChangeTime);
+    }
+
+    [Fact]
+    public void WhenMonitoredConnectorIsRestarted_ThenLivenessReturnsToUnavailable()
+    {
+        // Arrange
+        var metrics = new ConnectorMetrics();
+        var diagnostics = new ConnectorDiagnostics(metrics);
+        metrics.MarkOperational();
+        metrics.MarkStopped();
+
+        // Act
+        metrics.MarkStarted();
+
+        // Assert: the new epoch reports nothing observed rather than the previous epoch's value and a
+        // timestamp from before it began.
         Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
     }

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectConnectorBaseTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectConnectorBaseTests.cs
@@ -66,7 +66,7 @@ public class SubjectConnectorBaseTests
         using var connector = new TestConnector();
         await ((IHostedService)connector).StartAsync(CancellationToken.None);
         connector.MarkOperational();
-        await AsyncTestHelpers.WaitUntilAsync(() => connector.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => connector.Diagnostics.IsOperational == true);
 
         // Act
         connector.Release();
@@ -83,7 +83,7 @@ public class SubjectConnectorBaseTests
         var connector = new TestConnector();
         await ((IHostedService)connector).StartAsync(CancellationToken.None);
         connector.MarkOperational();
-        await AsyncTestHelpers.WaitUntilAsync(() => connector.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => connector.Diagnostics.IsOperational == true);
 
         // Act
         connector.Dispose();

--- a/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/SubjectSourceDiagnosticsTests.cs
@@ -23,8 +23,8 @@ public class SubjectSourceDiagnosticsTests
         // Assert
         Assert.NotNull(source.Diagnostics);
         Assert.Null(source.Diagnostics.StartTime);
-        Assert.False(source.Diagnostics.IsOperational);
-        Assert.Equal(0, source.Diagnostics.ClaimedPropertyCount);
+        Assert.Null(source.Diagnostics.IsOperational);
+        Assert.Null(source.Diagnostics.ClaimedPropertyCount);
     }
 
     [Fact]
@@ -62,6 +62,25 @@ public class SubjectSourceDiagnosticsTests
 
         // Assert
         Assert.NotNull(source.Diagnostics.StartTime);
+        await ((IHostedService)source).StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WhenStartedWithoutLivenessReporting_ThenTheSourceIsSynchronizedWithUnavailableLiveness()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithRegistry().WithLifecycle();
+        var subject = new Person(context);
+        using var source = new TestSubjectSource(subject, context, NullLogger.Instance);
+
+        // Act
+        await ((IHostedService)source).StartAsync(CancellationToken.None);
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => source.State == SourceState.Synchronized,
+            message: "The source did not complete its initial synchronization.");
+
+        // Assert
+        Assert.Null(source.Diagnostics.IsOperational);
         await ((IHostedService)source).StopAsync(CancellationToken.None);
     }
 

--- a/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -180,7 +180,7 @@ namespace Namotion.Interceptor.Connectors.Diagnostics
     public class ConnectorDiagnostics
     {
         public ConnectorDiagnostics(Namotion.Interceptor.Connectors.Diagnostics.ConnectorMetrics metrics) { }
-        public bool IsOperational { get; }
+        public bool? IsOperational { get; }
         public System.Exception? LastError { get; }
         public System.DateTimeOffset? OperationalChangeTime { get; }
         public Namotion.Interceptor.Connectors.Diagnostics.QueueDiagnostics OutboundChanges { get; }
@@ -220,7 +220,7 @@ namespace Namotion.Interceptor.Connectors.Diagnostics
     public class SourceDiagnostics : Namotion.Interceptor.Connectors.Diagnostics.ConnectorDiagnostics
     {
         public SourceDiagnostics(Namotion.Interceptor.Connectors.Diagnostics.SourceMetrics metrics) { }
-        public int ClaimedPropertyCount { get; }
+        public int? ClaimedPropertyCount { get; }
         public Namotion.Interceptor.Connectors.Diagnostics.QueueDiagnostics InboundBuffer { get; }
         public Namotion.Interceptor.Connectors.Diagnostics.QueueDiagnostics OutboundRetries { get; }
     }

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorDiagnostics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorDiagnostics.cs
@@ -5,7 +5,7 @@ namespace Namotion.Interceptor.Connectors.Diagnostics;
 /// </summary>
 /// <remarks>
 /// This answers what the transport is doing. Whether the model can be trusted is a separate question
-/// answered by <see cref="ISubjectSource.State"/>, so read them together: a network outage is
+/// answered by <see cref="ISubjectSource.State"/>, so read them together: a reported network outage is
 /// <see cref="IsOperational"/> false, while a connected source still loading is
 /// <see cref="IsOperational"/> true with a state of
 /// <see cref="Monitoring.SourceState.Synchronizing"/>. See docs/connectors-monitoring.md.

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorDiagnostics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorDiagnostics.cs
@@ -26,15 +26,17 @@ public class ConnectorDiagnostics
     }
 
     /// <summary>
-    /// Gets a value indicating whether the transport is up and serving. What that means is defined
-    /// by each connector and documented on its own diagnostics type. It does not mean the model is
-    /// in sync: see the remarks on this type.
+    /// Gets a value indicating whether the transport is up and serving, or <c>null</c> when liveness
+    /// is unavailable because the connector has not reported it. What that means is defined by each
+    /// connector and documented on its own diagnostics type. It does not mean the model is in sync:
+    /// see the remarks on this type.
     /// </summary>
-    public bool IsOperational => _metrics.IsOperational;
+    public bool? IsOperational => _metrics.IsOperational;
 
     /// <summary>
     /// Gets when <see cref="IsOperational"/> last changed, or <c>null</c> until the first liveness
-    /// change. Moves whenever the flag moves, so the pair reads as "up since T" or "down since T".
+    /// report establishes a value and timestamp. Moves whenever the flag moves, so the pair reads as
+    /// "up since T" or "down since T".
     /// </summary>
     public DateTimeOffset? OperationalChangeTime => _metrics.OperationalChangeTime;
 

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorDiagnostics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorDiagnostics.cs
@@ -8,7 +8,8 @@ namespace Namotion.Interceptor.Connectors.Diagnostics;
 /// answered by <see cref="ISubjectSource.State"/>, so read them together: a reported network outage is
 /// <see cref="IsOperational"/> false, while a connected source still loading is
 /// <see cref="IsOperational"/> true with a state of
-/// <see cref="Monitoring.SourceState.Synchronizing"/>. See docs/connectors-monitoring.md.
+/// <see cref="Monitoring.SourceState.Synchronizing"/>. A connector that does not measure liveness
+/// reads <see cref="IsOperational"/> null while it runs. See docs/connectors-monitoring.md.
 /// </remarks>
 public class ConnectorDiagnostics
 {
@@ -26,17 +27,17 @@ public class ConnectorDiagnostics
     }
 
     /// <summary>
-    /// Gets a value indicating whether the transport is up and serving, or <c>null</c> when liveness
-    /// is unavailable because the connector has not reported it. What that means is defined by each
-    /// connector and documented on its own diagnostics type. It does not mean the model is in sync:
-    /// see the remarks on this type.
+    /// Gets a value indicating whether the transport is up and serving, or <c>null</c> while the
+    /// connector is running and has not reported liveness. A stopped connector always reads
+    /// <c>false</c>. What being up means is defined by each connector and documented on its own
+    /// diagnostics type. It does not mean the model is in sync: see the remarks on this type.
     /// </summary>
     public bool? IsOperational => _metrics.IsOperational;
 
     /// <summary>
-    /// Gets when <see cref="IsOperational"/> last changed, or <c>null</c> until the first liveness
-    /// report establishes a value and timestamp. Moves whenever the flag moves, so the pair reads as
-    /// "up since T" or "down since T".
+    /// Gets when <see cref="IsOperational"/> last changed, or <c>null</c> while liveness is still
+    /// unavailable. Moves whenever the value moves, so the pair reads as "up since T" or "down since
+    /// T", and clears with the value when a new epoch starts.
     /// </summary>
     public DateTimeOffset? OperationalChangeTime => _metrics.OperationalChangeTime;
 

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorMetrics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorMetrics.cs
@@ -107,8 +107,10 @@ public class ConnectorMetrics
     public void MarkNotOperational() => SetOperational(false, terminal: false);
 
     /// <summary>
-    /// Reports that the connector has stopped for good and latches that for the rest of the epoch,
-    /// until the next <see cref="MarkStarted"/>.
+    /// Reports that the connector has stopped for good and terminally latches liveness for the rest
+    /// of the epoch, until the next <see cref="MarkStarted"/>. Converts an observed <c>true</c> value
+    /// to <c>false</c>, preserves an existing <c>false</c> value or unavailable <c>null</c>, and rejects
+    /// later liveness reports until the next start.
     /// </summary>
     /// <remarks>
     /// Terminal because a liveness transition detected off the pump thread can otherwise land after

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorMetrics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorMetrics.cs
@@ -7,15 +7,19 @@ namespace Namotion.Interceptor.Connectors.Diagnostics;
 /// never reachable through <see cref="ISubjectConnector"/>, so only the connector itself can move
 /// its liveness or record its errors.
 /// </summary>
+/// <remarks>
+/// Liveness stays unavailable until the connector reports it, and diagnostics expose that state as
+/// <c>null</c>. The first liveness report establishes its change timestamp.
+/// </remarks>
 public class ConnectorMetrics
 {
-    private sealed record Liveness(bool IsOperational, long ChangeTicks, bool IsStopped);
+    private sealed record Liveness(bool? IsOperational, long ChangeTicks, bool IsStopped);
 
     // Writers serialize on this lock; readers take an immutable snapshot without locking, so no
     // getter can throw or block. Transitions are rare (per connect/disconnect, not per item).
     private readonly Lock _livenessLock = new();
 
-    private Liveness _liveness = new(false, 0, false);
+    private Liveness _liveness = new(null, 0, false);
     private long _startTicks;
     private Exception? _lastError;
     private ImmutableArray<IResettableMetrics> _resettables = [];
@@ -91,13 +95,14 @@ public class ConnectorMetrics
     }
 
     /// <summary>
-    /// Reports that the connector is now serving. Ignored between <see cref="MarkStopped"/> and the
-    /// next <see cref="MarkStarted"/>.
+    /// Reports that the connector is now serving. The first liveness report establishes the liveness
+    /// change timestamp. Ignored between <see cref="MarkStopped"/> and the next <see cref="MarkStarted"/>.
     /// </summary>
     public void MarkOperational() => SetOperational(true, terminal: false);
 
     /// <summary>
-    /// Reports that the connector is no longer serving but may recover.
+    /// Reports that the connector is no longer serving but may recover. The first liveness report
+    /// establishes the liveness change timestamp.
     /// </summary>
     public void MarkNotOperational() => SetOperational(false, terminal: false);
 
@@ -123,7 +128,7 @@ public class ConnectorMetrics
         Volatile.Write(ref _lastError, error);
     }
 
-    internal bool IsOperational => Volatile.Read(ref _liveness).IsOperational;
+    internal bool? IsOperational => Volatile.Read(ref _liveness).IsOperational;
 
     internal DateTimeOffset? OperationalChangeTime
     {
@@ -172,7 +177,11 @@ public class ConnectorMetrics
             }
 
             var stopped = current.IsStopped || terminal;
-            if (current.IsOperational == isOperational && current.IsStopped == stopped)
+            bool? publishedValue = terminal && current.IsOperational is null
+                ? null
+                : isOperational;
+
+            if (current.IsOperational == publishedValue && current.IsStopped == stopped)
             {
                 return;
             }
@@ -180,9 +189,9 @@ public class ConnectorMetrics
             // The timestamp moves only when the flag does, so latching the terminal bit on a connector
             // that was never operational does not invent a transition. It is sampled inside the lock,
             // so it cannot move backwards relative to an already published transition.
-            var updated = current.IsOperational == isOperational
+            var updated = current.IsOperational == publishedValue
                 ? current with { IsStopped = stopped }
-                : new Liveness(isOperational, DateTimeOffset.UtcNow.UtcTicks, stopped);
+                : new Liveness(publishedValue, DateTimeOffset.UtcNow.UtcTicks, stopped);
 
             Volatile.Write(ref _liveness, updated);
         }

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorMetrics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/ConnectorMetrics.cs
@@ -8,8 +8,9 @@ namespace Namotion.Interceptor.Connectors.Diagnostics;
 /// its liveness or record its errors.
 /// </summary>
 /// <remarks>
-/// Liveness stays unavailable until the connector reports it, and diagnostics expose that state as
-/// <c>null</c>. The first liveness report establishes its change timestamp.
+/// An epoch opens with liveness unavailable, which diagnostics expose as <c>null</c>, and closes at
+/// <c>false</c> when <see cref="MarkStopped"/> runs. A connector that reports liveness refines the
+/// value in between, so <c>null</c> means "running and not measured" and never survives a stop.
 /// </remarks>
 public class ConnectorMetrics
 {
@@ -53,9 +54,9 @@ public class ConnectorMetrics
     public QueueMetrics OutboundChanges { get; } = new(nameof(OutboundChanges));
 
     /// <summary>
-    /// Opens a new counter epoch: stamps a fresh start time, clears the last error, releases the
-    /// <see cref="MarkStopped"/> latch and resets every <c>Total</c> counter, including those of
-    /// registered hoisted metrics.
+    /// Opens a new counter epoch: stamps a fresh start time, clears the last error, returns liveness
+    /// to unavailable, releases the <see cref="MarkStopped"/> latch and resets every <c>Total</c>
+    /// counter, including those of registered hoisted metrics.
     /// </summary>
     /// <remarks>
     /// Deliberately not idempotent. Called once per <c>ExecuteAsync</c> entry, so a host stop and
@@ -102,15 +103,16 @@ public class ConnectorMetrics
 
     /// <summary>
     /// Reports that the connector is no longer serving but may recover. The first liveness report
-    /// establishes the liveness change timestamp.
+    /// establishes the liveness change timestamp. Ignored between <see cref="MarkStopped"/> and the
+    /// next <see cref="MarkStarted"/>.
     /// </summary>
     public void MarkNotOperational() => SetOperational(false, terminal: false);
 
     /// <summary>
     /// Reports that the connector has stopped for good and terminally latches liveness for the rest
-    /// of the epoch, until the next <see cref="MarkStarted"/>. Converts an observed <c>true</c> value
-    /// to <c>false</c>, preserves an existing <c>false</c> value or unavailable <c>null</c>, and rejects
-    /// later liveness reports until the next start.
+    /// of the epoch, until the next <see cref="MarkStarted"/>. Always publishes <c>false</c>, because a
+    /// stopped connector is known not to be serving whether or not it measures liveness itself, and
+    /// rejects later liveness reports until the next start.
     /// </summary>
     /// <remarks>
     /// Terminal because a liveness transition detected off the pump thread can otherwise land after
@@ -154,17 +156,13 @@ public class ConnectorMetrics
 
     private protected virtual void ResetTotals() => OutboundChanges.Reset();
 
-    // Only the latch is cleared: the transition timestamp is left alone so the pair keeps reading as
-    // "down since T" rather than inventing a new transition.
+    // The value and its timestamp both clear, so a new epoch starts with nothing observed rather than
+    // carrying the previous epoch's liveness and a timestamp from before this run began.
     private void ResetLiveness()
     {
         lock (_livenessLock)
         {
-            var current = _liveness;
-            if (current.IsStopped)
-            {
-                Volatile.Write(ref _liveness, current with { IsStopped = false });
-            }
+            Volatile.Write(ref _liveness, new Liveness(null, 0, false));
         }
     }
 
@@ -179,21 +177,17 @@ public class ConnectorMetrics
             }
 
             var stopped = current.IsStopped || terminal;
-            bool? publishedValue = terminal && current.IsOperational is null
-                ? null
-                : isOperational;
-
-            if (current.IsOperational == publishedValue && current.IsStopped == stopped)
+            if (current.IsOperational == isOperational && current.IsStopped == stopped)
             {
                 return;
             }
 
-            // The timestamp moves only when the flag does, so latching the terminal bit on a connector
-            // that was never operational does not invent a transition. It is sampled inside the lock,
-            // so it cannot move backwards relative to an already published transition.
-            var updated = current.IsOperational == publishedValue
+            // The timestamp moves only when the value does, so a repeated report keeps reading as
+            // "up since T" or "down since T". It is sampled inside the lock, so it cannot move
+            // backwards relative to an already published transition.
+            var updated = current.IsOperational == isOperational
                 ? current with { IsStopped = stopped }
-                : new Liveness(publishedValue, DateTimeOffset.UtcNow.UtcTicks, stopped);
+                : new Liveness(isOperational, DateTimeOffset.UtcNow.UtcTicks, stopped);
 
             Volatile.Write(ref _liveness, updated);
         }

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/SourceDiagnostics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/SourceDiagnostics.cs
@@ -20,10 +20,11 @@ public class SourceDiagnostics : ConnectorDiagnostics
     }
 
     /// <summary>
-    /// Gets how many properties this source currently owns. A gauge, not a counter: it rises as the
-    /// source claims properties and falls as subjects detach.
+    /// Gets how many properties this source currently owns, or <c>null</c> when the count is
+    /// unavailable. A gauge, not a counter: it rises as the source claims properties and falls as
+    /// subjects detach. A throwing count provider is sampled as unavailable.
     /// </summary>
-    public int ClaimedPropertyCount => _metrics.ClaimedPropertyCount;
+    public int? ClaimedPropertyCount => _metrics.ClaimedPropertyCount;
 
     /// <summary>
     /// Gets the queue of outbound writes awaiting retry. A growing depth means the external system

--- a/src/Namotion.Interceptor.Connectors/Diagnostics/SourceMetrics.cs
+++ b/src/Namotion.Interceptor.Connectors/Diagnostics/SourceMetrics.cs
@@ -27,11 +27,11 @@ public class SourceMetrics : ConnectorMetrics
 
     /// <summary>
     /// Points the claimed-property gauge at the source's ownership manager. A source that registers
-    /// nothing reports 0.
+    /// nothing reports an unavailable count.
     /// </summary>
     /// <remarks>
-    /// The delegate must return a non-negative count, must not throw (a throwing delegate is treated
-    /// as reporting 0) and must not take a lock owned by this library, because a diagnostics read can
+    /// The delegate must return a non-negative count, must not throw (a throwing delegate is sampled
+    /// as unavailable) and must not take a lock owned by this library, because a diagnostics read can
     /// happen while a monitor holds its own lock.
     /// </remarks>
     public void RegisterClaimedProperties(Func<int> count)
@@ -41,14 +41,14 @@ public class SourceMetrics : ConnectorMetrics
         Volatile.Write(ref _claimedPropertyCount, count);
     }
 
-    internal int ClaimedPropertyCount
+    internal int? ClaimedPropertyCount
     {
         get
         {
             var count = Volatile.Read(ref _claimedPropertyCount);
             if (count is null)
             {
-                return 0;
+                return null;
             }
 
             try
@@ -57,7 +57,7 @@ public class SourceMetrics : ConnectorMetrics
             }
             catch
             {
-                return 0;
+                return null;
             }
         }
     }

--- a/src/Namotion.Interceptor.Connectors/SubjectConnectorBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectConnectorBase.cs
@@ -5,7 +5,7 @@ namespace Namotion.Interceptor.Connectors;
 
 /// <summary>
 /// Abstract base for every connector, client or server, owning the diagnostics lifecycle so that a
-/// connector cannot forget to report that it stopped serving.
+/// connector cannot forget to terminally latch liveness when it stops serving.
 /// </summary>
 /// <remarks>
 /// <see cref="ExecuteAsync"/> is sealed and derived classes override <see cref="RunAsync"/> instead.

--- a/src/Namotion.Interceptor.Connectors/SubjectConnectorBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectConnectorBase.cs
@@ -5,7 +5,7 @@ namespace Namotion.Interceptor.Connectors;
 
 /// <summary>
 /// Abstract base for every connector, client or server, owning the diagnostics lifecycle so that a
-/// connector cannot forget to terminally latch liveness when it stops serving.
+/// connector cannot forget to report that it stopped serving.
 /// </summary>
 /// <remarks>
 /// <see cref="ExecuteAsync"/> is sealed and derived classes override <see cref="RunAsync"/> instead.

--- a/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientDiagnosticsTests.cs
@@ -32,7 +32,7 @@ public class MqttClientDiagnosticsTests
         var diagnostics = source.Diagnostics;
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
         Assert.Null(diagnostics.StartTime);
         Assert.Null(diagnostics.LastError);
@@ -115,7 +115,7 @@ public class MqttClientDiagnosticsTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational once it has connected to the broker.");
             Assert.Null(source.Diagnostics.LastError);
 

--- a/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientDiagnosticsTests.cs
@@ -23,7 +23,7 @@ public class MqttClientDiagnosticsTests
     /// counter this connector does not feed, which would report a misleading zero.
     /// </summary>
     [Fact]
-    public async Task WhenNeverConnected_ThenTheSourceReportsNotOperationalAndNoThroughput()
+    public async Task WhenNeverConnected_ThenTheSourceReportsUnavailableLivenessAndNoThroughput()
     {
         // Arrange
         await using var source = CreateClientSource();

--- a/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientLivenessTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientLivenessTests.cs
@@ -56,7 +56,7 @@ public partial class MqttClientLivenessTests
         await source.StartAsync(CancellationToken.None);
 
         await AsyncTestHelpers.WaitUntilAsync(
-            () => source.Diagnostics.IsOperational,
+            () => source.Diagnostics.IsOperational == true,
             message: "The client should report operational once it has connected to the broker.");
 
         // Assert
@@ -86,7 +86,7 @@ public partial class MqttClientLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational once it has connected to the broker.");
 
             var connectedAt = source.Diagnostics.OperationalChangeTime;
@@ -97,11 +97,11 @@ public partial class MqttClientLivenessTests
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == false,
                 message: "A disconnected client should stop reporting that it is serving.");
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational again once the monitor has reconnected.");
 
             // The rise is a second transition rather than the first one never having been dropped.
@@ -127,7 +127,7 @@ public partial class MqttClientLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational once it has connected to the broker.");
 
             var firstClient = GetCurrentClient(source);
@@ -137,13 +137,13 @@ public partial class MqttClientLivenessTests
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(3),
                 message: "A force-killed client should report the transport outage.");
             var downAt = source.Diagnostics.OperationalChangeTime;
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "A force-killed client should become operational on a replacement transport.");
 
             Assert.NotSame(firstClient, GetCurrentClient(source));
@@ -171,7 +171,7 @@ public partial class MqttClientLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational once it has connected to the broker.");
             await stateRecorder.WaitForStatesAsync(
                 TimeSpan.FromSeconds(30),
@@ -202,7 +202,7 @@ public partial class MqttClientLivenessTests
                 monitor.SignalReconnectNeeded();
 
                 await AsyncTestHelpers.WaitUntilAsync(
-                    () => !source.Diagnostics.IsOperational,
+                    () => source.Diagnostics.IsOperational == false,
                     message: "The confirmed disconnect should mark the client non-operational.");
                 await stateRecorder.WaitForStatesAsync(
                     TimeSpan.FromSeconds(15),
@@ -211,7 +211,7 @@ public partial class MqttClientLivenessTests
                     SourceState.Synchronizing);
 
                 await AsyncTestHelpers.WaitUntilAsync(
-                    () => source.Diagnostics.IsOperational,
+                    () => source.Diagnostics.IsOperational == true,
                     message: "The client should report operational again once the monitor has reconnected.");
                 await stateRecorder.WaitForStatesAsync(
                     TimeSpan.FromSeconds(30),
@@ -261,7 +261,7 @@ public partial class MqttClientLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational && clientRoot.Name == "Initial",
+                () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Initial",
                 message: "The initial transport should receive the broker's retained value.");
 
             var oldClient = GetCurrentClient(source);
@@ -283,7 +283,7 @@ public partial class MqttClientLivenessTests
 
             await ((IFaultInjectable)source).InjectFaultAsync(FaultType.Kill, CancellationToken.None);
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational &&
+                () => source.Diagnostics.IsOperational == true &&
                     !ReferenceEquals(oldClient, GetCurrentClient(source)) &&
                     clientRoot.Name == "Recovered",
                 message: "The replacement transport should restore the newer retained value.");
@@ -330,7 +330,7 @@ public partial class MqttClientLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational && clientRoot.Name == "Initial",
+                () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Initial",
                 message: "The initial transport should receive the broker's retained value.");
 
             brokerRoot.Name = "Recovered";
@@ -371,7 +371,7 @@ public partial class MqttClientLivenessTests
             commitGate.Release();
             await oldCallback.WaitAsync(TimeSpan.FromSeconds(10));
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational && clientRoot.Name == "Recovered",
+                () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Recovered",
                 message: "Recovery should follow an old commit that retirement already admitted.");
 
             // Assert

--- a/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerDiagnosticsTests.cs
@@ -15,7 +15,7 @@ namespace Namotion.Interceptor.Mqtt.Tests.Server;
 public class MqttServerDiagnosticsTests
 {
     [Fact]
-    public async Task WhenNeverStarted_ThenTheServerReportsNotOperationalAndNoThroughput()
+    public async Task WhenNeverStarted_ThenTheServerReportsUnavailableLivenessAndNoThroughput()
     {
         // Arrange
         await using var server = CreateServer(new MqttServerConfiguration());

--- a/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerDiagnosticsTests.cs
@@ -24,7 +24,7 @@ public class MqttServerDiagnosticsTests
         var diagnostics = server.Diagnostics;
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
         Assert.Null(diagnostics.StartTime);
         Assert.Null(diagnostics.LastError);
@@ -47,7 +47,7 @@ public class MqttServerDiagnosticsTests
         // Assert
         Assert.IsType<FormatException>(server.Diagnostics.LastError);
         Assert.NotNull(server.Diagnostics.StartTime);
-        Assert.False(server.Diagnostics.IsOperational);
+        Assert.Null(server.Diagnostics.IsOperational);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerDiagnosticsTests.cs
@@ -47,7 +47,7 @@ public class MqttServerDiagnosticsTests
         // Assert
         Assert.IsType<FormatException>(server.Diagnostics.LastError);
         Assert.NotNull(server.Diagnostics.StartTime);
-        Assert.Null(server.Diagnostics.IsOperational);
+        Assert.False(server.Diagnostics.IsOperational);
     }
 
     [Fact]

--- a/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerLivenessTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerLivenessTests.cs
@@ -57,7 +57,7 @@ public partial class MqttServerLivenessTests
         // Act
         await server.StartAsync(CancellationToken.None);
         await AsyncTestHelpers.WaitUntilAsync(
-            () => server.Diagnostics.IsOperational,
+            () => server.Diagnostics.IsOperational == true,
             message: "The broker should report operational once it is listening.");
 
         // Assert
@@ -85,7 +85,7 @@ public partial class MqttServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational,
+                () => server.Diagnostics.IsOperational == true,
                 message: "The broker should report operational once it is listening.");
 
             // Act
@@ -118,7 +118,7 @@ public partial class MqttServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational,
+                () => server.Diagnostics.IsOperational == true,
                 message: "The broker should report operational once it is listening.");
 
             var firstOperationalTime = server.Diagnostics.OperationalChangeTime;
@@ -128,7 +128,7 @@ public partial class MqttServerLivenessTests
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational &&
+                () => server.Diagnostics.IsOperational == true &&
                       server.Diagnostics.OperationalChangeTime != firstOperationalTime,
                 message: "The broker should report operational again after restarting.");
         }
@@ -184,7 +184,7 @@ public partial class MqttServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational,
+                () => server.Diagnostics.IsOperational == true,
                 message: "The first broker run should become operational.");
 
             var firstBroker = GetCurrentBroker(server);
@@ -211,7 +211,7 @@ public partial class MqttServerLivenessTests
             // Act
             await server.StartAsync(CancellationToken.None);
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational,
+                () => server.Diagnostics.IsOperational == true,
                 message: "The second broker run should become operational.");
 
             // Assert
@@ -231,7 +231,7 @@ public partial class MqttServerLivenessTests
         // Arrange
         await using var server = CreateServer();
         await server.StartAsync(CancellationToken.None);
-        await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
         var staleHandler = GetInstalledHandler<ClientConnectedEventArgs>(
             GetCurrentBroker(server), "ClientConnectedEvent");
         await server.StopAsync(CancellationToken.None);
@@ -261,13 +261,13 @@ public partial class MqttServerLivenessTests
         await server.StartAsync(CancellationToken.None);
         try
         {
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
             var staleHandler = GetInstalledHandler<ClientDisconnectedEventArgs>(
                 GetCurrentBroker(server), "ClientDisconnectedEvent");
 
             await server.StopAsync(CancellationToken.None);
             await server.StartAsync(CancellationToken.None);
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
 
             var options = new MqttClientOptionsBuilder()
                 .WithTcpServer("127.0.0.1", brokerPort)
@@ -339,7 +339,7 @@ public partial class MqttServerLivenessTests
         Task? staleCallback = null;
         try
         {
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
             var staleHandler = GetInstalledHandler<InterceptingPublishEventArgs>(
                 GetCurrentBroker(server), "InterceptingPublishEvent");
             var staleArgs = CreatePublishEventArgs("Old", publishCancellation.Token);
@@ -348,7 +348,7 @@ public partial class MqttServerLivenessTests
 
             await server.StopAsync(CancellationToken.None);
             await server.StartAsync(CancellationToken.None);
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
 
             var subscriberOptions = new MqttClientOptionsBuilder()
                 .WithTcpServer("127.0.0.1", brokerPort)
@@ -458,7 +458,7 @@ public partial class MqttServerLivenessTests
         Task? stopTask = null;
         try
         {
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
             var broker = GetCurrentBroker(server);
             var subscriberOptions = new MqttClientOptionsBuilder()
                 .WithTcpServer("127.0.0.1", brokerPort)
@@ -558,7 +558,7 @@ public partial class MqttServerLivenessTests
         Task? staleCallback = null;
         try
         {
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
             var broker = GetCurrentBroker(server);
             var staleHandler = GetInstalledHandler<InterceptingPublishEventArgs>(
                 broker, "InterceptingPublishEvent");
@@ -602,7 +602,7 @@ public partial class MqttServerLivenessTests
         Task? admittedCallback = null;
         try
         {
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
             var broker = GetCurrentBroker(server);
             var handler = GetInstalledHandler<InterceptingPublishEventArgs>(
                 broker, "InterceptingPublishEvent");
@@ -626,7 +626,7 @@ public partial class MqttServerLivenessTests
             Assert.Equal("Old", root.Name);
 
             await server.StartAsync(CancellationToken.None);
-            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => server.Diagnostics.IsOperational == true);
             var replacementHandler = GetInstalledHandler<InterceptingPublishEventArgs>(
                 GetCurrentBroker(server), "InterceptingPublishEvent");
             await replacementHandler(CreatePublishEventArgs("New"));

--- a/src/Namotion.Interceptor.Mqtt/Server/MqttServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.Mqtt/Server/MqttServerDiagnostics.cs
@@ -6,7 +6,8 @@ namespace Namotion.Interceptor.Mqtt.Server;
 /// What the MQTT server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// <see cref="ConnectorDiagnostics.IsOperational"/> means the broker is listening. Neither
+/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the broker is
+/// listening. A <c>null</c> value means the server has not published liveness yet. Neither
 /// throughput direction is measured, so both rates are <c>null</c> rather than 0.
 /// </remarks>
 public sealed class MqttServerDiagnostics : ConnectorDiagnostics

--- a/src/Namotion.Interceptor.Mqtt/Server/MqttServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.Mqtt/Server/MqttServerDiagnostics.cs
@@ -6,9 +6,10 @@ namespace Namotion.Interceptor.Mqtt.Server;
 /// What the MQTT server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// A value of <c>true</c> means the broker is listening; <c>false</c> means it explicitly reports
-/// that it is not listening, and <c>null</c> means the server has not published liveness yet.
-/// Neither throughput direction is measured, so both rates are <c>null</c> rather than 0.
+/// A value of <c>true</c> means the broker is listening and <c>false</c> means it is not, either
+/// because the server reported that or because it has stopped. It reads <c>null</c> only while the
+/// server runs before its first liveness report. Neither throughput direction is measured, so both
+/// rates are <c>null</c> rather than 0.
 /// </remarks>
 public sealed class MqttServerDiagnostics : ConnectorDiagnostics
 {

--- a/src/Namotion.Interceptor.Mqtt/Server/MqttServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.Mqtt/Server/MqttServerDiagnostics.cs
@@ -6,9 +6,9 @@ namespace Namotion.Interceptor.Mqtt.Server;
 /// What the MQTT server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the broker is
-/// listening. A <c>null</c> value means the server has not published liveness yet. Neither
-/// throughput direction is measured, so both rates are <c>null</c> rather than 0.
+/// A value of <c>true</c> means the broker is listening; <c>false</c> means it explicitly reports
+/// that it is not listening, and <c>null</c> means the server has not published liveness yet.
+/// Neither throughput direction is measured, so both rates are <c>null</c> rather than 0.
 /// </remarks>
 public sealed class MqttServerDiagnostics : ConnectorDiagnostics
 {

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaClientDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaClientDiagnosticsTests.cs
@@ -37,7 +37,7 @@ public class OpcUaClientDiagnosticsTests
         NodeId? sessionId = diagnostics.SessionId;
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
         Assert.Null(diagnostics.LastError);
         Assert.Null(diagnostics.StartTime);

--- a/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaClientLivenessTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Client/OpcUaClientLivenessTests.cs
@@ -75,7 +75,7 @@ public class OpcUaClientLivenessTests
             await source.StartAsync(CancellationToken.None);
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(90),
                 message: "The client should report itself operational before the poisoned load runs");
 
@@ -156,7 +156,7 @@ public class OpcUaClientLivenessTests
                 message: "Initial sync should complete");
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(60),
                 message: "The first health check tick should report the session as operational");
 
@@ -167,19 +167,19 @@ public class OpcUaClientLivenessTests
             await server.RestartAsync();
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(30),
                 message: "The failing keep-alive should drop liveness");
 
             // Assert - raised again by the completed transfer on the reconnect callback's own thread,
             // far inside the health check interval, so no tick can be what raised it.
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(30),
                 message: "The completed subscription transfer should raise liveness again");
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(75),
                 message: "The failed full state sync should drop liveness with the session it cleared");
 
@@ -192,7 +192,7 @@ public class OpcUaClientLivenessTests
             // Act
             converter.Disarm();
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(75),
                 message: "The health loop should reconnect after the failed full state sync");
 
@@ -253,7 +253,7 @@ public class OpcUaClientLivenessTests
                 message: "Initial sync should complete");
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(30),
                 message: "The health check loop should report the session as operational");
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaConcurrencyTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaConcurrencyTests.cs
@@ -95,7 +95,7 @@ public class OpcUaConcurrencyTests
             logger.Log("Stopping server...");
             await server.StopAsync();
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !client.Source.Diagnostics.IsOperational,
+                () => client.Source.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(90),
                 message: "Client should detect disconnection");
             logger.Log("Client detected disconnection");

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaReconnectionTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaReconnectionTests.cs
@@ -129,7 +129,7 @@ public class OpcUaReconnectionTests
                 await server.StopAsync();
 
                 await AsyncTestHelpers.WaitUntilAsync(
-                    () => !client.Source!.Diagnostics.IsOperational,
+                    () => client.Source!.Diagnostics.IsOperational == false,
                     timeout: TimeSpan.FromSeconds(90),
                     message: "Client should detect disconnection");
                 logger.Log("Client detected disconnection");
@@ -163,7 +163,7 @@ public class OpcUaReconnectionTests
                 // intervals (5s each here), so a rise that arrived late enough to be worthless
                 // still fails.
                 await AsyncTestHelpers.WaitUntilAsync(
-                    () => client.Source!.Diagnostics.IsOperational,
+                    () => client.Source!.Diagnostics.IsOperational == true,
                     timeout: TimeSpan.FromSeconds(20),
                     message: "Client should report itself operational again after reconnecting");
                 Assert.NotNull(client.Source.CurrentSession);
@@ -273,14 +273,14 @@ public class OpcUaReconnectionTests
 
             Assert.NotNull(client.Source);
             await AsyncTestHelpers.WaitUntilAsync(
-                () => client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(60),
                 message: "Client should report operational after the initial connect");
 
             // Act
             await server.StopAsync();
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(60),
                 message: "Client should detect the outage");
             logger.Log("Client detected disconnection");
@@ -291,7 +291,7 @@ public class OpcUaReconnectionTests
             // out. The bound is far below that, so a rise that arrived late enough to be worthless
             // still fails.
             await AsyncTestHelpers.WaitUntilAsync(
-                () => client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(30),
                 message: "Client should report operational as soon as the reconnect transferred its subscriptions");
 
@@ -367,7 +367,7 @@ public class OpcUaReconnectionTests
             logger.Log("Stopping server...");
             await server.StopAsync();
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(90),
                 message: "Client should detect disconnection");
             logger.Log("Client detected disconnection");

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerLivenessTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaServerLivenessTests.cs
@@ -38,7 +38,7 @@ public class OpcUaServerLivenessTests
 
         // Act
         await AsyncTestHelpers.WaitUntilAsync(
-            () => serverService.Diagnostics.IsOperational,
+            () => serverService.Diagnostics.IsOperational == true,
             message: "The server should report operational once it has started serving.");
 
         // Assert
@@ -72,7 +72,7 @@ public class OpcUaServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => serverService.Diagnostics.IsOperational,
+                () => serverService.Diagnostics.IsOperational == true,
                 message: "The server should report operational once it has started serving.");
 
             var firstOperationalTime = serverService.Diagnostics.OperationalChangeTime;
@@ -84,7 +84,7 @@ public class OpcUaServerLivenessTests
             // The timestamp only moves when the flag does, so this also pins that the server reported
             // itself down between the two runs rather than staying up across the restart.
             await AsyncTestHelpers.WaitUntilAsync(
-                () => serverService.Diagnostics.IsOperational &&
+                () => serverService.Diagnostics.IsOperational == true &&
                       serverService.Diagnostics.OperationalChangeTime != firstOperationalTime,
                 message: "The server should report operational again after restarting.");
 
@@ -117,7 +117,7 @@ public class OpcUaServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => serverService.Diagnostics.IsOperational,
+                () => serverService.Diagnostics.IsOperational == true,
                 message: "The server should report operational once it has started serving.");
 
             // Act

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaStallDetectionTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaStallDetectionTests.cs
@@ -74,7 +74,7 @@ public class OpcUaStallDetectionTests
 
             // Verify initial connection
             await AsyncTestHelpers.WaitUntilAsync(
-                () => client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(120),
                 message: "Client should be connected after startup");
             logger.Log("Initial connection established");
@@ -88,7 +88,7 @@ public class OpcUaStallDetectionTests
 
             // Wait for client to detect disconnection (longer timeout for parallel test execution)
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == false,
                 timeout: TimeSpan.FromSeconds(120),
                 message: "Client should detect disconnection");
             logger.Log("Client detected disconnection");
@@ -212,7 +212,7 @@ public class OpcUaStallDetectionTests
 
             // Wait for connection status to stabilize
             await AsyncTestHelpers.WaitUntilAsync(
-                () => client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(120),
                 message: "Client should report as connected after recovery");
             logger.Log("Test passed - client recovered after stall");
@@ -292,7 +292,7 @@ public class OpcUaStallDetectionTests
 
             // Wait for client to detect disconnection (longer timeout for slow CI runners)
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !client.Source!.Diagnostics.IsOperational || client.Source!.Diagnostics.IsReconnecting,
+                () => client.Source!.Diagnostics.IsOperational == false || client.Source!.Diagnostics.IsReconnecting,
                 timeout: TimeSpan.FromSeconds(120),
                 message: "Client should detect disconnection or start reconnecting");
             logger.Log($"Client state after stop - Connected: {client.Source!.Diagnostics.IsOperational}, Reconnecting: {client.Source!.Diagnostics.IsReconnecting}");
@@ -311,7 +311,7 @@ public class OpcUaStallDetectionTests
 
             // Verify client is connected
             await AsyncTestHelpers.WaitUntilAsync(
-                () => client.Source!.Diagnostics.IsOperational,
+                () => client.Source!.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(120),
                 message: "Client should report as connected after recovery");
 

--- a/src/Namotion.Interceptor.OpcUa.Tests/Server/OpcUaServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Server/OpcUaServerDiagnosticsTests.cs
@@ -20,7 +20,7 @@ public class OpcUaServerDiagnosticsTests
     /// here is what a fresh <c>ConnectorMetrics</c> reports.
     /// </summary>
     [Fact]
-    public void WhenNeverStarted_ThenTheServerReportsNotOperational()
+    public void WhenNeverStarted_ThenTheServerReportsUnavailableLiveness()
     {
         // Arrange
         using var server = CreateServer();
@@ -30,7 +30,7 @@ public class OpcUaServerDiagnosticsTests
         int activeSessionCount = diagnostics.ActiveSessionCount;
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
         Assert.Null(diagnostics.StartTime);
         Assert.Null(diagnostics.LastError);
@@ -127,7 +127,7 @@ public class OpcUaServerDiagnosticsTests
         // Assert
         Assert.IsType<InvalidOperationException>(server.Diagnostics.LastError);
         Assert.NotNull(server.Diagnostics.StartTime);
-        Assert.False(server.Diagnostics.IsOperational);
+        Assert.Null(server.Diagnostics.IsOperational);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.OpcUa.Tests/Server/OpcUaServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Server/OpcUaServerDiagnosticsTests.cs
@@ -127,7 +127,7 @@ public class OpcUaServerDiagnosticsTests
         // Assert
         Assert.IsType<InvalidOperationException>(server.Diagnostics.LastError);
         Assert.NotNull(server.Diagnostics.StartTime);
-        Assert.Null(server.Diagnostics.IsOperational);
+        Assert.False(server.Diagnostics.IsOperational);
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -7,11 +7,11 @@ namespace Namotion.Interceptor.OpcUa.Client;
 /// What the OPC UA client reports about its session, on top of the shared source diagnostics.
 /// </summary>
 /// <remarks>
-/// A value of <c>true</c> means the client has a live session with its subscriptions set up;
-/// <c>false</c> means it explicitly reports that it is not serving, and <c>null</c> means the client
-/// has not published liveness yet. It stays false for the whole address space browse and subscription
-/// creation, which on a large server takes minutes, and drops whenever the session is lost, killed
-/// or torn down. True does not mean the model is in sync: while the initial value read runs the
+/// A value of <c>true</c> means the client has a live session with its subscriptions set up and
+/// <c>false</c> means it is not serving, either because the client reported that or because it has
+/// stopped. It reads <c>null</c> only while the client runs before its first liveness report. It
+/// stays false for the whole address space browse and subscription creation, which on a large server
+/// takes minutes, and drops whenever the session is lost, killed or torn down. True does not mean the model is in sync: while the initial value read runs the
 /// source state is
 /// <see cref="Namotion.Interceptor.Connectors.Monitoring.SourceState.Synchronizing"/>, so read the
 /// two together to tell a network outage from a connected client still loading. See

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -7,9 +7,9 @@ namespace Namotion.Interceptor.OpcUa.Client;
 /// What the OPC UA client reports about its session, on top of the shared source diagnostics.
 /// </summary>
 /// <remarks>
-/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the client has a
-/// live session with its subscriptions set up. A <c>null</c> value means the client has not
-/// published liveness yet. It stays false for the whole address space browse and subscription
+/// A value of <c>true</c> means the client has a live session with its subscriptions set up;
+/// <c>false</c> means it explicitly reports that it is not serving, and <c>null</c> means the client
+/// has not published liveness yet. It stays false for the whole address space browse and subscription
 /// creation, which on a large server takes minutes, and drops whenever the session is lost, killed
 /// or torn down. True does not mean the model is in sync: while the initial value read runs the
 /// source state is

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientDiagnostics.cs
@@ -7,8 +7,9 @@ namespace Namotion.Interceptor.OpcUa.Client;
 /// What the OPC UA client reports about its session, on top of the shared source diagnostics.
 /// </summary>
 /// <remarks>
-/// <see cref="ConnectorDiagnostics.IsOperational"/> means the client has a live session with its
-/// subscriptions set up. It stays false for the whole address space browse and subscription
+/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the client has a
+/// live session with its subscriptions set up. A <c>null</c> value means the client has not
+/// published liveness yet. It stays false for the whole address space browse and subscription
 /// creation, which on a large server takes minutes, and drops whenever the session is lost, killed
 /// or torn down. True does not mean the model is in sync: while the initial value read runs the
 /// source state is

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerDiagnostics.cs
@@ -6,11 +6,11 @@ namespace Namotion.Interceptor.OpcUa.Server;
 /// What the OPC UA server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// A value of <c>true</c> means the server has started and is accepting client connections;
-/// <c>false</c> means it explicitly reports that it is not accepting connections, and <c>null</c>
-/// means the server has not published liveness yet. <see cref="ConnectorDiagnostics.OperationalChangeTime"/>
-/// moves on every internal restart, where <see cref="ConnectorDiagnostics.StartTime"/> marks the
-/// hosted service's own start and does not.
+/// A value of <c>true</c> means the server has started and is accepting client connections and
+/// <c>false</c> means it is not, either because the server reported that or because it has stopped.
+/// It reads <c>null</c> only while the server runs before its first liveness report.
+/// <see cref="ConnectorDiagnostics.OperationalChangeTime"/> moves on every internal restart, where
+/// <see cref="ConnectorDiagnostics.StartTime"/> marks the hosted service's own start and does not.
 /// </remarks>
 public sealed class OpcUaServerDiagnostics : ConnectorDiagnostics
 {

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerDiagnostics.cs
@@ -6,11 +6,11 @@ namespace Namotion.Interceptor.OpcUa.Server;
 /// What the OPC UA server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the server has
-/// started and is accepting client connections. A <c>null</c> value means the server has not
-/// published liveness yet. <see cref="ConnectorDiagnostics.OperationalChangeTime"/> moves on every
-/// internal restart, where <see cref="ConnectorDiagnostics.StartTime"/> marks the hosted service's
-/// own start and does not.
+/// A value of <c>true</c> means the server has started and is accepting client connections;
+/// <c>false</c> means it explicitly reports that it is not accepting connections, and <c>null</c>
+/// means the server has not published liveness yet. <see cref="ConnectorDiagnostics.OperationalChangeTime"/>
+/// moves on every internal restart, where <see cref="ConnectorDiagnostics.StartTime"/> marks the
+/// hosted service's own start and does not.
 /// </remarks>
 public sealed class OpcUaServerDiagnostics : ConnectorDiagnostics
 {

--- a/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.OpcUa/Server/OpcUaServerDiagnostics.cs
@@ -6,8 +6,9 @@ namespace Namotion.Interceptor.OpcUa.Server;
 /// What the OPC UA server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// <see cref="ConnectorDiagnostics.IsOperational"/> means the server has started and is accepting
-/// client connections. <see cref="ConnectorDiagnostics.OperationalChangeTime"/> moves on every
+/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the server has
+/// started and is accepting client connections. A <c>null</c> value means the server has not
+/// published liveness yet. <see cref="ConnectorDiagnostics.OperationalChangeTime"/> moves on every
 /// internal restart, where <see cref="ConnectorDiagnostics.StartTime"/> marks the hosted service's
 /// own start and does not.
 /// </remarks>

--- a/src/Namotion.Interceptor.WebSocket.Tests/Client/WebSocketClientDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Client/WebSocketClientDiagnosticsTests.cs
@@ -32,7 +32,7 @@ public class WebSocketClientDiagnosticsTests
     /// counter this connector does not feed, which would report a misleading zero.
     /// </summary>
     [Fact]
-    public async Task WhenNeverConnected_ThenTheSourceReportsNotOperationalAndNoThroughput()
+    public async Task WhenNeverConnected_ThenTheSourceReportsUnavailableLivenessAndNoThroughput()
     {
         // Arrange
         await using var source = CreateClientSource();

--- a/src/Namotion.Interceptor.WebSocket.Tests/Client/WebSocketClientDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Client/WebSocketClientDiagnosticsTests.cs
@@ -41,7 +41,7 @@ public class WebSocketClientDiagnosticsTests
         var diagnostics = source.Diagnostics;
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
         Assert.Null(diagnostics.StartTime);
         Assert.Null(diagnostics.LastError);
@@ -91,7 +91,7 @@ public class WebSocketClientDiagnosticsTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational once the handshake is accepted.");
             Assert.Null(source.Diagnostics.LastError);
 

--- a/src/Namotion.Interceptor.WebSocket.Tests/Client/WebSocketClientLivenessTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Client/WebSocketClientLivenessTests.cs
@@ -46,7 +46,7 @@ public class WebSocketClientLivenessTests
         // Act
         await source.StartAsync(CancellationToken.None);
         await AsyncTestHelpers.WaitUntilAsync(
-            () => source.Diagnostics.IsOperational,
+            () => source.Diagnostics.IsOperational == true,
             message: "The client should report operational once the handshake is accepted.");
 
         // Assert
@@ -73,7 +73,7 @@ public class WebSocketClientLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational once the handshake is accepted.");
 
             var connectedAt = source.Diagnostics.OperationalChangeTime;
@@ -84,11 +84,11 @@ public class WebSocketClientLivenessTests
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => !source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == false,
                 message: "A client whose receive loop has exited should stop reporting that it is serving.");
 
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 message: "The client should report operational again once it has reconnected.");
 
             // The rise is a second transition rather than the first one never having been dropped.
@@ -111,7 +111,7 @@ public class WebSocketClientLivenessTests
 
         try
         {
-            await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == true);
             var connectedAt = source.Diagnostics.OperationalChangeTime;
 
             // Act
@@ -121,7 +121,7 @@ public class WebSocketClientLivenessTests
             // operational client with a newer timestamp proves the liveness fell and rose again even
             // when both transitions happen between two polls.
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational && source.Diagnostics.OperationalChangeTime > connectedAt,
+                () => source.Diagnostics.IsOperational == true && source.Diagnostics.OperationalChangeTime > connectedAt,
                 message: "The kill should drop liveness and a replacement attempt should raise it again.");
         }
         finally
@@ -143,13 +143,13 @@ public class WebSocketClientLivenessTests
             portLease.Port, reconnectDelay: TimeSpan.FromSeconds(2), writeInterceptor: reloadGate);
         await source.StartAsync(CancellationToken.None);
         var clientRoot = (TestRoot)source.RootSubject;
-        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == true);
 
         try
         {
             // Act
             await ((IFaultInjectable)source).InjectFaultAsync(FaultType.Disconnect, CancellationToken.None);
-            await AsyncTestHelpers.WaitUntilAsync(() => !source.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == false);
             reloadGate.Arm();
             server.Root!.Name = "Reload";
             await reloadGate.ReloadStarted.WaitAsync(TimeSpan.FromSeconds(10));
@@ -183,7 +183,7 @@ public class WebSocketClientLivenessTests
 
         var clientRoot = (TestRoot)source.RootSubject;
         await AsyncTestHelpers.WaitUntilAsync(
-            () => source.Diagnostics.IsOperational && clientRoot.Name == "Initial");
+            () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Initial");
 
         var oldLoopCompletion = GetReceiveLoopCompletion(source);
         source.BeforeUpdateCommitAdmission = admissionGate.Wait;
@@ -228,7 +228,7 @@ public class WebSocketClientLivenessTests
 
         var clientRoot = (TestRoot)source.RootSubject;
         await AsyncTestHelpers.WaitUntilAsync(
-            () => source.Diagnostics.IsOperational && clientRoot.Name == "Initial");
+            () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Initial");
 
         try
         {
@@ -292,7 +292,7 @@ public class WebSocketClientLivenessTests
 
         var clientRoot = (TestRoot)source.RootSubject;
         await AsyncTestHelpers.WaitUntilAsync(
-            () => source.Diagnostics.IsOperational && clientRoot.Name == "Initial");
+            () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Initial");
 
         var oldLoopCompletion = GetReceiveLoopCompletion(source);
         source.BeforeUpdateCommitAdmission = admissionGate.Wait;
@@ -336,7 +336,7 @@ public class WebSocketClientLivenessTests
 
         var clientRoot = (TestRoot)source.RootSubject;
         await AsyncTestHelpers.WaitUntilAsync(
-            () => source.Diagnostics.IsOperational && clientRoot.Name == "Initial");
+            () => source.Diagnostics.IsOperational == true && clientRoot.Name == "Initial");
 
         server.Root!.Name = "Old";
         await commitGate.Entered.WaitAsync(TimeSpan.FromSeconds(10));
@@ -394,7 +394,7 @@ public class WebSocketClientLivenessTests
         await server.StartAsync(portLease.Port);
         await using var source = CreateClientSource(portLease.Port, reconnectDelay: TimeSpan.FromMilliseconds(20));
         await source.StartAsync(CancellationToken.None);
-        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == true);
 
         try
         {
@@ -422,7 +422,7 @@ public class WebSocketClientLivenessTests
         await using var server = await StartServerAsync(portLease.Port);
         await using var source = CreateClientSource(portLease.Port);
         await source.StartAsync(CancellationToken.None);
-        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == true);
 
         var oldCompletion = GetReceiveLoopCompletion(source);
         var receiveCts = GetReceiveCancellation(source);
@@ -458,18 +458,18 @@ public class WebSocketClientLivenessTests
             circuitBreakerFailureThreshold: 0);
 
         await source.StartAsync(CancellationToken.None);
-        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == true);
 
         try
         {
             // Act - stopping the server fails every reconnect attempt for real until it returns.
             await server.StopAsync();
-            await AsyncTestHelpers.WaitUntilAsync(() => !source.Diagnostics.IsOperational);
+            await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == false);
             await server.RestartAsync();
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => source.Diagnostics.IsOperational,
+                () => source.Diagnostics.IsOperational == true,
                 timeout: TimeSpan.FromSeconds(15),
                 message: "The monitor should keep retrying failed replacement attempts until one succeeds.");
         }
@@ -487,7 +487,7 @@ public class WebSocketClientLivenessTests
         await using var server = await StartServerAsync(portLease.Port);
         await using var source = CreateClientSource(portLease.Port);
         await source.StartAsync(CancellationToken.None);
-        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational);
+        await AsyncTestHelpers.WaitUntilAsync(() => source.Diagnostics.IsOperational == true);
 
         var oldCompletion = GetReceiveLoopCompletion(source);
         var receiveCts = GetReceiveCancellation(source);

--- a/src/Namotion.Interceptor.WebSocket.Tests/Server/WebSocketServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Server/WebSocketServerDiagnosticsTests.cs
@@ -29,7 +29,7 @@ public class WebSocketServerDiagnosticsTests
         var diagnostics = server.Diagnostics;
 
         // Assert
-        Assert.False(diagnostics.IsOperational);
+        Assert.Null(diagnostics.IsOperational);
         Assert.Null(diagnostics.OperationalChangeTime);
         Assert.Null(diagnostics.StartTime);
         Assert.Null(diagnostics.LastError);

--- a/src/Namotion.Interceptor.WebSocket.Tests/Server/WebSocketServerDiagnosticsTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Server/WebSocketServerDiagnosticsTests.cs
@@ -20,7 +20,7 @@ public class WebSocketServerDiagnosticsTests
     /// here is what a fresh <c>ConnectorMetrics</c> and an idle handler report.
     /// </summary>
     [Fact]
-    public void WhenNeverStarted_ThenTheServerReportsNotOperational()
+    public void WhenNeverStarted_ThenTheServerReportsUnavailableLiveness()
     {
         // Arrange
         using var server = CreateServer();

--- a/src/Namotion.Interceptor.WebSocket.Tests/Server/WebSocketServerLivenessTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Server/WebSocketServerLivenessTests.cs
@@ -32,7 +32,7 @@ public class WebSocketServerLivenessTests
         // Act
         await server.StartAsync(CancellationToken.None);
         await AsyncTestHelpers.WaitUntilAsync(
-            () => server.Diagnostics.IsOperational,
+            () => server.Diagnostics.IsOperational == true,
             message: "The server should report operational once the listener is accepting connections.");
 
         // Assert
@@ -62,7 +62,7 @@ public class WebSocketServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational,
+                () => server.Diagnostics.IsOperational == true,
                 message: "The server should report operational once the listener is accepting connections.");
 
             // Act
@@ -96,7 +96,7 @@ public class WebSocketServerLivenessTests
         try
         {
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational,
+                () => server.Diagnostics.IsOperational == true,
                 message: "The server should report operational once the listener is accepting connections.");
 
             var firstOperationalTime = server.Diagnostics.OperationalChangeTime;
@@ -106,7 +106,7 @@ public class WebSocketServerLivenessTests
 
             // Assert
             await AsyncTestHelpers.WaitUntilAsync(
-                () => server.Diagnostics.IsOperational &&
+                () => server.Diagnostics.IsOperational == true &&
                       server.Diagnostics.OperationalChangeTime != firstOperationalTime,
                 message: "The server should report operational again after restarting.");
 

--- a/src/Namotion.Interceptor.WebSocket/Server/WebSocketServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.WebSocket/Server/WebSocketServerDiagnostics.cs
@@ -6,10 +6,10 @@ namespace Namotion.Interceptor.WebSocket.Server;
 /// What the WebSocket server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// A value of <c>true</c> means the listener is accepting connections; <c>false</c> means it
-/// explicitly reports that it is not accepting connections, and <c>null</c> means the server has
-/// not published liveness yet. Neither throughput direction is measured, so both rates are
-/// <c>null</c> rather than 0.
+/// A value of <c>true</c> means the listener is accepting connections and <c>false</c> means it is
+/// not, either because the server reported that or because it has stopped. It reads <c>null</c> only
+/// while the server runs before its first liveness report. Neither throughput direction is measured,
+/// so both rates are <c>null</c> rather than 0.
 /// </remarks>
 public sealed class WebSocketServerDiagnostics : ConnectorDiagnostics
 {

--- a/src/Namotion.Interceptor.WebSocket/Server/WebSocketServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.WebSocket/Server/WebSocketServerDiagnostics.cs
@@ -6,7 +6,8 @@ namespace Namotion.Interceptor.WebSocket.Server;
 /// What the WebSocket server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// <see cref="ConnectorDiagnostics.IsOperational"/> means the listener is accepting connections.
+/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the listener is
+/// accepting connections. A <c>null</c> value means the server has not published liveness yet.
 /// Neither throughput direction is measured, so both rates are <c>null</c> rather than 0.
 /// </remarks>
 public sealed class WebSocketServerDiagnostics : ConnectorDiagnostics

--- a/src/Namotion.Interceptor.WebSocket/Server/WebSocketServerDiagnostics.cs
+++ b/src/Namotion.Interceptor.WebSocket/Server/WebSocketServerDiagnostics.cs
@@ -6,9 +6,10 @@ namespace Namotion.Interceptor.WebSocket.Server;
 /// What the WebSocket server reports about its transport, on top of the shared connector diagnostics.
 /// </summary>
 /// <remarks>
-/// When <see cref="ConnectorDiagnostics.IsOperational"/> has a value, it means the listener is
-/// accepting connections. A <c>null</c> value means the server has not published liveness yet.
-/// Neither throughput direction is measured, so both rates are <c>null</c> rather than 0.
+/// A value of <c>true</c> means the listener is accepting connections; <c>false</c> means it
+/// explicitly reports that it is not accepting connections, and <c>null</c> means the server has
+/// not published liveness yet. Neither throughput direction is measured, so both rates are
+/// <c>null</c> rather than 0.
 /// </remarks>
 public sealed class WebSocketServerDiagnostics : ConnectorDiagnostics
 {


### PR DESCRIPTION
Expose unavailable connector diagnostics explicitly instead of reporting misleading `false` and `0` values. Simple custom sources can omit liveness monitoring and ownership gauges, while built-in connectors continue to publish measured values after their first protocol-specific observation.

Consumers now receive `null` while a diagnostic is genuinely unavailable, and a measured value as soon as one exists. MQTT, WebSocket, OPC UA, HomeBlaze, XML documentation, and connector guidance have been migrated to preserve that distinction.

## Why

An MVP source that does not implement monitoring should not look explicitly down, and a source without an ownership gauge should not look like it measured zero owned properties. Nullable snapshots let consumers distinguish unavailable diagnostics from observed states without coupling source synchronization, monitoring, and ownership.

Liveness is scoped to the run, so unavailable never outlives the situation that made it unavailable. A connector that has stopped is known not to be serving whether or not it measures liveness itself, and `SubjectConnectorBase` is the only caller of `MarkStarted()` and `MarkStopped()`, so the base brackets every run with values it can back. `null` therefore means "running and not measured" and is confined to the window where the distinction is real.

## Contract

- `IsOperational` is `true` when the connector reports serving, `false` when it reports down or has stopped, and `null` while it is running and has not reported liveness.
- `MarkStarted()` opens an epoch by returning liveness to `null` and clearing its change timestamp, so a restarted connector carries neither the previous epoch's value nor a timestamp from before the run began.
- `MarkStopped()` closes the epoch by always publishing `false`, terminally latching it, and rejecting late reports until the next `MarkStarted()`.
- `OperationalChangeTime` is `null` while liveness is unavailable and moves only when the liveness value moves.
- `ClaimedPropertyCount` is `null` without a working registered provider and includes measured zero when a provider reports zero.
- Synchronization state remains independent. A source may reach `Synchronized` while optional diagnostics remain unavailable.

While a connector runs, `null` distinguishes one that does not measure liveness from one that does. While it is stopped, every connector reads `false`, because both answers coincide at "not serving". The tri-state carries information only where the states genuinely differ.

## Breaking changes

- API: `ConnectorDiagnostics.IsOperational` changes from `bool` to `bool?`. Consumers must handle `null`; use `== true` for readiness and `== false` when an explicitly reported outage is required.
- API: `SourceDiagnostics.ClaimedPropertyCount` changes from `int` to `int?`. Consumers must handle `null` as unmeasured and distinguish it from measured zero.
- Behavior: while running, a source that never opts into liveness reporting now exposes `null` instead of a misleading default `false`.
- Behavior: a restarted connector now opens its run at `null` instead of carrying the previous run's liveness value and change timestamp.
- Behavior: sources without a claimed-property provider, or whose provider throws, now expose `null` instead of a misleading default `0`.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| HomeBlaze.OpcUa | 1 | 2 | 1 | +1 |
| Namotion.Interceptor.Connectors | 4 | 47 | 38 | +9 |
| Namotion.Interceptor.Mqtt | 1 | 4 | 2 | +2 |
| Namotion.Interceptor.OpcUa | 2 | 10 | 8 | +2 |
| Namotion.Interceptor.WebSocket | 1 | 4 | 2 | +2 |
| Tests and benchmarks | 19 | 173 | 104 | +69 |
| Documentation | 8 | 25 | 19 | +6 |
| **Total** | **36** | **265** | **174** | **+91** |

## Verification

- [x] Documentation updated
- [x] Unit tests: `dotnet test src/Namotion.Interceptor.slnx --filter "Category!=Integration"`, zero failures
- [x] Public API snapshot test: 1 passed, no `.received.txt` files
- [x] Focused connector tests: Connectors 736, MQTT 70, WebSocket 104, OPC UA 309, all passed
- [x] HomeBlaze.OpcUa compiled as part of the full solution run
- [x] Integration tests: full suite run, `dotnet test src/Namotion.Interceptor.slnx` with no filter, 3470 tests across 27 assemblies, zero failures. Liveness values at stop and restart changed, so the suite was run rather than reasoned about: OPC UA 352, WebSocket 159, MQTT 103, HomeBlaze.E2E 23. Every `IsOperational == false` wait resolved normally, confirming each is driven by the connector's own explicit report rather than the old default.
- ~~[ ] Benchmarks~~ Not run because the change preserves the existing lock-free, allocation-neutral snapshot access pattern
- ~~[ ] Load tests~~ Not run because connector protocol and reconnection behavior did not change
- ~~[ ] Chaos tests~~ Not run because connector protocol and reconnection behavior did not change
