### PR TITLE
fix: classify Nullable<T> structural properties by their underlying type

### DIFF
--- a/src/Namotion.Interceptor.Tracking.Tests/LifecycleInterceptorTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/LifecycleInterceptorTests.cs
@@ -468,6 +468,99 @@ public class LifecycleInterceptorTests
         Assert.Contains(events, e => e.Contains("Car3") && e.Contains("attached"));
     }
 
+    [Fact]
+    public void WhenAssigningNullableImmutableArray_ThenSubjectsAreAttached()
+    {
+        // Arrange
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+        var car1 = new Car { Name = "Car1" };
+        var car2 = new Car { Name = "Car2" };
+
+        // Act
+        holder.ImmutableCars = ImmutableArray.Create(car1, car2);
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("ImmutableCars[0] -> Car1") && e.Contains("attached"));
+        Assert.Contains(events, e => e.Contains("ImmutableCars[1] -> Car2") && e.Contains("attached"));
+    }
+
+    [Fact]
+    public void WhenAssigningNullableReadOnlyStructCollection_ThenSubjectsAreAttached()
+    {
+        // Arrange
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.BagCars = new CarBag(car);
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("BagCars[0] -> Car1") && e.Contains("attached"));
+    }
+
+    [Fact]
+    public void WhenAssigningNullableReadOnlyStructDictionary_ThenSubjectsAreAttachedUnderTheirKey()
+    {
+        // Arrange: the boxed value is only an IEnumerable of key value pairs, so the keyed dispatch
+        // arm has to come from the declared Nullable<CarMap> property type.
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.MappedCars = new CarMap(new Dictionary<string, Car> { ["first"] = car });
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("MappedCars[first] -> Car1") && e.Contains("attached"));
+    }
+
+    [Fact]
+    public void WhenClearingNullableStructuralProperty_ThenSubjectsAreDetached()
+    {
+        // Arrange
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+        var car = new Car { Name = "Car1" };
+        holder.ImmutableCars = ImmutableArray.Create(car);
+        handler.Clear();
+
+        // Act
+        holder.ImmutableCars = null;
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("ImmutableCars[0] -> Car1") && e.Contains("detached"));
+    }
+
     public class AddPropertyToSubjectHandler : ILifecycleHandler
     {
         public void HandleLifecycleChange(SubjectLifecycleChange change)

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/NullableStructuralHolder.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/NullableStructuralHolder.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Collections.Immutable;
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+/// <summary>
+/// Model with structural properties typed <c>Nullable&lt;T&gt;</c>, where <c>T</c> is a struct that
+/// carries subjects. The nullable form distinguishes "not set" from "empty", which a bare
+/// <see cref="ImmutableArray{T}"/> cannot express.
+/// </summary>
+[InterceptorSubject]
+public partial class NullableStructuralHolder
+{
+    /// <summary>Boxes to an <see cref="ICollection"/>, the collection dispatch arm.</summary>
+    public partial ImmutableArray<Car>? ImmutableCars { get; set; }
+
+    /// <summary>Boxes to a bare <see cref="IEnumerable"/>, the read-only collection dispatch arm.</summary>
+    public partial CarBag? BagCars { get; set; }
+
+    /// <summary>
+    /// Boxes to a bare <see cref="IEnumerable"/> of key value pairs, so the dispatch arm is chosen
+    /// from the declared property type rather than from the value.
+    /// </summary>
+    public partial CarMap? MappedCars { get; set; }
+}
+
+/// <summary>Read-only struct collection that implements neither <see cref="ICollection"/> nor <see cref="IDictionary"/>.</summary>
+public readonly struct CarBag(params Car[] cars) : IEnumerable<Car>
+{
+    private readonly Car[] _cars = cars;
+
+    public IEnumerator<Car> GetEnumerator() => ((IEnumerable<Car>)(_cars ?? [])).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <summary>Read-only struct dictionary that implements neither <see cref="ICollection"/> nor <see cref="IDictionary"/>.</summary>
+public readonly struct CarMap(Dictionary<string, Car> cars) : IReadOnlyDictionary<string, Car>
+{
+    private readonly Dictionary<string, Car> _cars = cars;
+
+    private Dictionary<string, Car> Cars => _cars ?? [];
+
+    public Car this[string key] => Cars[key];
+
+    public IEnumerable<string> Keys => Cars.Keys;
+
+    public IEnumerable<Car> Values => Cars.Values;
+
+    public int Count => Cars.Count;
+
+    public bool ContainsKey(string key) => Cars.ContainsKey(key);
+
+    public bool TryGetValue(string key, out Car value) => Cars.TryGetValue(key, out value!);
+
+    public IEnumerator<KeyValuePair<string, Car>> GetEnumerator() => Cars.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/NullableStructuralPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/NullableStructuralPropertyTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Immutable;
+using Namotion.Interceptor.Connectors.Updates;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking.Lifecycle;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests;
+
+/// <summary>
+/// Covers the consequences of classifying a <c>Nullable&lt;T&gt;</c> structural property by its
+/// underlying type, beyond the attach and detach callbacks exercised in
+/// <see cref="LifecycleInterceptorTests"/>: that the children reach the registry with their
+/// indices, that the connector update path emits the property as a collection rather than a
+/// scalar value, and that a default struct value fails fast instead of being read as empty.
+/// </summary>
+public class NullableStructuralPropertyTests
+{
+    [Fact]
+    public void WhenANullableStructuralPropertyIsAssigned_ThenItsChildrenAreRegisteredWithTheirIndices()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+        var car1 = new Car { Name = "Car1" };
+        var car2 = new Car { Name = "Car2" };
+
+        // Act
+        holder.ImmutableCars = ImmutableArray.Create(car1, car2);
+
+        // Assert
+        var children = holder
+            .TryGetRegisteredSubject()!
+            .TryGetProperty(nameof(NullableStructuralHolder.ImmutableCars))!
+            .Children;
+
+        Assert.Equal(2, children.Length);
+        Assert.Equal([0, 1], children.Select(child => child.Index).Cast<int>().ToArray());
+        Assert.Equal([car1, car2], children.Select(child => child.Subject).ToArray());
+    }
+
+    [Fact]
+    public void WhenANullableStructuralPropertyIsSerialized_ThenItEmitsAsACollection()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context)
+        {
+            ImmutableCars = ImmutableArray.Create(new Car { Name = "Car1" })
+        };
+
+        // Act
+        var update = SubjectUpdate.CreateCompleteUpdate(holder, []);
+
+        // Assert
+        // Before the classification fix this emitted Kind=Value carrying the raw boxed collection,
+        // which leaks subject children into the scalar value channel.
+        var properties = update.Subjects[update.Root!];
+        Assert.Equal(
+            SubjectPropertyUpdateKind.Collection,
+            properties[nameof(NullableStructuralHolder.ImmutableCars)].Kind);
+    }
+
+    [Fact]
+    public void WhenAssigningADefaultStructCollectionToANullableStructuralProperty_ThenItThrows()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+
+        // Act & Assert
+        // A default ImmutableArray cannot be enumerated, so the structural scan surfaces it at the
+        // assignment rather than tolerating it as empty. The non-nullable form already behaves this
+        // way, and null remains how the nullable form expresses "not set".
+        Assert.Throws<InvalidOperationException>(() => holder.ImmutableCars = default(ImmutableArray<Car>));
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/SubjectPropertyTypeExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/SubjectPropertyTypeExtensionsTests.cs
@@ -56,6 +56,12 @@ public class SubjectPropertyTypeExtensionsTests
     // IReadOnlyDictionary with non-subject values: has dict interface but int values cannot be subjects.
     [InlineData(typeof(IReadOnlyDictionary<string, int>),                   false, false, false)]
 
+    // --- Nullable<T> of a subject-carrying struct: classified by the underlying type ---
+    [InlineData(typeof(ImmutableArray<Person>?),                            false, true,  false)]
+    [InlineData(typeof(ArraySegment<Person>?),                              false, true,  false)]
+    [InlineData(typeof(StructSubjectCollection?),                           false, true,  false)]
+    [InlineData(typeof(StructSubjectDictionary?),                           false, false, true)]
+
     // --- Not subject-carrying ---
     [InlineData(typeof(int),                                                false, false, false)]
     [InlineData(typeof(decimal),                                            false, false, false)]
@@ -68,6 +74,13 @@ public class SubjectPropertyTypeExtensionsTests
     [InlineData(typeof(IEnumerable<int>),                                   false, false, false)]
     [InlineData(typeof(IDictionary<string, int>),                           false, false, false)]
     [InlineData(typeof(ImmutableArray<int>),                                false, false, false)]
+    // Nullable<T> of a struct that cannot hold subjects stays unclassified.
+    [InlineData(typeof(ImmutableArray<int>?),                               false, false, false)]
+    [InlineData(typeof(int?),                                               false, false, false)]
+    [InlineData(typeof(DateTime?),                                          false, false, false)]
+    // Nullable<T> of a subject-shaped struct that is neither a container nor a reference.
+    [InlineData(typeof(KeyValuePair<string, Person>?),                      false, false, false)]
+    [InlineData(typeof((Person, Person)?),                                  false, false, false)]
     // Element-of-container-of-non-subjects: outer is not a subject collection.
     [InlineData(typeof(List<IEnumerable<Person>>),                          false, false, false)]
     [InlineData(typeof(List<IList<int>>),                                   false, false, false)]
@@ -181,6 +194,24 @@ public class SubjectPropertyTypeExtensionsTests
 
     private sealed class NonSubjectPlainClass
     {
+    }
+
+    private readonly struct StructSubjectCollection : IEnumerable<Person>
+    {
+        public IEnumerator<Person> GetEnumerator() => throw new NotSupportedException();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private readonly struct StructSubjectDictionary : IReadOnlyDictionary<string, Person>
+    {
+        public Person this[string key] => throw new NotSupportedException();
+        public IEnumerable<string> Keys => throw new NotSupportedException();
+        public IEnumerable<Person> Values => throw new NotSupportedException();
+        public int Count => throw new NotSupportedException();
+        public bool ContainsKey(string key) => throw new NotSupportedException();
+        public bool TryGetValue(string key, out Person value) => throw new NotSupportedException();
+        public IEnumerator<KeyValuePair<string, Person>> GetEnumerator() => throw new NotSupportedException();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class SelfReferentialSubjectCollection : IInterceptorSubject, IEnumerable<SelfReferentialSubjectCollection>

--- a/src/Namotion.Interceptor.Tracking/SubjectPropertyTypeExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/SubjectPropertyTypeExtensions.cs
@@ -15,6 +15,9 @@ public static class SubjectPropertyTypeExtensions
     // function of Type. The dependency graph (Reference -> Collection, Dictionary; Collection ->
     // Dictionary; Dictionary -> nothing) is acyclic, so racing factory invocations on different
     // Types converge to the same result without deadlock or inconsistency.
+    // Nullable<T> is normalised to T inside the factories rather than at the entry points, so a
+    // cache hit stays a single dictionary lookup; the nullable and underlying types simply get
+    // one entry each.
     private static readonly ConcurrentDictionary<Type, bool> CanContainSubjectsCache = new();
     private static readonly ConcurrentDictionary<Type, bool> IsSubjectReferenceTypeCache = new();
     private static readonly ConcurrentDictionary<Type, bool> IsSubjectCollectionTypeCache = new();
@@ -106,6 +109,8 @@ public static class SubjectPropertyTypeExtensions
     {
         return IsSubjectReferenceTypeCache.GetOrAdd(type, static t =>
         {
+            t = Nullable.GetUnderlyingType(t) ?? t;
+
             if (typeof(IInterceptorSubject).IsAssignableFrom(t))
             {
                 return true;
@@ -121,6 +126,8 @@ public static class SubjectPropertyTypeExtensions
     {
         return IsSubjectCollectionTypeCache.GetOrAdd(type, static t =>
         {
+            t = Nullable.GetUnderlyingType(t) ?? t;
+
             if (typeof(IInterceptorSubject).IsAssignableFrom(t))
                 return false;
 
@@ -144,6 +151,8 @@ public static class SubjectPropertyTypeExtensions
     {
         return IsSubjectDictionaryTypeCache.GetOrAdd(type, static t =>
         {
+            t = Nullable.GetUnderlyingType(t) ?? t;
+
             if (typeof(IInterceptorSubject).IsAssignableFrom(t))
                 return false;
 


### PR DESCRIPTION
A structural property typed `Nullable<T>` is never classified as structural, so its children are never attached, never registered, and receive no lifecycle callbacks. The failure is silent: the source generator compiles `public partial ImmutableArray<Car>? Cars { get; set; }` without complaint, and nothing throws or warns at runtime.

There is a second symptom on the connector outbound path, which is the more damaging one: the property is emitted as `Kind=Value` carrying the raw boxed collection, so subject children leak into the scalar value channel. After the fix it emits `Kind=Collection`.

No model in this repository uses the nullable form, so nothing here changes behaviour. The consumer-visible changes are listed under Breaking changes.

## Why

`Nullable<T>` requires `T : struct`, so this only bites where `T` is a struct the classifier already accepts as a container. That set is small but real, and all four members were confirmed by running them:

| Shape | Before | After |
|---|---|---|
| `ImmutableArray<Subject>?` | not structural, 0 children attached | structural, children attached and registered |
| `ArraySegment<Subject>?` | not structural | structural |
| `readonly struct : IEnumerable<Subject>` made nullable | not structural | structural |
| `readonly struct : IReadOnlyDictionary<K, Subject>` made nullable | not structural | structural, attached under its key |

Controls that must stay unclassified, and do: `ImmutableArray<int>?`, `int?`, `DateTime?`, `KeyValuePair<,>?`, `ValueTuple<,>?`.

## Contract

- A structural property typed `Nullable<T>` now establishes ownership edges exactly as the non-nullable `T` does. Assigning null releases them, as an empty value does.
- Classification is the only place that needed the unwrap **for the tracking and registry paths**. A boxed `Nullable<T>` boxes to a plain boxed `T`, or to null, so the value scanners are already transparent to it, and the keyed-versus-ordinal dispatch for read-only containers routes through the same classifier. Verified in both directions, attach and detach.
- It is **not** sufficient for the connector apply path, which reads the declared type's generic arguments rather than the boxed value (`SubjectFactoryExtensions.cs:42`, `DefaultSubjectFactory.cs:45`, `SubjectItemsUpdateApplier.cs:137`). A nullable struct container now reaches that path and fails there. See the breaking-changes note.

## Breaking changes

No API change. No signature changes and no public API snapshot movement. Five existing public methods change behaviour for `Nullable<T>` inputs only, where the previous answer was wrong, plus four properties on `RegisteredSubjectProperty` that delegate to them, so the consumer-visible surface is nine members.

The change is monotonic, which is what bounds its blast radius. For any `Nullable<X>`, master answers false from all three classifiers, because a `Nullable<X>` implements no interfaces and is neither an interface, `object`, nor `IInterceptorSubject`. This change can therefore only turn false into true, never the reverse.

Three behaviour changes, all consequences of the property becoming structural, and all confirmed by running them:

**A nullable struct container now fails on the connector apply path**, where it previously appeared to succeed. That prior success was the defect: the applied collection held the source's subject instances, unattached and unregistered on the target. The same path is already broken for the non-nullable form, which throws `InvalidCastException` on master, so struct containers were never supported there. Tracked in #508; unwrapping at those three sites would swap one exception for another rather than fix it.

**Assigning `default(ImmutableArray<T>)` explicitly to such a property now throws**, because the property is now scanned and a default instance cannot be enumerated. This is deliberate, and it makes the nullable form consistent with the non-nullable one, which already throws on master for the same assignment. The throw is immediate and carries the BCL's own message naming the fix ("Consider initializing the array, or checking the `ImmutableArray<T>.IsDefault` property"), so it cannot reach production unnoticed. Assigning `null` is unaffected, which is what the nullable form uses for "not set", so a model using it works today and continues to.

**Leaf-property filters now exclude these properties.** The MQTT and WebSocket sources select on `!CanContainSubjects` (`MqttSubjectClientSource.cs:554`, `MqttSubjectServer.cs:587`, `WebSocketSubjectClientSource.cs:365`), so a consumer's nullable structural property disappears from the published topic set. Those are the connector-facing sites; around fourteen `CanContainSubjects` consumers change answer for such a property in total, including the MCP browse and property tools and several HomeBlaze path providers. All move in the same direction. This is the correct new behaviour, and it is visible to anyone who has one.

One deliberate consequence worth naming: `Nullable<StructSubject>` now classifies as a subject reference, matching what the non-nullable form already did. It is unreachable through the source generator, which is class-only.

## Performance

The unwrap sits inside the three `GetOrAdd` cache factories rather than at the public entry points, so a cache hit remains a single dictionary lookup instead of paying `IsGenericType` and `GetGenericTypeDefinition()` on every call. That matters because `CanContainSubjects<TProperty>()` runs on every intercepted write. The cost is one additional cache entry per nullable type encountered.

Not benchmarked: the change adds no work to any cached path, and the uncached path runs once per type.

## Verification

- [x] Documentation updated
- [x] Unit tests
- [ ] ~~Integration tests~~ no connector implementation changed

