### PR TITLE
fix: read a default struct collection as empty instead of throwing

### DIFF
--- a/src/HomeBlaze/HomeBlaze.Host.Services.Tests/Display/StateUnitExtensionsTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Host.Services.Tests/Display/StateUnitExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using HomeBlaze.Abstractions.Attributes;
 using HomeBlaze.Host.Services.Display;
 using HomeBlaze.Services.Lifecycle;
@@ -121,6 +122,22 @@ public class StateUnitExtensionsTests
 
         // Assert
         Assert.Equal(expected, result);
+    }
+    [Fact]
+    public void WhenDisplayValueIsADefaultStructCollection_ThenItRendersAsEmpty()
+    {
+        // Arrange: a property that was never assigned holds a struct collection whose inner array
+        // is null, so joining it throws instead of producing the empty string an empty one gives.
+        var context = CreateContext();
+        var subject = new DisplayTestSubject(context);
+        var registered = subject.TryGetRegisteredSubject()!;
+        var property = registered.TryGetProperty(nameof(DisplayTestSubject.Rate))!;
+
+        // Act
+        var result = property.GetPropertyDisplayValue(default(ImmutableArray<string>));
+
+        // Assert
+        Assert.Equal(string.Empty, result);
     }
 }
 

--- a/src/HomeBlaze/HomeBlaze.Host.Services/Display/StateUnitExtensions.cs
+++ b/src/HomeBlaze/HomeBlaze.Host.Services/Display/StateUnitExtensions.cs
@@ -3,6 +3,7 @@ using HomeBlaze.Abstractions.Attributes;
 using HomeBlaze.Abstractions.Metadata;
 using HomeBlaze.Services;
 using Namotion.Interceptor.Registry.Abstractions;
+using Namotion.Interceptor.Tracking;
 
 namespace HomeBlaze.Host.Services.Display;
 
@@ -103,7 +104,11 @@ public static class StateUnitExtensions
             DateTime dt => dt.ToString("g"),
             DateTimeOffset dto => $"{dto.ToLocalTime().ToString("g")} {dto.ToLocalTime():zzz}",
             Enum e => e.ToString(),
-            IEnumerable<string> strings => string.Join("\n", strings),
+            // A default struct collection throws when joined; it renders as the empty join an
+            // initialized empty collection produces.
+            IEnumerable<string> strings => SubjectPropertyTypeExtensions.ReadsAsEmpty(value)
+                ? string.Empty
+                : string.Join("\n", strings),
             _ => value.ToString() ?? ""
         };
     }

--- a/src/Namotion.Interceptor.AspNetCore/Extensions/SubjectRegistryJsonExtensions.cs
+++ b/src/Namotion.Interceptor.AspNetCore/Extensions/SubjectRegistryJsonExtensions.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using Namotion.Interceptor.Registry;
 using Namotion.Interceptor.Registry.Abstractions;
 using Namotion.Interceptor.Registry.Attributes;
+using Namotion.Interceptor.Tracking;
 using Namotion.Interceptor.Tracking.Parent;
 
 namespace Namotion.Interceptor.AspNetCore.Extensions;
@@ -129,6 +130,13 @@ public static class SubjectRegistryJsonExtensions
 
         if (value is IEnumerable enumerable and not string)
         {
+            // A default struct collection throws both when enumerated and when serialized as a
+            // value, so emit the empty array an initialized empty collection would produce.
+            if (SubjectPropertyTypeExtensions.ReadsAsEmpty(value))
+            {
+                return new JsonArray();
+            }
+
             // Materialize once so the Count check and the foreach share a single pass over
             // potentially lazy / one-shot enumerables.
             var subjectChildren = enumerable.OfType<IInterceptorSubject>().ToList();
@@ -197,7 +205,12 @@ public static class SubjectRegistryJsonExtensions
 
                     if (subject.Properties.TryGetValue(nextSegment, out var property))
                     {
-                        var collection = property.GetValue?.Invoke(subject) as IEnumerable;
+                        // A default struct collection holds no children, so no index resolves.
+                        var propertyValue = property.GetValue?.Invoke(subject);
+                        var collection = SubjectPropertyTypeExtensions.ReadsAsEmpty(propertyValue)
+                            ? null
+                            : propertyValue as IEnumerable;
+
                         var child = collection?.OfType<IInterceptorSubject>().ElementAt(index);
                         if (child is not null)
                         {

--- a/src/Namotion.Interceptor.Connectors.Tests/Models/StructCollectionNode.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Models/StructCollectionNode.cs
@@ -1,0 +1,22 @@
+using System.Collections.Immutable;
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Connectors.Tests.Models;
+
+/// <summary>
+/// Model whose collection properties are left at their default value, which for a struct
+/// collection is an instance holding a null inner array. Unlike
+/// <see cref="ReadOnlyTypesTestNode"/>, nothing initializes them in the constructor, so the
+/// connector update path sees the unusable default that a fresh subject actually has.
+/// </summary>
+[InterceptorSubject]
+public partial class StructCollectionNode
+{
+    public partial string? Name { get; set; }
+
+    /// <summary>Declared as a struct collection, so it starts as <c>default(ImmutableArray&lt;&gt;)</c>.</summary>
+    public partial ImmutableArray<StructCollectionNode> ImmutableItems { get; set; }
+
+    /// <summary>Interface-declared, so it can hold a boxed default struct and still be written back as a list.</summary>
+    public partial IReadOnlyList<StructCollectionNode>? InterfaceItems { get; set; }
+}

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDefaultStructCollectionTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDefaultStructCollectionTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+using System.Reactive.Concurrency;
+using Namotion.Interceptor.Connectors.Tests.Models;
+using Namotion.Interceptor.Connectors.Updates;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Connectors.Tests.Updates;
+
+/// <summary>
+/// Verifies that the connector update path treats the default instance of a struct collection as
+/// an empty collection. Such a value holds a null inner array, so every read of it throws, and it
+/// is what a collection property holds before anything is assigned to it.
+/// </summary>
+public class SubjectUpdateDefaultStructCollectionTests
+{
+    [Fact]
+    public void WhenCollectionPropertyHoldsADefaultStruct_ThenCompleteUpdateReportsItEmpty()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithRegistry();
+        var node = new StructCollectionNode(context) { Name = "Root" };
+
+        // Act
+        var update = SubjectUpdate.CreateCompleteUpdate(node, []);
+
+        // Assert
+        var itemsUpdate = update.Subjects[update.Root!][nameof(StructCollectionNode.ImmutableItems)];
+        Assert.Equal(SubjectPropertyUpdateKind.Collection, itemsUpdate.Kind);
+        Assert.Equal(0, itemsUpdate.Count);
+        Assert.Empty(itemsUpdate.Items!);
+    }
+
+    [Fact]
+    public void WhenCollectionPropertyStartsAsADefaultStruct_ThenAddingAnItemIsAnInsert()
+    {
+        // Arrange: the old value in the diff is the default struct the property was born with.
+        var context = InterceptorSubjectContext.Create().WithPropertyChangeSubscriptions().WithRegistry();
+        var node = new StructCollectionNode(context) { Name = "Root" };
+
+        var changes = new List<SubjectPropertyChange>();
+        context.GetPropertyChangeObservable(ImmediateScheduler.Instance).Subscribe(c => changes.Add(c));
+
+        // Act
+        node.ImmutableItems = [new StructCollectionNode { Name = "Item1" }];
+        var update = SubjectUpdate.CreatePartialUpdateFromChanges(node, changes.ToArray(), []);
+
+        // Assert
+        var itemsUpdate = update.Subjects[update.Root!][nameof(StructCollectionNode.ImmutableItems)];
+        Assert.NotNull(itemsUpdate.Operations);
+        Assert.Single(itemsUpdate.Operations);
+        Assert.Equal(SubjectCollectionOperationType.Insert, itemsUpdate.Operations[0].Action);
+        Assert.Equal(0, itemsUpdate.Operations[0].Index);
+    }
+
+    [Fact]
+    public void WhenCollectionPropertyIsSetToADefaultStruct_ThenItsItemsAreRemoved()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithPropertyChangeSubscriptions().WithRegistry();
+        var item1 = new StructCollectionNode { Name = "Item1" };
+        var node = new StructCollectionNode(context)
+        {
+            Name = "Root",
+            ImmutableItems = [item1]
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        context.GetPropertyChangeObservable(ImmediateScheduler.Instance).Subscribe(c => changes.Add(c));
+
+        // Act
+        node.ImmutableItems = default;
+        var update = SubjectUpdate.CreatePartialUpdateFromChanges(node, changes.ToArray(), []);
+
+        // Assert
+        var itemsUpdate = update.Subjects[update.Root!][nameof(StructCollectionNode.ImmutableItems)];
+        Assert.Equal(0, itemsUpdate.Count);
+        Assert.NotNull(itemsUpdate.Operations);
+        Assert.Single(itemsUpdate.Operations);
+        Assert.Equal(SubjectCollectionOperationType.Remove, itemsUpdate.Operations[0].Action);
+    }
+
+    [Fact]
+    public void WhenTargetPropertyHoldsADefaultStruct_ThenApplyingACollectionUpdateSucceeds()
+    {
+        // Arrange: the apply step reads the target's current value to build its working list, so
+        // the target, not the source, is what carries the unusable default here.
+        var context = InterceptorSubjectContext.Create().WithRegistry();
+        var source = new StructCollectionNode(context)
+        {
+            Name = "Root",
+            InterfaceItems = new List<StructCollectionNode> { new() { Name = "Item1" } }
+        };
+
+        var target = new StructCollectionNode(context)
+        {
+            Name = "Root",
+            InterfaceItems = default(ImmutableArray<StructCollectionNode>)
+        };
+
+        var update = SubjectUpdate.CreateCompleteUpdate(source, []);
+
+        // Act
+        target.ApplySubjectUpdate(update, null, ChangeOrigin.Local);
+
+        // Assert
+        Assert.NotNull(target.InterfaceItems);
+        Assert.Single(target.InterfaceItems);
+        Assert.Equal("Item1", target.InterfaceItems[0].Name);
+    }
+}

--- a/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectValueConvert.cs
+++ b/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectValueConvert.cs
@@ -26,6 +26,11 @@ internal static class SubjectValueConvert
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static IReadOnlyList<IInterceptorSubject> ToSubjectList(object value)
     {
+        // A default struct collection satisfies the covariant fast path but throws on every read,
+        // so it has to be answered as empty before it is passed on to the diff builder.
+        if (SubjectPropertyTypeExtensions.ReadsAsEmpty(value))
+            return [];
+
         if (value is IReadOnlyList<IInterceptorSubject> readOnlyList)
             return readOnlyList;
 
@@ -52,7 +57,7 @@ internal static class SubjectValueConvert
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static List<IInterceptorSubject> ToSubjectMutableList(object? value)
     {
-        if (value is null)
+        if (value is null || SubjectPropertyTypeExtensions.ReadsAsEmpty(value))
             return [];
 
         if (value is IEnumerable<IInterceptorSubject> typedEnumerable)

--- a/src/Namotion.Interceptor.Registry.Tests/Models/StructCollectionSubject.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/Models/StructCollectionSubject.cs
@@ -1,0 +1,18 @@
+using System.Collections.Immutable;
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Registry.Tests.Models;
+
+/// <summary>
+/// Model with struct collection properties that are never assigned, so they hold the default
+/// instance whose inner array is null. <see cref="Tags"/> is deliberately not subject-carrying:
+/// the JSON writer enumerates every <see cref="System.Collections.IEnumerable"/>, so a default
+/// struct reaches it whether or not the property is structural.
+/// </summary>
+[InterceptorSubject]
+public partial class StructCollectionSubject
+{
+    public partial ImmutableArray<string> Tags { get; set; }
+
+    public partial ImmutableArray<Person> Children { get; set; }
+}

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryJsonExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryJsonExtensionsTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Namotion.Interceptor.AspNetCore.Extensions;
+using Namotion.Interceptor.Registry.Tests.Models;
+using Namotion.Interceptor.Tracking;
+
+namespace Namotion.Interceptor.Registry.Tests;
+
+/// <summary>
+/// Covers the JSON readers against the default instance of a struct collection, which holds a
+/// null inner array and throws both when enumerated and when serialized as a plain value.
+/// </summary>
+public class SubjectRegistryJsonExtensionsTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerOptions.Default)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [Fact]
+    public void WhenPropertyHoldsADefaultStructCollection_ThenItIsWrittenAsAnEmptyArray()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithParents()
+            .WithRegistry();
+
+        var subject = new StructCollectionSubject(context);
+
+        // Act
+        var json = subject.ToJsonObject(JsonOptions);
+
+        // Assert
+        Assert.Equal("[]", json["tags"]!.ToJsonString(JsonOptions));
+        Assert.Equal("[]", json["children"]!.ToJsonString(JsonOptions));
+    }
+
+    [Fact]
+    public void WhenJsonPathIndexesIntoADefaultStructCollection_ThenNoPropertyIsFound()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithParents()
+            .WithRegistry();
+
+        var subject = new StructCollectionSubject(context);
+
+        // Act
+        var (owner, _) = subject.FindPropertyFromJsonPath("children[0].firstName");
+
+        // Assert
+        Assert.Null(owner);
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/LifecycleInterceptorTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/LifecycleInterceptorTests.cs
@@ -561,6 +561,128 @@ public class LifecycleInterceptorTests
         Assert.Contains(events, e => e.Contains("ImmutableCars[0] -> Car1") && e.Contains("detached"));
     }
 
+    [Fact]
+    public void WhenStructCollectionPropertyIsNeverAssigned_ThenAttachingTheSubjectSucceeds()
+    {
+        // Arrange
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        // Act: every structural property still holds its default struct instance here.
+        var holder = new StructCollectionHolder(context);
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("StructCollectionHolder") && e.Contains("attached"));
+        Assert.DoesNotContain(events, e => e.Contains("ImmutableCars"));
+        Assert.DoesNotContain(events, e => e.Contains("SegmentCars"));
+        Assert.True(holder.ImmutableCars.IsDefault);
+    }
+
+    [Fact]
+    public void WhenAssigningDefaultToStructCollection_ThenSubjectsAreDetached()
+    {
+        // Arrange
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new StructCollectionHolder(context);
+        var car = new Car { Name = "Car1" };
+        holder.ImmutableCars = ImmutableArray.Create(car);
+        handler.Clear();
+
+        // Act
+        holder.ImmutableCars = default;
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("ImmutableCars[0] -> Car1") && e.Contains("detached"));
+    }
+
+    [Fact]
+    public void WhenAssigningDefaultToStructCollectionWithoutCollectionInterface_ThenSubjectsAreDetached()
+    {
+        // Arrange: ArraySegment implements neither ICollection nor IDictionary, so it reaches the
+        // read-only IEnumerable dispatch arm rather than the ICollection one.
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new StructCollectionHolder(context);
+        var car = new Car { Name = "Car1" };
+        holder.SegmentCars = new ArraySegment<Car>([car]);
+        handler.Clear();
+
+        // Act
+        holder.SegmentCars = default;
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("SegmentCars[0] -> Car1") && e.Contains("detached"));
+    }
+
+    [Fact]
+    public void WhenInterfacePropertyIsAssignedABoxedDefaultStruct_ThenSubjectsAreDetached()
+    {
+        // Arrange: the declared type is an interface, so nothing about the property tells the
+        // readers that the boxed value could be a default struct.
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new StructCollectionHolder(context);
+        var car = new Car { Name = "Car1" };
+        holder.InterfaceCars = ImmutableArray.Create(car);
+        handler.Clear();
+
+        // Act
+        holder.InterfaceCars = default(ImmutableArray<Car>);
+
+        // Assert
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("InterfaceCars[0] -> Car1") && e.Contains("detached"));
+    }
+
+    [Fact]
+    public void WhenNullableStructuralPropertyIsAssignedTheDefaultOfItsUnderlyingType_ThenSubjectsAreDetached()
+    {
+        // Arrange: this is not the same as assigning null. The nullable has a value, and that
+        // value is the unusable default instance.
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithLifecycle()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        var holder = new NullableStructuralHolder(context);
+        var car = new Car { Name = "Car1" };
+        holder.ImmutableCars = ImmutableArray.Create(car);
+        handler.Clear();
+
+        // Act
+        holder.ImmutableCars = default(ImmutableArray<Car>);
+
+        // Assert
+        Assert.NotNull(holder.ImmutableCars);
+        var events = handler.GetEvents();
+        Assert.Contains(events, e => e.Contains("ImmutableCars[0] -> Car1") && e.Contains("detached"));
+    }
+
     public class AddPropertyToSubjectHandler : ILifecycleHandler
     {
         public void HandleLifecycleChange(SubjectLifecycleChange change)

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/StructCollectionHolder.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/StructCollectionHolder.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Immutable;
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+/// <summary>
+/// Model with structural properties typed as struct collections. Their default instance holds a
+/// null inner array, so such a property starts out in a state that throws when read, and
+/// <c>= default</c> is legal C# that puts it back there.
+/// </summary>
+[InterceptorSubject]
+public partial class StructCollectionHolder
+{
+    /// <summary>Boxes to an <see cref="ICollection"/>, the collection dispatch arm.</summary>
+    public partial ImmutableArray<Car> ImmutableCars { get; set; }
+
+    /// <summary>Boxes to a bare <see cref="IEnumerable"/>, the read-only collection dispatch arm.</summary>
+    public partial ArraySegment<Car> SegmentCars { get; set; }
+
+    /// <summary>Interface-declared, so the declared type cannot tell a default from a live value.</summary>
+    public partial IEnumerable<Car>? InterfaceCars { get; set; }
+}
+
+/// <summary>
+/// Read-only struct dictionary that does not defend against its own default instance, so every
+/// read of <c>default(RawCarMap)</c> throws.
+/// </summary>
+public readonly struct RawCarMap(Dictionary<string, Car> cars) : IReadOnlyDictionary<string, Car>
+{
+    private readonly Dictionary<string, Car> _cars = cars;
+
+    public Car this[string key] => _cars[key];
+
+    public IEnumerable<string> Keys => _cars.Keys;
+
+    public IEnumerable<Car> Values => _cars.Values;
+
+    public int Count => _cars.Count;
+
+    public bool ContainsKey(string key) => _cars.ContainsKey(key);
+
+    public bool TryGetValue(string key, out Car value) => _cars.TryGetValue(key, out value!);
+
+    public IEnumerator<KeyValuePair<string, Car>> GetEnumerator() => _cars.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <summary>Struct collection that declares a parameterless constructor, so <c>Activator.CreateInstance</c> would not produce its default.</summary>
+public struct ConstructedCarBag : IEnumerable<Car>
+{
+    public int Marker;
+
+    public ConstructedCarBag()
+    {
+        Marker = 42;
+    }
+
+    public readonly IEnumerator<Car> GetEnumerator() => throw new NotSupportedException();
+
+    readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/SubjectLookupTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/SubjectLookupTests.cs
@@ -262,4 +262,33 @@ public class SubjectLookupTests
         Assert.Equal("k2", key2);
         Assert.Same(person2, subject2);
     }
+
+    [Fact]
+    public void WhenCollectionValueIsDefaultStruct_ThenReturnsNull()
+    {
+        // Arrange: ImmutableArray takes the IList fast path, ArraySegment the enumerable fallback.
+        object immutableArray = default(ImmutableArray<Person>);
+        object arraySegment = default(ArraySegment<Person>);
+
+        // Act
+        var fromImmutableArray = SubjectLookup.FindSubjectInCollection(immutableArray, 0);
+        var fromArraySegment = SubjectLookup.FindSubjectInCollection(arraySegment, 0);
+
+        // Assert
+        Assert.Null(fromImmutableArray);
+        Assert.Null(fromArraySegment);
+    }
+
+    [Fact]
+    public void WhenDictionaryValueIsDefaultStruct_ThenReturnsNull()
+    {
+        // Arrange
+        object map = default(RawCarMap);
+
+        // Act
+        var result = SubjectLookup.FindSubjectInDictionary(map, "first");
+
+        // Assert
+        Assert.Null(result);
+    }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/SubjectPropertyTypeExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/SubjectPropertyTypeExtensionsTests.cs
@@ -196,6 +196,72 @@ public class SubjectPropertyTypeExtensionsTests
     {
     }
 
+    [Fact]
+    public void WhenValueIsDefaultStructCollection_ThenItReadsAsEmpty()
+    {
+        // Arrange
+        object immutableArray = default(ImmutableArray<Person>);
+        object arraySegment = default(ArraySegment<Person>);
+        object nonSubjectImmutableArray = default(ImmutableArray<int>);
+        object structDictionary = default(RawCarMap);
+
+        // Act & Assert
+        Assert.True(SubjectPropertyTypeExtensions.ReadsAsEmpty(immutableArray));
+        Assert.True(SubjectPropertyTypeExtensions.ReadsAsEmpty(arraySegment));
+        Assert.True(SubjectPropertyTypeExtensions.ReadsAsEmpty(nonSubjectImmutableArray));
+        Assert.True(SubjectPropertyTypeExtensions.ReadsAsEmpty(structDictionary));
+    }
+
+    [Fact]
+    public void WhenValueIsAnInitializedCollection_ThenItDoesNotReadAsEmpty()
+    {
+        // Arrange: an initialized but empty collection is a usable value and must stay distinguishable
+        // from a default one, otherwise readers could not tell "empty" from "never set".
+        object emptyImmutableArray = ImmutableArray<Person>.Empty;
+        object filledImmutableArray = ImmutableArray.Create(new Person());
+        object emptyArraySegment = new ArraySegment<Person>([]);
+        object emptyList = new List<Person>();
+        object emptyArray = Array.Empty<Person>();
+
+        // Act & Assert
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(emptyImmutableArray));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(filledImmutableArray));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(emptyArraySegment));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(emptyList));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(emptyArray));
+    }
+
+    [Fact]
+    public void WhenValueIsNullOrScalarOrString_ThenItDoesNotReadAsEmpty()
+    {
+        // Arrange: a default scalar is not a collection, and an empty string is not "no value".
+        object defaultInt = 0;
+        object defaultDateTime = default(DateTime);
+        object defaultKeyValuePair = default(KeyValuePair<string, Person>);
+
+        // Act & Assert
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(null));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(defaultInt));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(defaultDateTime));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(defaultKeyValuePair));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(string.Empty));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty("text"));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(new Person()));
+    }
+
+    [Fact]
+    public void WhenStructCollectionDeclaresAParameterlessConstructor_ThenOnlyItsDefaultReadsAsEmpty()
+    {
+        // Arrange: running the declared constructor would produce a non-default instance, so the
+        // default value has to be obtained without invoking it.
+        object defaultBag = default(ConstructedCarBag);
+        object constructedBag = new ConstructedCarBag();
+
+        // Act & Assert
+        Assert.True(SubjectPropertyTypeExtensions.ReadsAsEmpty(defaultBag));
+        Assert.False(SubjectPropertyTypeExtensions.ReadsAsEmpty(constructedBag));
+    }
+
     private readonly struct StructSubjectCollection : IEnumerable<Person>
     {
         public IEnumerator<Person> GetEnumerator() => throw new NotSupportedException();

--- a/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -145,6 +145,7 @@ namespace Namotion.Interceptor.Tracking
         public static bool IsSubjectCollectionType(this System.Type type) { }
         public static bool IsSubjectDictionaryType(this System.Type type) { }
         public static bool IsSubjectReferenceType(this System.Type type) { }
+        public static bool ReadsAsEmpty(object? value) { }
     }
 }
 namespace Namotion.Interceptor.Tracking.Lifecycle

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
@@ -441,6 +441,13 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
         List<(IInterceptorSubject subject, PropertyReference property, object? index)> collectedSubjects,
         HashSet<IInterceptorSubject>? touchedSubjects)
     {
+        // A default struct collection carries no children and throws when enumerated, so it
+        // releases the previously attached ones exactly as an empty collection does.
+        if (SubjectPropertyTypeExtensions.ReadsAsEmpty(value))
+        {
+            return;
+        }
+
         // Hot paths (IDictionary, ICollection) come before string/IEnumerable so common
         // writes don't pay extra type checks. The IEnumerable case at the end handles read-only
         // types that implement neither ICollection nor IDictionary (e.g. custom IReadOnlyList /

--- a/src/Namotion.Interceptor.Tracking/SubjectLookup.cs
+++ b/src/Namotion.Interceptor.Tracking/SubjectLookup.cs
@@ -12,6 +12,8 @@ namespace Namotion.Interceptor.Tracking;
 /// read-only-dictionary KVP extraction. Hot paths in <c>LifecycleInterceptor</c> and
 /// <c>RegisteredSubjectProperty</c> inline the dispatch switch directly for best codegen
 /// rather than going through this class.
+/// A default struct collection reads as empty here: it holds no entries, so no index or key
+/// resolves to a subject, and touching it would throw.
 /// </summary>
 public static class SubjectLookup
 {
@@ -31,6 +33,9 @@ public static class SubjectLookup
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IInterceptorSubject? FindSubjectInCollection(object value, int index)
     {
+        if (SubjectPropertyTypeExtensions.ReadsAsEmpty(value))
+            return null;
+
         if (value is IList list)
             return list[index] as IInterceptorSubject;
 
@@ -66,6 +71,9 @@ public static class SubjectLookup
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IInterceptorSubject? FindSubjectInDictionary(object value, object key)
     {
+        if (SubjectPropertyTypeExtensions.ReadsAsEmpty(value))
+            return null;
+
         if (value is IDictionary dictionary)
             return dictionary[key] as IInterceptorSubject;
 

--- a/src/Namotion.Interceptor.Tracking/SubjectPropertyTypeExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/SubjectPropertyTypeExtensions.cs
@@ -23,6 +23,11 @@ public static class SubjectPropertyTypeExtensions
     private static readonly ConcurrentDictionary<Type, bool> IsSubjectCollectionTypeCache = new();
     private static readonly ConcurrentDictionary<Type, bool> IsSubjectDictionaryTypeCache = new();
 
+    // Boxed default instance per struct type, used by ReadsAsEmpty. Keyed by the runtime type of a
+    // value, so it never shares keys with the classification caches above (those are keyed by
+    // declared property types, which are frequently interfaces).
+    private static readonly ConcurrentDictionary<Type, object> DefaultStructValueCache = new();
+
     /// <summary>
     /// Checks whether a property can contain subjects, using both a JIT-constant fast path
     /// via <typeparamref name="TProperty"/> and a runtime fallback via the declared
@@ -95,6 +100,37 @@ public static class SubjectPropertyTypeExtensions
         return IsSubjectDictionaryTypeCache.TryGetValue(type, out var result)
             ? result
             : IsSubjectDictionaryTypeSlow(type);
+    }
+
+    /// <summary>
+    /// Returns true if the value is the default instance of a struct collection, such as
+    /// <c>default(ImmutableArray&lt;T&gt;)</c> or <c>default(ArraySegment&lt;T&gt;)</c>. Those hold a null
+    /// inner array and throw when read, so readers must treat them as an empty collection rather
+    /// than touching them. Returns false for null, for scalars, for an initialized but empty
+    /// collection, and for every reference type including strings.
+    /// </summary>
+    /// <remarks>
+    /// This is a value-level test rather than a property-type one: interface-declared properties
+    /// hold boxed default structs, so the declared type cannot tell a default apart from a live
+    /// value. Testing <see cref="IEnumerable"/> first keeps a subject reference or a scalar to a
+    /// single type test and only lets boxed containers reach the cache.
+    /// </remarks>
+    public static bool ReadsAsEmpty(object? value)
+    {
+        if (value is not IEnumerable || value is string)
+        {
+            return false;
+        }
+
+        var type = value.GetType();
+        return type.IsValueType && value.Equals(GetDefaultStructValue(type));
+    }
+
+    // GetUninitializedObject rather than Activator.CreateInstance: a struct may declare a
+    // parameterless constructor, and running it would produce something other than the default.
+    private static object GetDefaultStructValue(Type type)
+    {
+        return DefaultStructValueCache.GetOrAdd(type, static t => RuntimeHelpers.GetUninitializedObject(t));
     }
 
     private static bool CanContainSubjectsSlow(Type type)


### PR DESCRIPTION
`ImmutableArray<T>` and `ArraySegment<T>` are structs whose `default` holds a null inner array, which the BCL treats as distinct from empty on purpose: enumerating or measuring one throws. A property of either type therefore starts life unusable, because a C# field defaults to `default`, and `subject.Cars = default;` is legal and puts it straight back there.

A default instance of those two types now reads as empty everywhere the framework enumerates a property value. It releases children exactly as an empty collection does, and does not throw.

Stacked on #507. That PR makes `Nullable<T>` structural properties classify by their underlying type, which widens this defect's exposure: on `master` a nullable immutable array is not structural, so a default assignment is a silent no-op, and after #507 it becomes structural and the same assignment throws. **The two should merge together.**

## Why

The day-one case needs no unusual code at all:

```csharp
[InterceptorSubject]
public partial class Garage
{
    public partial ImmutableArray<Car> Cars { get; set; }   // never assigned
}

new Garage(context);   // throws inside the lifecycle attach lock
```

And the exposure is wider than the type choice suggests, because an interface-declared property accepts a boxed default struct:

```csharp
public partial IReadOnlyList<Car> Cars { get; set; }   // ordinary declaration
garage.Cars = default(ImmutableArray<Car>);            // legal, throws today
```

Seven readers were found by instrumenting every code path that enumerates a property value and driving them from an uninitialised property. Five throw, one passes a boxed default through to a caller that then throws on `.Count`, and one takes down a HomeBlaze display panel. Notably `ValueToJsonNode` enumerates any `IEnumerable`, so a default `ImmutableArray<int>` reaches it even though it is not structural at all.

Every immutable *class* collection is unaffected, since their default is null and the existing null paths handle it.

## How the test works

`SubjectLookup.IsDefaultStructCollection(object?)` covers exactly `ImmutableArray<T>` and `ArraySegment<T>`, asking each through its own API (`IsDefault`, and a null `Array`) via a delegate closed over the element type once per runtime type. Everything else returns false, which is precisely how readers behaved before the guard existed and is therefore safe.

It deliberately does **not** ask a value whether it equals its own default, because that dispatches into the struct's `Equals`, which is consumer code. A struct collection with ordinary value semantics compares its contents, so on a default instance it dereferences the null inner array and throws: an equality-based guard reproduces the failure it exists to prevent. That matters beyond correctness, because the lifecycle reader calls this while holding its attach lock.

The narrow scope is the point. A consumer struct collection with the same property is not covered and should defend in its own accessors, which costs a `?? []` on the backing field. Inline arrays, fixed buffers, pointers, ref structs and negative zero are not cases to get right, they are simply out of scope.

## Contract

- A default `ImmutableArray<T>` or `ArraySegment<T>` reads as empty: it establishes no ownership edges, and assigning one releases whatever the property held.
- An initialised empty collection remains distinguishable from a never-set one, which is the distinction a nullable struct collection property exists to express.

## What this does not cover

**Dictionaries are out of scope in both directions.** Neither type in scope can be classified as a dictionary, so a default struct dictionary is not handled here and nothing about dictionary properties changes. A concrete declared dictionary type is untouched by this PR: it was already produce-only on the apply path and still is, for reasons unrelated to default instances (#508).

The seven sites are the complete set of readers that walk a property value looking for **subjects**. They are not the complete set of readers of a struct collection: a scalar-typed one, for example `ImmutableArray<string>`, still reaches connector serializers as a raw value through `SubjectUpdateFactory`'s value path and the per-connector converters. That is pre-existing and out of scope here.

## Also fixed

Two defects of the same shape, found while reviewing the guard sites:

- The JSON writer threw on a default struct collection both when enumerating it and when serializing it as a plain value. It now emits what an initialised empty one emits.
- The JSON path resolver threw `ArgumentOutOfRangeException` for an index past the end of a collection.

## Breaking changes

None. `SubjectLookup.IsDefaultStructCollection(object?)` is added, so the public API snapshot moves by one line. No signature changes, and no shape that previously worked behaves differently: every affected shape previously threw.

## Performance

The guard sits behind the existing `CanContainSubjects` gate that scalar writes already return at, so scalar writes pay nothing. In the lifecycle reader it sits in a `ValueType` arm placed after the null and subject arms, so a subject reference, the dominant structural write, keeps its exact previous cost. Reference-typed collections pay one `isinst`; only boxed structs reach the predicate. The connector and lookup entry points keep their inlined reference-type fast paths and route boxed structs to their existing slow paths.

Not benchmarked. The affected classes are the lifecycle and registry ones if that is wanted before merge.

## Verification

- [x] Documentation updated
- [x] Unit tests
- [ ] ~~Integration tests~~ no connector behaviour changed; the connector guards convert a throw into an empty read
- [ ] ~~Benchmarks~~ see above
- [ ] ~~Load tests~~ no connector implementation changed
- [ ] ~~Chaos tests~~ no connector implementation changed

Twenty tests across Tracking, Connectors, Registry and HomeBlaze; full suite 3330 passing across 26 assemblies. Every guard site was demonstrated rather than assumed: with the value test forced to return false, fifteen tests fail and every one of the seven sites is among them. The two JSON fixes were each reverted individually and confirmed to fail their own test.

Net production change is +137 / -8 lines, 73 of the additions being code rather than comments.
