### PR TITLE
fix: emit dictionary Remove operations before Insert operations

### DIFF
--- a/docs/connectors-subject-updates.md
+++ b/docs/connectors-subject-updates.md
@@ -204,6 +204,7 @@ Apply structural changes in two sub-phases:
 **Sub-phase 1a: Remove and Insert operations** are applied sequentially in the order they appear:
 - `Remove` operations are sent in **descending index order** so each remove doesn't affect subsequent removes
 - `Insert` operations reference the final target position
+- All `Remove` operations precede all `Insert` operations, for dictionaries and for collections alike, so replacing the value at an existing key removes the old entry before the replacement is inserted
 
 **Sub-phase 1b: Move operations** are applied atomically using snapshot semantics:
 - All moves reference the state **after** removes/inserts have been applied

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.WhenAddAndRemoveCombined_ThenBothOperationsAreCreated.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.WhenAddAndRemoveCombined_ThenBothOperationsAreCreated.verified.txt
@@ -7,12 +7,12 @@
         Timestamp: DateTimeOffset_1,
         Operations: [
           {
+            Index: key1
+          },
+          {
             Action: Insert,
             Index: key3,
             Id: 2
-          },
-          {
-            Index: key1
           }
         ],
         Count: 2

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.WhenValueReplacedAtSameKey_ThenInsertAndRemoveOperationsAreCreated.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.WhenValueReplacedAtSameKey_ThenInsertAndRemoveOperationsAreCreated.verified.txt
@@ -7,12 +7,12 @@
         Timestamp: DateTimeOffset_1,
         Operations: [
           {
+            Index: key1
+          },
+          {
             Action: Insert,
             Index: key1,
             Id: 2
-          },
-          {
-            Index: key1
           }
         ],
         Count: 1

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateDictionaryTests.cs
@@ -272,6 +272,46 @@ public class SubjectUpdateDictionaryTests
     }
 
     [Fact]
+    public void WhenValueReplacedAtSameKey_ThenRemoveIsEmittedBeforeInsertForThatKey()
+    {
+        // Arrange
+        // The apply side walks operations sequentially, so the Remove for the replaced key
+        // has to precede the Insert that carries the replacement.
+        var context = InterceptorSubjectContext.Create().WithPropertyChangeSubscriptions().WithRegistry();
+        var item1 = new CycleTestNode { Name = "Item1" };
+        var node = new CycleTestNode(context)
+        {
+            Name = "Root",
+            Lookup = new Dictionary<string, CycleTestNode> { ["key1"] = item1 }
+        };
+
+        var changes = new List<SubjectPropertyChange>();
+        context.GetPropertyChangeObservable(ImmediateScheduler.Instance).Subscribe(c => changes.Add(c));
+
+        // Act
+        var item2 = new CycleTestNode { Name = "ReplacementItem" };
+        node.Lookup = new Dictionary<string, CycleTestNode> { ["key1"] = item2 };
+
+        var update = SubjectUpdate.CreatePartialUpdateFromChanges(node, changes.ToArray(), []);
+
+        // Assert
+        var operations = update.Subjects[update.Root]["Lookup"].Operations;
+        Assert.NotNull(operations);
+        Assert.Collection(operations,
+            operation =>
+            {
+                Assert.Equal(SubjectCollectionOperationType.Remove, operation.Action);
+                Assert.Equal("key1", operation.Index);
+            },
+            operation =>
+            {
+                Assert.Equal(SubjectCollectionOperationType.Insert, operation.Action);
+                Assert.Equal("key1", operation.Index);
+                Assert.NotNull(operation.Id);
+            });
+    }
+
+    [Fact]
     public async Task WhenDictionarySetToNull_ThenCompleteUpdateHasValueKindWithNull()
     {
         // Arrange

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateExtensionsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateExtensionsTests.cs
@@ -379,6 +379,47 @@ public partial class SubjectUpdateExtensionsTests
     }
 
     [Fact]
+    public void WhenApplyingDictionaryValueReplacedAtSameKey_ThenEntryIsReplacedNotDeleted()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithRegistry();
+        var originalItem = new CycleTestNode(context) { Name = "Item1" };
+        var source = new CycleTestNode(context)
+        {
+            Name = "Root",
+            Lookup = new Dictionary<string, CycleTestNode> { ["key1"] = originalItem }
+        };
+        var target = new CycleTestNode(context)
+        {
+            Name = "Root",
+            Lookup = new Dictionary<string, CycleTestNode>
+            {
+                ["key1"] = new(context) { Name = "Item1" }
+            }
+        };
+
+        // Make a change - replace the value at an existing key with a different subject
+        var changes = new List<SubjectPropertyChange>();
+        using (context.GetPropertyChangeObservable(System.Reactive.Concurrency.ImmediateScheduler.Instance)
+            .Subscribe(c => changes.Add(c)))
+        {
+            source.Lookup = new Dictionary<string, CycleTestNode>
+            {
+                ["key1"] = new(context) { Name = "Replacement" }
+            };
+        }
+
+        // Act
+        var update = SubjectUpdate.CreatePartialUpdateFromChanges(source, changes.ToArray(), []);
+        target.ApplySubjectUpdate(update, DefaultSubjectFactory.Instance, ChangeOrigin.Local);
+
+        // Assert
+        Assert.True(target.Lookup.ContainsKey("key1"), "The replaced entry must survive the round trip.");
+        Assert.Equal("Replacement", target.Lookup["key1"].Name);
+        Assert.Single(target.Lookup);
+    }
+
+    [Fact]
     public async Task WhenApplyingCircularReference_ThenItWorks()
     {
         // Arrange

--- a/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectItemsUpdateFactory.cs
+++ b/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectItemsUpdateFactory.cs
@@ -192,6 +192,22 @@ internal static class SubjectItemsUpdateFactory
             // every subject-valued entry in newDictionary is either a new insert or a retained common item.
             update.Count = (newItemsToProcess?.Count ?? 0) + changeBuilder.GetRetainedDictionaryItems().Count;
 
+            // Add Remove operations before the Insert operations: a value replaced at an existing key
+            // appears in both lists, and the apply side walks the operations sequentially, so an Insert
+            // emitted first would be undone by the Remove that follows it.
+            if (removedKeys is not null)
+            {
+                foreach (var removedKey in removedKeys)
+                {
+                    operations ??= [];
+                    operations.Add(new SubjectCollectionOperation
+                    {
+                        Action = SubjectCollectionOperationType.Remove,
+                        Index = removedKey
+                    });
+                }
+            }
+
             // Add Insert operations for new items
             if (newItemsToProcess is not null)
             {
@@ -206,20 +222,6 @@ internal static class SubjectItemsUpdateFactory
                         Action = SubjectCollectionOperationType.Insert,
                         Index = key,
                         Id = itemId
-                    });
-                }
-            }
-
-            // Add Remove operations
-            if (removedKeys is not null)
-            {
-                foreach (var removedKey in removedKeys)
-                {
-                    operations ??= [];
-                    operations.Add(new SubjectCollectionOperation
-                    {
-                        Action = SubjectCollectionOperationType.Remove,
-                        Index = removedKey
                     });
                 }
             }

--- a/src/Namotion.Interceptor.WebSocket.Tests/Serialization/SubjectUpdateFlowTests.cs
+++ b/src/Namotion.Interceptor.WebSocket.Tests/Serialization/SubjectUpdateFlowTests.cs
@@ -258,6 +258,52 @@ public class SubjectUpdateFlowTests
     }
 
     [Fact]
+    public void PartialUpdate_DictionaryValueReplacedAtSameKey_ShouldRoundTripThroughJson()
+    {
+        // Arrange
+        var serverContext = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithRegistry();
+        var originalItem = new TestItem(serverContext) { Label = "Original", Value = 1 };
+        var serverRoot = new TestRoot(serverContext)
+        {
+            Name = "Root",
+            Lookup = new Dictionary<string, TestItem> { ["key1"] = originalItem }
+        };
+
+        var clientContext = InterceptorSubjectContext.Create().WithFullPropertyTracking().WithRegistry();
+        var clientRoot = new TestRoot(clientContext)
+        {
+            Name = "Root",
+            Lookup = new Dictionary<string, TestItem> { ["key1"] = new TestItem(clientContext) { Label = "Original", Value = 1 } }
+        };
+
+        // Make change - replace the value at key1 with a different subject
+        var changes = new List<SubjectPropertyChange>();
+        using (serverContext.GetPropertyChangeObservable(System.Reactive.Concurrency.ImmediateScheduler.Instance)
+            .Subscribe(c => changes.Add(c)))
+        {
+            serverRoot.Lookup = new Dictionary<string, TestItem>
+            {
+                ["key1"] = new TestItem(serverContext) { Label = "Replacement", Value = 2 }
+            };
+        }
+
+        // Act
+        var update = SubjectUpdate.CreatePartialUpdateFromChanges(serverRoot, changes.ToArray(), []);
+        var serializer = new JsonWebSocketSerializer();
+        var bytes = serializer.SerializeMessage(MessageType.Update, update);
+        var (_, payloadStart, payloadLength) = serializer.DeserializeMessageEnvelope(bytes);
+        var deserialized = serializer.Deserialize<SubjectUpdate>(bytes.AsSpan(payloadStart, payloadLength));
+
+        clientRoot.ApplySubjectUpdate(deserialized, DefaultSubjectFactory.Instance, ChangeOrigin.Local);
+
+        // Assert
+        Assert.True(clientRoot.Lookup.ContainsKey("key1"));
+        Assert.Equal("Replacement", clientRoot.Lookup["key1"].Label);
+        Assert.Equal(2, clientRoot.Lookup["key1"].Value);
+        Assert.Single(clientRoot.Lookup);
+    }
+
+    [Fact]
     public void PartialUpdate_CollectionMove_ShouldRoundTripThroughJson()
     {
         // Arrange


### PR DESCRIPTION
Replacing the value at an existing dictionary key was lost over the wire instead of being replaced. The diff emitted `Insert@key` followed by `Remove@key`, and because the apply side walks operations sequentially, the remove undid the insert and the entry vanished on the consumer.

The loss is not limited to a single entry. Every replaced key is affected, so a wholesale refresh of a dictionary keyed by stable identifiers, which is the ordinary connector pattern, wipes the entire dictionary on the consumer. Swapping the values held at two keys loses both.

Emitting the removes first makes the sequence `Remove@key`, `Insert@key`, which yields the replacement.

## Why

A key whose value is replaced legitimately appears in both collections the diff builds: `CollectionDiffBuilder` adds it to the new items on a `ReferenceEquals` failure and deliberately leaves it in the removed set. The emitter then wrote the inserts before the removes, so the two operations arrived in the order that cancels them.

The applier is faithful to the contract already documented for the format, that operations are applied sequentially in the order they appear, so this is an emitter defect rather than an applier one. A checked-in snapshot had recorded the broken order as expected output, which is why no test caught it.

Reach is the WebSocket connector only, in both directions since the link is bidirectional. `Operations` is produced solely by the diff path; complete updates cannot emit it, and the OPC UA, MQTT and GraphQL connectors do not reference the format at all.

## Contract

- For dictionaries and collections alike, all `Remove` operations precede all `Insert` operations in a partial update, so replacing the value at an existing key removes the old entry before the replacement is inserted.
- Operations remain applied sequentially in the order they appear. That rule is unchanged and is what makes the new ordering sufficient.

## Breaking changes

**API.** None.

**Behavior.** A partial update now carries its dictionary removes before its inserts. The wire format, the operation set and the protocol version are unchanged, so a peer running an older build applies the new ordering correctly and no coordinated upgrade is required.

**Contract.** None.

An emitter-only fix heals a mixed-version link in the direction where the upgraded endpoint produces. An endpoint still running an older build keeps emitting the lossy pair, which is a reason to upgrade both ends rather than to add tolerance to the applier: doing that would permanently weaken the sequential-order rule to serve a transitional case, and there is no version gate to scope it to.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 1 | 16 | 14 | +2 |
| Tests and benchmarks | 5 | 133 | 6 | +127 |
| Documentation | 1 | 1 | 0 | +1 |
| **Total** | **7** | **150** | **20** | **+130** |

The production change moves two emission blocks verbatim; the net two lines are both comment.

## Verification

- [x] Documentation updated
- [x] Unit tests
- [x] Integration tests
- [ ] ~~Benchmarks~~ two loops appending to the same list are swapped, with identical work and allocation count
- [ ] ~~Load tests~~ see below
- [ ] ~~Chaos tests~~ see below

The shared Connectors library did change and the serialized bytes do change, so "no connector implementation changed" would be the wrong justification for skipping the Connector Tester. The sound one is that this is a deterministic reordering of serialized operations with no concurrency, timing or reconnect dimension, and the emit-and-apply matrix plus the end-to-end round trip cover exactly the changed behavior. Chaos and load exercise reconnects, and reconnect recovery goes through complete updates, which never carry `Operations`.

Connectors 787/787, WebSocket 160/160 including integration, ConnectorTester 117/117, Mqtt 70/70.

Reproduced at two levels before fixing: at the object level, and end to end through `JsonWebSocketSerializer` with a full rebuild on both sides. An eleven-scenario emit-and-apply matrix passes 11/11 on this branch and fails 5 on `master`, every failure a same-key replacement. Reverting the production change leaves exactly 4 failures in Connectors and 1 in WebSocket, matching the fix surface with nothing over or under.

Follow-up, pre-existing and untouched here: with a case-insensitive source dictionary, a retained entry whose key is re-cased emits a spurious lone `Remove` that deletes it on the peer. `keysToRemove` is a default-comparer set while the source lookup honors the dictionary's own comparer. Both emission orders produce that same lone remove, so this change neither causes nor worsens it.

Two `Verify` snapshots were accepted. A scan of every snapshot in the repository found exactly three containing both a remove and an insert; the third is a collection case that was already remove-first, so the accepted set is complete.

