### PR TITLE
test: drain the stale publish before releasing the commit gate

### DIFF
--- a/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerLivenessTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Server/MqttServerLivenessTests.cs
@@ -509,12 +509,17 @@ public partial class MqttServerLivenessTests
         finally
         {
             mapper.Release();
-            commitGate.Release();
 
+            // Drain the publish before releasing the commit gate. The gate is what holds the shutdown
+            // open, so releasing it first lets the broker send DISCONNECT and the QoS 1 publish the
+            // body left in flight never gets its PUBACK. The transport error that then surfaces here
+            // would replace the failure the body is already reporting.
             if (stalePublishTask is not null)
             {
                 await stalePublishTask.WaitAsync(TimeSpan.FromSeconds(10));
             }
+
+            commitGate.Release();
 
             if (admittedCallback is not null)
             {


### PR DESCRIPTION
Three retiring-broker liveness tests shared a teardown that released the commit gate and only then awaited the publish the body had left in flight. The gate is what holds the shutdown open, so releasing it first let the broker send DISCONNECT, and the QoS 1 publish never got its PUBACK. The transport error that surfaced from the teardown then replaced whatever failure the body was already reporting, so a test failing for a real reason reported an MQTT exception instead.

Draining before the release keeps the broker alive until the publish has completed. On the passing path it changes nothing, because the body has already awaited that task.

## Why

A teardown that throws while a test exception is in flight destroys the diagnostic, which costs far more than a flake: the failure that reaches the log is not the one that matters, and the real assertion never appears.

Reordering is preferred over catching the transport error. It removes the fault rather than hiding it, and it swallows nothing, so a genuine teardown defect still fails the test. This file already swallows an expected teardown failure in `DisconnectForTeardownAsync`, and one more catch would have made that idiom load-bearing where it does not need to be.

Scope was checked rather than assumed. Failures were injected at two in-flight points in each of the nine `try`/`finally` blocks in the file, half of the runs pinned to two cores, and only this site ever masked. The other eight either tear down through `server.StopAsync` alone or await gated callbacks that resume cleanly against a live or a retired broker, so they are left untouched.

Note for anyone tracing the original report: the mechanism it described was already fixed by #503, which added `DisconnectForTeardownAsync`. This is a different site, one line beyond that helper's reach.

## Breaking changes

None. Test-only.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Tests and benchmarks | 1 | 6 | 1 | +5 |
| **Total** | **1** | **6** | **1** | **+5** |

The code change is one moved statement; four of the added lines are comment.

## Verification

- [ ] ~~Documentation updated~~ test-only, no documented behavior changes
- [x] Unit tests
- [ ] ~~Integration tests~~ no connector implementation or HomeBlaze UI changed
- [ ] ~~Benchmarks~~ test-only
- [ ] ~~Load tests~~ test-only
- [ ] ~~Chaos tests~~ test-only

Mqtt 103/103, unchanged from `master`, verified normally and pinned to two cores.

Both halves were demonstrated rather than argued. With a failing assertion injected into the body, all three affected tests report the injected failure instead of an MQTT exception, across three runs. With a throwing teardown injected into a passing test, the test still fails with that exception, so a real teardown defect stays visible.

One residual, unchanged by this PR: `await using var server` is declared outside the `try`, so `DisposeAsync` runs after the `finally` and could in principle replace an in-flight test exception. Never observed across roughly twenty-five runs, and not made worse here.
