### PR TITLE
test: keep the restart reset race participant off the thread pool

### DIFF
--- a/src/Namotion.Interceptor.Connectors.Tests/Diagnostics/ConnectorMetricsTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Diagnostics/ConnectorMetricsTests.cs
@@ -1,4 +1,5 @@
 using Namotion.Interceptor.Connectors.Diagnostics;
+using Namotion.Interceptor.Testing;
 
 namespace Namotion.Interceptor.Connectors.Tests.Diagnostics;
 
@@ -271,11 +272,15 @@ public class ConnectorMetricsTests
         ClockTestHelpers.WaitForClockTick();
 
         // Act
-        var restart = Task.Run(metrics.MarkStarted);
-        await resettable.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        // Off the thread pool: the restart parks inside the resettable for as long as this test holds
+        // it, and a pool work item can wait seconds to be scheduled at all while the rest of the
+        // assembly runs, which times out the wait below for a reason the test does not cover.
+        var restart = DedicatedThreadTestHelpers.RunOnDedicatedThreadAsync(metrics.MarkStarted, "restart reset");
 
         try
         {
+            await resettable.Entered.WaitAsync(TimeSpan.FromSeconds(30));
+
             // Assert
             Assert.Equal(firstStart, diagnostics.StartTime);
         }


### PR DESCRIPTION
`ConnectorMetricsTests.WhenRestartResetIsStillRunning_ThenTheNewEpochIsNotYetVisible` timed out under load for a reason it does not cover. The restart was queued with `Task.Run`, but its body parks immediately inside the resettable the test holds shut, so under thread pool starvation the work item was not dispatched at all inside the five second budget. The test then failed at the wait rather than at anything to do with epoch visibility.

Running the restart on a dedicated thread removes the dependency on pool dispatch. This is the remedy #503 applied at twenty-two sites; this one, in the `Diagnostics` subfolder, was missed.

## Why

Measured rather than inferred: with the pool saturated by blocking work items and the process pinned to two cores, a `Task.Run` work item took 5803 ms to be dispatched at all, while a dedicated thread reached the same gate in 1 ms. That lands precisely on the observed five to six second failures, and explains why the five second budget was the thing that broke.

The old shape also occupied a pool worker for the rest of the test, deepening the starvation it depended on. The new shape occupies none.

A second defect is fixed in passing. The bounded wait sat outside the `try`, so a timeout skipped `AllowReset()` and left the parked thread blocked forever, after which `using var resettable` disposed the `ManualResetEventSlim` underneath it. Disposing that event under a parked thread neither wakes it nor throws, so the worker leaked for the remainder of the assembly run. Moving the wait inside the `try` cures both halves.

The wait budget moves from five seconds to thirty. The repository carries both numbers: the #503 dedicated-thread sites wait ten seconds, but those waits are synchronous and need no pool dispatch to resume, whereas this one awaits, so its resumption is itself a pool work item. Thirty seconds matches `AsyncTestHelpers.DefaultTimeout` and hides nothing: with the epoch defect injected the test fails in twelve milliseconds.

## Breaking changes

None. Test-only. `ConnectorMetrics.MarkStarted` publishing its start stamp after the resettable loop is correct and is exactly what the test pins.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Tests and benchmarks | 1 | 7 | 2 | +5 |
| **Total** | **1** | **7** | **2** | **+5** |

## Verification

- [ ] ~~Documentation updated~~ test-only, no documented behavior changes
- [x] Unit tests
- [ ] ~~Integration tests~~ no connector implementation or HomeBlaze UI changed
- [ ] ~~Benchmarks~~ test-only
- [ ] ~~Load tests~~ test-only
- [ ] ~~Chaos tests~~ test-only

Connectors 785/785 before and after.

The flake does not reproduce under a plain two-core run of the suite on a sixteen core machine, which is worth stating plainly: it took six concurrent test hosts with `xUnit.MaxParallelThreads=24` to provoke it, at two failures in eighteen runs, with the signature the report described. The fixed test passed eighteen of eighteen under the same harness. The dispatch measurement above is the load-bearing evidence, not the run counts, since at that failure rate six runs cannot distinguish a fix from luck.

Still convicts: moving the start stamp above the resettable loop, so the new epoch becomes visible while the reset is running, fails the test on a genuine value mismatch.

Observed and left alone: under the same artificial oversubscription, several other tests in this assembly fail on the same starvation class. None reproduce under normal runs, and each is a separate change.
