### PR TITLE
docs: state the Native AOT position for new code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,16 @@ The library has specialized support for:
 - **GraphQL**: Real-time subscription support
 - **Blazor**: UI data binding components
 
+## Native AOT
+
+Native AOT is not supported yet and nothing declares it, but it is the direction, so do not add new obstacles to it. Full compatibility is tracked in issue #516.
+
+- **New code avoids dynamic-code constructs** where a static alternative exists at comparable cost. `Expression.Compile()`, `MakeGenericMethod` and `MakeGenericType` over value types, and `Activator.CreateInstance` on a type the trimmer cannot see are all annotated `RequiresDynamicCode` or `RequiresUnreferencedCode`: under Native AOT they throw or fall back to interpretation.
+- **Existing sites are worth closing when a change already touches them**, and worth leaving alone otherwise. Several exist today, listed in #516.
+- **The generator is the escape hatch.** The declared shape of an `[InterceptorSubject]` type is known at compile time, so what would otherwise be resolved reflectively can often be emitted instead.
+
+This is guidance rather than a rule, because the AOT analyzer is not enabled yet, so nothing mechanically enforces it. Weigh it like any other constraint: a static alternative that costs a measurable amount on a hot path, or a large amount of complexity, is not automatically the right trade. Say in the pull request which way you went and why.
+
 ## Performance Considerations
 
 - All interception logic generated at compile-time (no runtime reflection)


### PR DESCRIPTION
States the Native AOT position for new code in `AGENTS.md`, so it does not have to be argued in each pull request that brushes against it.

Nothing changes mechanically: no project declares `PublishAot`, `IsAotCompatible` or `IsTrimmable`, and no analyzer is enabled. This records a direction and a default, not a gate.

Related to #516, which tracks getting to full compatibility and lists the sites that stand in the way.

## Why

Reviewing #514 turned on whether putting `Expression.Compile()` on the common path of a keyed dictionary lookup was acceptable. It was avoidable there at little cost, and avoiding it shaped the final design: ordinary dictionaries keep a path that needs no runtime code generation, and only a type observed to misbehave reaches the compiled delegate.

That was the right outcome, but it was reached by argument rather than by policy. The next change to touch this ground would have to have the same conversation from scratch.

## Contract

- New code avoids `Expression.Compile()`, `MakeGenericMethod` and `MakeGenericType` over value types, and `Activator.CreateInstance` on types the trimmer cannot see, where a static alternative exists at comparable cost.
- Existing sites are worth closing when a change already touches them, and worth leaving alone otherwise.
- The source generator is the preferred escape hatch, since the declared shape of an `[InterceptorSubject]` type is known at compile time.
- This is guidance, not a rule. A static alternative that costs a measurable amount on a hot path, or a large amount of complexity, is not automatically the right trade; the pull request should say which way it went and why.

## Breaking changes

None. Documentation only.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Documentation | 1 | 10 | 0 | +10 |
| **Total** | **1** | **10** | **0** | **+10** |

## Verification

- [x] Documentation updated
- [ ] ~~Unit tests~~ documentation only
- [ ] ~~Integration tests~~ documentation only
- [ ] ~~Benchmarks~~ documentation only
- [ ] ~~Load tests~~ documentation only
- [ ] ~~Chaos tests~~ documentation only
