### PR TITLE
fix: retain MQTT cache entries for the connector's own root subject

### DIFF
--- a/src/Namotion.Interceptor.Mqtt.Tests/MqttMappingCacheTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/MqttMappingCacheTests.cs
@@ -1,0 +1,387 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Connectors.Mapping;
+using Namotion.Interceptor.Mqtt.Client;
+using Namotion.Interceptor.Mqtt.Mapping;
+using Namotion.Interceptor.Mqtt.Server;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Registry.Abstractions;
+using Namotion.Interceptor.Registry.Attributes;
+using Namotion.Interceptor.Registry.Paths;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Lifecycle;
+
+namespace Namotion.Interceptor.Mqtt.Tests;
+
+/// <summary>
+/// A connector's own root subject is anchored to the context rather than held by a parent property,
+/// so nothing increments its reference count and it permanently reports zero. These pin that its
+/// properties still reach the topic and path caches, that a subject which has left the graph does
+/// not, and that a lookup landing in the middle of a detach evicts its own entry.
+/// </summary>
+public class MqttMappingCacheTests
+{
+    [Fact]
+    public async Task WhenRootSubjectPropertyIsMappedTwice_ThenTheServerTopicCacheServesTheSecondLookup()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var server = CreateServer(subject, mapper);
+        var property = subject.TryGetRegisteredSubject()!.TryGetProperty(nameof(MqttCacheTestRoot.Name))!;
+
+        // Act
+        var first = server.TryGetTopicForProperty(property.Reference, property);
+        var second = server.TryGetTopicForProperty(property.Reference, property);
+
+        // Assert
+        Assert.Equal("name", first.Topic);
+        Assert.Equal("name", second.Topic);
+        Assert.Equal(1, mapper.MappingLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenRootSubjectPathIsResolvedTwice_ThenTheServerPathCacheServesTheSecondLookup()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var server = CreateServer(subject, mapper);
+
+        // Act
+        var first = await server.TryGetPropertyForTopicAsync("name", CancellationToken.None);
+        var second = await server.TryGetPropertyForTopicAsync("name", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(nameof(MqttCacheTestRoot.Name), first?.Name);
+        Assert.Equal(nameof(MqttCacheTestRoot.Name), second?.Name);
+        Assert.Equal(1, mapper.PropertyLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenRootSubjectPropertyIsMappedTwice_ThenTheClientTopicCacheServesTheSecondLookup()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+        var property = subject.TryGetRegisteredSubject()!.TryGetProperty(nameof(MqttCacheTestRoot.Name))!;
+
+        // Act
+        var first = client.TryGetTopicForProperty(property.Reference, property);
+        var second = client.TryGetTopicForProperty(property.Reference, property);
+
+        // Assert
+        Assert.Equal("name", first.Topic);
+        Assert.Equal("name", second.Topic);
+        Assert.Equal(1, mapper.MappingLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenRootSubjectTopicIsResolvedTwice_ThenTheClientTopicCacheServesTheSecondLookup()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+
+        // Act
+        var first = await client.TryGetPropertyForTopicAsync("name");
+        var second = await client.TryGetPropertyForTopicAsync("name");
+
+        // Assert
+        Assert.Equal(nameof(MqttCacheTestRoot.Name), first?.Name);
+        Assert.Equal(nameof(MqttCacheTestRoot.Name), second?.Name);
+        Assert.Equal(1, mapper.PropertyLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenSubjectHasLeftTheRegistry_ThenTheServerTopicCacheDoesNotRetainIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var server = CreateServer(subject, mapper);
+        var detachedProperty = DetachChildAndReturnStaleProperty(subject);
+
+        // Act
+        server.TryGetTopicForProperty(detachedProperty.Reference, detachedProperty);
+        server.TryGetTopicForProperty(detachedProperty.Reference, detachedProperty);
+
+        // Assert
+        Assert.Equal(2, mapper.MappingLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenSubjectHasLeftTheRegistry_ThenTheClientTopicCacheDoesNotRetainIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+        var detachedProperty = DetachChildAndReturnStaleProperty(subject);
+
+        // Act
+        client.TryGetTopicForProperty(detachedProperty.Reference, detachedProperty);
+        client.TryGetTopicForProperty(detachedProperty.Reference, detachedProperty);
+
+        // Assert
+        Assert.Equal(2, mapper.MappingLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenTheConnectorRootHasLeftTheContext_ThenTheClientTopicCacheDoesNotRetainIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+        var property = subject.TryGetRegisteredSubject()!.TryGetProperty(nameof(MqttCacheTestRoot.Name))!;
+        ((IInterceptorSubject)subject).Context.TryGetLifecycleInterceptor()!.DetachSubjectFromContext(subject);
+
+        // Act
+        client.TryGetTopicForProperty(property.Reference, property);
+        client.TryGetTopicForProperty(property.Reference, property);
+
+        // Assert
+        Assert.Equal(2, mapper.MappingLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenLookupInsertsWhileSubjectIsDetaching_ThenTheClientTopicCacheDoesNotRetainIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+
+        // Act
+        var (property, topicSeenDuringDetach) = DetachChildWhileInserting(
+            subject, p => client.TryGetTopicForProperty(p.Reference, p).Topic);
+        var after = client.TryGetTopicForProperty(property.Reference, property);
+
+        // Assert
+        Assert.Equal("child/value", topicSeenDuringDetach);
+        Assert.Null(after.Topic);
+        Assert.Equal(2, mapper.MappingLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenLookupInsertsWhileSubjectIsDetaching_ThenTheClientPropertyCacheDoesNotRetainIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+
+        // Act
+        var (_, resolvedDuringDetach) = DetachChildWhileInserting(
+            subject, _ => SyncResult(client.TryGetPropertyForTopicAsync("child/value"))?.Name);
+        var after = await client.TryGetPropertyForTopicAsync("child/value");
+
+        // Assert
+        Assert.Equal(nameof(MqttCacheTestChild.Value), resolvedDuringDetach);
+        Assert.Null(after);
+        Assert.Equal(2, mapper.PropertyLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenLookupInsertsWhileSubjectIsDetaching_ThenTheServerTopicCacheDoesNotRetainIt()
+    {
+        // Arrange: the server is never started, so its own eviction scan is not subscribed and
+        // the insert-time guard is the only thing that can drop the entry again.
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var server = CreateServer(subject, mapper);
+
+        // Act
+        var (property, topicSeenDuringDetach) = DetachChildWhileInserting(
+            subject, p => server.TryGetTopicForProperty(p.Reference, p).Topic);
+        var after = server.TryGetTopicForProperty(property.Reference, property);
+
+        // Assert
+        Assert.Equal("child/value", topicSeenDuringDetach);
+        Assert.Null(after.Topic);
+    }
+
+    [Fact]
+    public async Task WhenLookupInsertsWhileSubjectIsDetaching_ThenTheServerPathCacheDoesNotRetainIt()
+    {
+        // Arrange: the server is never started, so its own eviction scan is not subscribed and
+        // the insert-time guard is the only thing that can drop the entry again.
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var server = CreateServer(subject, mapper);
+
+        // Act
+        var (_, resolvedDuringDetach) = DetachChildWhileInserting(
+            subject, _ => SyncResult(server.TryGetPropertyForTopicAsync("child/value", CancellationToken.None))?.Name);
+        var after = await server.TryGetPropertyForTopicAsync("child/value", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(nameof(MqttCacheTestChild.Value), resolvedDuringDetach);
+        Assert.Null(after);
+    }
+
+    private static MqttCacheTestRoot CreateRootSubject()
+    {
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking()
+            .WithRegistry();
+
+        return new MqttCacheTestRoot(context);
+    }
+
+    /// <summary>
+    /// Attaches a child, captures the registration of one of its properties, then removes the child
+    /// again. The returned registration is deliberately stale: the caches must refuse it.
+    /// </summary>
+    private static RegisteredSubjectProperty DetachChildAndReturnStaleProperty(MqttCacheTestRoot root)
+    {
+        root.Child = new MqttCacheTestChild();
+        var property = root.Child.TryGetRegisteredSubject()!.TryGetProperty(nameof(MqttCacheTestChild.Value))!;
+        root.Child = null;
+
+        Assert.Null(property.Subject.TryGetRegisteredSubject());
+        return property;
+    }
+
+    /// <summary>
+    /// Attaches a child, then detaches it while <paramref name="insert"/> runs from a SubjectDetaching
+    /// subscriber added after the connector's own. That is the deterministic stand-in for a publish or
+    /// an inbound message whose lookup lands between the connector's eviction scan and the registry
+    /// deregistration that follows it. Returns the child's now stale registration together with what
+    /// the insert observed, which proves the registry was still intact at that point.
+    /// </summary>
+    private static (RegisteredSubjectProperty Property, string? Observed) DetachChildWhileInserting(
+        MqttCacheTestRoot root,
+        Func<RegisteredSubjectProperty, string?> insert)
+    {
+        var child = new MqttCacheTestChild();
+        root.Child = child;
+
+        var property = child.TryGetRegisteredSubject()!.TryGetProperty(nameof(MqttCacheTestChild.Value))!;
+        var lifecycle = ((IInterceptorSubject)root).Context.TryGetLifecycleInterceptor()!;
+
+        string? observed = null;
+
+        void Handler(SubjectLifecycleChange change)
+        {
+            if (ReferenceEquals(change.Subject, child))
+            {
+                observed = insert(property);
+            }
+        }
+
+        lifecycle.SubjectDetaching += Handler;
+        try
+        {
+            root.Child = null;
+        }
+        finally
+        {
+            lifecycle.SubjectDetaching -= Handler;
+        }
+
+        Assert.Null(child.TryGetRegisteredSubject());
+        return (property, observed);
+    }
+
+    private static T SyncResult<T>(ValueTask<T> task)
+    {
+        Assert.True(task.IsCompleted, "The mapper is expected to resolve synchronously.");
+        return task.Result;
+    }
+
+    private static MqttSubjectServer CreateServer(
+        IInterceptorSubject subject,
+        IReversePropertyMapper<MqttPropertyMapping, MqttLookupKey> mapper)
+    {
+        return new MqttSubjectServer(
+            subject,
+            new MqttServerConfiguration { Mapper = mapper },
+            NullLogger<MqttSubjectServer>.Instance);
+    }
+
+    private static MqttSubjectClientSource CreateClient(
+        IInterceptorSubject subject,
+        IReversePropertyMapper<MqttPropertyMapping, MqttLookupKey> mapper)
+    {
+        return new MqttSubjectClientSource(
+            subject,
+            new MqttClientConfiguration { BrokerHost = "127.0.0.1", Mapper = mapper },
+            NullLogger<MqttSubjectClientSource>.Instance);
+    }
+
+    private static MqttCompositeMapper CreateMapper() => new(
+        new MqttPathProviderMapper(new AttributeBasedPathProvider("mqtt", '/')),
+        new MqttAttributeMapper("mqtt"));
+
+    /// <summary>
+    /// Counts how often the caches fall through to the mapper, which is the only externally visible
+    /// signal that a lookup was not served from cache.
+    /// </summary>
+    private sealed class CountingMapper : IReversePropertyMapper<MqttPropertyMapping, MqttLookupKey>
+    {
+        private readonly IReversePropertyMapper<MqttPropertyMapping, MqttLookupKey> _inner;
+
+        private int _mappingLookupCount;
+        private int _propertyLookupCount;
+
+        public CountingMapper(IReversePropertyMapper<MqttPropertyMapping, MqttLookupKey> inner)
+        {
+            _inner = inner;
+        }
+
+        public int MappingLookupCount => Volatile.Read(ref _mappingLookupCount);
+
+        public int PropertyLookupCount => Volatile.Read(ref _propertyLookupCount);
+
+        public bool TryGetMapping(
+            RegisteredSubjectProperty property,
+            IInterceptorSubject rootSubject,
+            [NotNullWhen(true)] out MqttPropertyMapping? mapping)
+        {
+            Interlocked.Increment(ref _mappingLookupCount);
+            return _inner.TryGetMapping(property, rootSubject, out mapping);
+        }
+
+        public ValueTask<RegisteredSubjectProperty?> TryGetPropertyAsync(
+            MqttLookupKey key,
+            RegisteredSubject subject,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _propertyLookupCount);
+            return _inner.TryGetPropertyAsync(key, subject, cancellationToken);
+        }
+    }
+}
+
+[InterceptorSubject]
+public partial class MqttCacheTestRoot
+{
+    [Path("mqtt", "name")]
+    public partial string Name { get; set; }
+
+    [Path("mqtt", "child")]
+    public partial MqttCacheTestChild? Child { get; set; }
+
+    public MqttCacheTestRoot()
+    {
+        Name = string.Empty;
+    }
+}
+
+[InterceptorSubject]
+public partial class MqttCacheTestChild
+{
+    [Path("mqtt", "value")]
+    public partial string Value { get; set; }
+
+    public MqttCacheTestChild()
+    {
+        Value = string.Empty;
+    }
+}

--- a/src/Namotion.Interceptor.Mqtt/Client/MqttSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.Mqtt/Client/MqttSubjectClientSource.cs
@@ -586,7 +586,7 @@ internal sealed class MqttSubjectClientSource : SubjectSourceBase, IFaultInjecta
         _logger.LogInformation("Subscribed to {Count} MQTT topics.", properties.Count);
     }
 
-    private (string? Topic, MqttPropertyMapping? Mapping) TryGetTopicForProperty(PropertyReference propertyReference, RegisteredSubjectProperty property)
+    internal (string? Topic, MqttPropertyMapping? Mapping) TryGetTopicForProperty(PropertyReference propertyReference, RegisteredSubjectProperty property)
     {
         if (_propertyToTopic.TryGetValue(propertyReference, out var cached))
         {
@@ -604,19 +604,15 @@ internal sealed class MqttSubjectClientSource : SubjectSourceBase, IFaultInjecta
         var entry = (topic, resolvedMapping);
 
         // Add first, then validate (guarantees no memory leak)
-        if (_propertyToTopic.TryAdd(propertyReference, entry))
+        if (_propertyToTopic.TryAdd(propertyReference, entry) && !IsRetainable(propertyReference.Subject))
         {
-            var registeredSubject = propertyReference.Subject.TryGetRegisteredSubject();
-            if (registeredSubject is null || registeredSubject.ReferenceCount <= 0)
-            {
-                _propertyToTopic.TryRemove(propertyReference, out _);
-            }
+            _propertyToTopic.TryRemove(propertyReference, out _);
         }
 
         return entry;
     }
 
-    private async ValueTask<PropertyReference?> TryGetPropertyForTopicAsync(string topic)
+    internal async ValueTask<PropertyReference?> TryGetPropertyForTopicAsync(string topic)
     {
         if (_topicToProperty.TryGetValue(topic, out var cachedProperty))
         {
@@ -631,19 +627,27 @@ internal sealed class MqttSubjectClientSource : SubjectSourceBase, IFaultInjecta
         var propertyReference = property?.Reference;
 
         // Add first, then validate (guarantees no memory leak)
-        if (_topicToProperty.TryAdd(topic, propertyReference))
+        if (_topicToProperty.TryAdd(topic, propertyReference) &&
+            propertyReference is { } resolvedProperty &&
+            !IsRetainable(resolvedProperty.Subject))
         {
-            if (propertyReference is { } propRef)
-            {
-                var registeredSubject = propRef.Subject.TryGetRegisteredSubject();
-                if (registeredSubject is null || registeredSubject.ReferenceCount <= 0)
-                {
-                    _topicToProperty.TryRemove(topic, out _);
-                }
-            }
+            _topicToProperty.TryRemove(topic, out _);
         }
 
         return propertyReference;
+    }
+
+    /// <summary>
+    /// Whether a cache entry for a property of <paramref name="subject"/> may stay. The reference count
+    /// drops before LifecycleInterceptor.SubjectDetaching fires, where the eviction scan runs, and the registry
+    /// deregisters only after that. Only the count catches a lookup that inserts in between. The connector root is
+    /// exempt: it is anchored to the context rather than to a property, so its count is zero for its whole life.
+    /// </summary>
+    private bool IsRetainable(IInterceptorSubject subject)
+    {
+        var registeredSubject = subject.TryGetRegisteredSubject();
+        return registeredSubject is not null &&
+            (registeredSubject.ReferenceCount > 0 || ReferenceEquals(subject, _subject));
     }
 
     private async Task OnMessageReceivedAsync(

--- a/src/Namotion.Interceptor.Mqtt/Server/MqttSubjectServer.cs
+++ b/src/Namotion.Interceptor.Mqtt/Server/MqttSubjectServer.cs
@@ -468,7 +468,7 @@ public class MqttSubjectServer : SubjectConnectorBase, IFaultInjectable, IAsyncD
         }
     }
 
-    private (string? Topic, MqttPropertyMapping? Mapping) TryGetTopicForProperty(PropertyReference propertyReference, RegisteredSubjectProperty property)
+    internal (string? Topic, MqttPropertyMapping? Mapping) TryGetTopicForProperty(PropertyReference propertyReference, RegisteredSubjectProperty property)
     {
         if (_propertyToTopic.TryGetValue(propertyReference, out var cached))
         {
@@ -486,19 +486,15 @@ public class MqttSubjectServer : SubjectConnectorBase, IFaultInjectable, IAsyncD
         var entry = (topic, resolvedMapping);
 
         // Add first, then validate (guarantees no memory leak)
-        if (_propertyToTopic.TryAdd(propertyReference, entry))
+        if (_propertyToTopic.TryAdd(propertyReference, entry) && !IsRetainable(propertyReference.Subject))
         {
-            var registeredSubject = propertyReference.Subject.TryGetRegisteredSubject();
-            if (registeredSubject is null || registeredSubject.ReferenceCount <= 0)
-            {
-                _propertyToTopic.TryRemove(propertyReference, out _);
-            }
+            _propertyToTopic.TryRemove(propertyReference, out _);
         }
 
         return entry;
     }
 
-    private async ValueTask<PropertyReference?> TryGetPropertyForTopicAsync(
+    internal async ValueTask<PropertyReference?> TryGetPropertyForTopicAsync(
         string path,
         CancellationToken cancellationToken)
     {
@@ -514,19 +510,27 @@ public class MqttSubjectServer : SubjectConnectorBase, IFaultInjectable, IAsyncD
         var propertyReference = property?.Reference;
 
         // Add first, then validate (guarantees no memory leak)
-        if (_pathToProperty.TryAdd(path, propertyReference))
+        if (_pathToProperty.TryAdd(path, propertyReference) &&
+            propertyReference is { } resolvedProperty &&
+            !IsRetainable(resolvedProperty.Subject))
         {
-            if (propertyReference is { } propRef)
-            {
-                var registeredSubject = propRef.Subject.TryGetRegisteredSubject();
-                if (registeredSubject is null || registeredSubject.ReferenceCount <= 0)
-                {
-                    _pathToProperty.TryRemove(path, out _);
-                }
-            }
+            _pathToProperty.TryRemove(path, out _);
         }
 
         return propertyReference;
+    }
+
+    /// <summary>
+    /// Whether a cache entry for a property of <paramref name="subject"/> may stay. The reference count
+    /// drops before LifecycleInterceptor.SubjectDetaching fires, where the eviction scan runs, and the registry
+    /// deregisters only after that. Only the count catches a lookup that inserts in between. The connector root is
+    /// exempt: it is anchored to the context rather than to a property, so its count is zero for its whole life.
+    /// </summary>
+    private bool IsRetainable(IInterceptorSubject subject)
+    {
+        var registeredSubject = subject.TryGetRegisteredSubject();
+        return registeredSubject is not null &&
+            (registeredSubject.ReferenceCount > 0 || ReferenceEquals(subject, _subject));
     }
 
     private Task ClientConnectedAsync(


### PR DESCRIPTION
The MQTT outbound topic cache and inbound path cache never retained a mapping for a property declared directly on the connector's own root subject, so every publish and every inbound message re-ran the mapper: a full path walk, a `MqttPropertyMapping` record and a topic string, per message, forever.

## Why

The insert-time guard rejected any subject whose reference count was zero, and a context-anchored root is permanently zero. The count records parent property edges, and a root is held by the context rather than by a parent, so the guard was rejecting a live registered subject rather than catching a dead one.

The guard itself has to stay. It exists for a real race: the entry is built and inserted before liveness is checked, so a lookup running while a subject detaches would otherwise strand an entry that pins the subject in memory. Registry membership cannot replace it, because detach is two steps and the eviction scan is the first: the reference count drops, then `SubjectDetaching` fires and the scan runs, and only afterwards does the registry deregister. A lookup landing between the scan and the deregistration still sees a registered subject, so nothing would evict its entry.

An earlier attempt did exactly that and was caught in review: it stranded **19,679 of 20,000** contended iterations, with a weak reference proving the stranded key pinned the detached subject. So the count test stays and only the connector root is exempted, which is safe because a root entry pins a subject the connector holds for its whole life and a root maps relative to itself, so the topic cannot go stale.

## Notes for review

- The four duplicated guards collapse into one `IsRetainable` helper per class, which states the ordering invariant once.
- The four lookup methods move from `private` to `internal` so the tests can observe a cache hit directly rather than through reflection. `InternalsVisibleTo` already existed and internal members stay out of the public API snapshot.
- Two test families are complementary, not redundant: against `master` the four root-cache tests fail; against the earlier broken attempt the four mid-detach tests fail; only this shape passes both.

## Verification

- [x] Unit tests: MQTT 114, Connectors 787, integration included
- [x] Cache tests 10x under `taskset -c 0,1`, 0 failures
- [x] Public API snapshot unchanged
- [ ] Benchmarks: not run. The saving is one path walk, one record and one string per message, argued from the mechanism rather than measured
- [ ] Connector Tester: not run. No wire behaviour changes, only whether a mapping result is memoized
