### PR TITLE
fix: keep the escape on generated identifiers and normalise the hint name

### DIFF
--- a/src/Namotion.Interceptor.Generator.Tests/EscapedIdentifierTests.cs
+++ b/src/Namotion.Interceptor.Generator.Tests/EscapedIdentifierTests.cs
@@ -1,0 +1,126 @@
+namespace Namotion.Interceptor.Generator.Tests;
+
+/// <summary>
+/// Covers declarations whose identifiers are C# keywords escaped with '@'. The escape is part of
+/// the identifier's spelling but not part of its value, so a generator that copies the value into
+/// generated source emits a bare keyword and produces code that cannot compile.
+/// </summary>
+public class EscapedIdentifierTests
+{
+    [Fact]
+    public void WhenSubjectClassNameIsAnEscapedKeyword_ThenGeneratedCodeCompiles()
+    {
+        // Arrange
+        const string source = @"
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class @class
+    {
+        public partial string Name { get; set; }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Contains("public partial class @class", generated.SingleSource());
+    }
+
+    [Fact]
+    public void WhenContainingTypeNameIsAnEscapedKeyword_ThenGeneratedCodeCompiles()
+    {
+        // Arrange
+        const string source = @"
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    public partial class @class
+    {
+        [InterceptorSubject]
+        public partial class Machine
+        {
+            public partial string Name { get; set; }
+        }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Contains("partial class @class", generated.SingleSource());
+    }
+
+    [Fact]
+    public void WhenInterceptedMethodParameterIsAnEscapedKeyword_ThenGeneratedCodeCompiles()
+    {
+        // Arrange
+        const string source = @"
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class Machine
+    {
+        public partial string Name { get; set; }
+
+        public void DoWorkWithoutInterceptor(int @event) { }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Contains("public void DoWork(int @event)", generated.SingleSource());
+    }
+
+    [Fact]
+    public void WhenNamespaceSegmentIsAnEscapedKeyword_ThenGeneratedCodeIsEmittedAndCompiles()
+    {
+        // Arrange: the namespace reaches the generated file's hint name, and '@' is rejected there,
+        // which fails the whole subject instead of only mangling a name inside the file.
+        const string source = @"
+using Namotion.Interceptor.Attributes;
+namespace @class.Inner
+{
+    [InterceptorSubject]
+    public partial class Machine
+    {
+        public partial string Name { get; set; }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Equal("class.Inner.Machine.g.cs", generated.Sources.Single().HintName);
+    }
+
+    [Fact]
+    public void WhenSubjectNameUsesAUnicodeEscape_ThenGeneratedCodeIsEmittedAndCompiles()
+    {
+        // Arrange: the other spelling an identifier can carry. It puts a backslash rather than an
+        // '@' into the source name, so a hint name derived from that spelling fails the same way.
+        const string source = @"
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class \u0041bc
+    {
+        public partial string Name { get; set; }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Equal("Repro.Abc.g.cs", generated.Sources.Single().HintName);
+    }
+}

--- a/src/Namotion.Interceptor.Generator/SubjectCodeGenerator.cs
+++ b/src/Namotion.Interceptor.Generator/SubjectCodeGenerator.cs
@@ -51,14 +51,13 @@ internal static class SubjectCodeGenerator
     /// </summary>
     public static string GetFileName(SubjectMetadata metadata)
     {
-        var containingTypesPath = metadata.ContainingTypes.Length > 0
-            ? string.Join(".", metadata.ContainingTypes.Select(t => t.Name)) + "."
-            : "";
-        var namespacePrefix = metadata.NamespaceName is null
-            ? ""
-            : metadata.NamespaceName + ".";
-
-        return $"{namespacePrefix}{containingTypesPath}{metadata.ClassName}.g.cs";
+        // From the symbol name, not from the emitted names: those keep their source spelling, and
+        // AddSource rejects the '@' of a keyword escape, the backslash of a \uXXXX escape, and the
+        // comment or line break a namespace name can hold, failing the whole subject with NI0004
+        // and emitting nothing. The symbol name is that name normalised, so only two decorations go.
+        return metadata.FullTypeName
+            .Replace("global::", "")
+            .Replace("@", "") + ".g.cs";
     }
 
     private static void EmitFileHeader(StringBuilder builder)

--- a/src/Namotion.Interceptor.Generator/SubjectMetadataExtractor.cs
+++ b/src/Namotion.Interceptor.Generator/SubjectMetadataExtractor.cs
@@ -78,7 +78,11 @@ internal static class SubjectMetadataExtractor
             }
         }
 
-        var className = typeDeclaration.Identifier.ValueText;
+        // Text rather than ValueText: ValueText drops the '@' that escapes a keyword used as a
+        // name, and the bare keyword does not parse. Property names below stay on ValueText,
+        // because they are also emitted as string literals, as nameof arguments and as parts of
+        // derived names such as _Name and OnNameChanged, where the escape would be wrong.
+        var className = typeDeclaration.Identifier.Text;
 
         // Use the symbol rather than the syntax modifiers: a top-level class without a modifier
         // defaults to internal, a nested one to private.
@@ -168,7 +172,7 @@ internal static class SubjectMetadataExtractor
         {
             types.Insert(0, new ContainingType(
                 GetTypeKeyword(typeDeclaration),
-                typeDeclaration.Identifier.ValueText));
+                typeDeclaration.Identifier.Text));
             parent = parent.Parent;
         }
         return types.ToArray();
@@ -518,7 +522,7 @@ internal static class SubjectMetadataExtractor
 
                 var parameters = method.ParameterList.Parameters
                     .Select(p => new ParameterMetadata(
-                        p.Identifier.ValueText,
+                        p.Identifier.Text,
                         GetFullTypeName(p.Type, declarationModel) ?? "object"))
                     .ToList();
 


### PR DESCRIPTION
A subject whose name is a contextual keyword written with an `@` escape emitted source that cannot be parsed. `[InterceptorSubject] partial class @class` produced `public class(IInterceptorSubjectContext context)`, and the consumer saw 172 compile errors. The same applied to a containing type and to an intercepted method's parameter.

## Why

The generator read those identifiers through `Identifier.ValueText`, which strips the escape. They now read `Identifier.Text`, which preserves the spelling that has to be emitted.

The hint name had to move at the same time, and this is the part worth a reviewer's attention. Once identifiers keep their escape, a hint name built from those spellings carries the `@` too, and `AddSource` rejects it. So the hint name is now composed from the fully qualified symbol name, which is that same name normalised. That also covers the backslash of a `\uXXXX` escape and the comment trivia or line break a namespace name can hold, and it makes the absence of hint name collisions structural rather than incidental, since a fully qualified name is unique per type.

`namespace A /*x*/ . B` and a namespace name wrapped across lines were **already broken on master** for that reason: `NI0004`, a stub file holding the stack trace, no generated code, and a `CS9248` cascade on every partial property with nothing naming the cause. The second is a realistic spelling.

## Notes for review

- Partial **property** names deliberately stay on `ValueText`. A property name is not only an identifier: it is also emitted as a string literal, as a `nameof` argument, and as a fragment of `_Name` and `OnNameChanged`, where an escape would be wrong. That needs a spelling and value pair rather than a token swap, and is left alone.
- Hint names were compared against `master` across **299 solution subjects and 224 test subjects**: zero differences. The only shapes that rename are two that already failed to compile.
- The `\uXXXX` test is a regression guard against a hazard this change itself introduces, not a fix for a master bug. Master handled that spelling correctly.

## Verification

- [x] Unit tests: Generator 249, Core 157, Tracking 565
- [x] Hint name parity with master across 523 subjects
- [x] Public API snapshot unchanged, no snapshot accepted
