### PR TITLE
fix: attach read-only dictionaries the structural scan dropped

### DIFF
--- a/src/Namotion.Interceptor.Tracking.Tests/BroadlyDeclaredStructuralPropertyTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/BroadlyDeclaredStructuralPropertyTests.cs
@@ -1,0 +1,139 @@
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking.Parent;
+using Namotion.Interceptor.Tracking.Tests.Models;
+
+namespace Namotion.Interceptor.Tracking.Tests;
+
+/// <summary>
+/// Covers structural values whose declared property type is too broad to say whether they are
+/// keyed or ordinal, so the shape has to come from the value itself, plus the precisely declared
+/// dictionary that enumerates as its values and therefore also depends on a total keyed arm.
+/// </summary>
+public class BroadlyDeclaredStructuralPropertyTests
+{
+    private static (BroadlyDeclaredHolder Holder, TestLifecycleHandler Handler) CreateHolder()
+    {
+        var handler = new TestLifecycleHandler();
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry()
+            .WithParents()
+            .WithService(() => handler)
+            .WithContextInheritance();
+
+        return (new BroadlyDeclaredHolder(context), handler);
+    }
+
+    [Fact]
+    public void WhenAReadOnlyDictionaryIsHeldBehindABroadProperty_ThenItsChildrenAreAttachedUnderTheirKey()
+    {
+        // Arrange
+        var (holder, handler) = CreateHolder();
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.BroadCars = new ReadOnlyDictionaryWrapper<string, Car>(new Dictionary<string, Car> { ["first"] = car });
+
+        // Assert
+        Assert.Contains(handler.GetEvents(), e => e.Contains("BroadCars[first] -> Car1") && e.Contains("attached"));
+        Assert.Equal("first", Assert.Single(car.GetParents()).Index);
+    }
+
+    [Fact]
+    public void WhenABroadPropertyHoldingAReadOnlyDictionaryIsCleared_ThenItsChildrenAreDetached()
+    {
+        // Arrange
+        var (holder, handler) = CreateHolder();
+        var car = new Car { Name = "Car1" };
+        holder.BroadCars = new ReadOnlyDictionaryWrapper<string, Car>(new Dictionary<string, Car> { ["first"] = car });
+        handler.Clear();
+
+        // Act
+        holder.BroadCars = null;
+
+        // Assert
+        Assert.Contains(handler.GetEvents(), e => e.Contains("BroadCars[first] -> Car1") && e.Contains("detached"));
+        Assert.Empty(car.GetParents());
+        Assert.Empty(holder
+            .TryGetRegisteredSubject()!
+            .TryGetProperty(nameof(BroadlyDeclaredHolder.BroadCars))!
+            .Children);
+    }
+
+    [Fact]
+    public void WhenAReadOnlyCollectionIsHeldBehindABroadProperty_ThenItsChildrenAreAttachedByPosition()
+    {
+        // Arrange: the value carries no key value pairs, so the same broad declaration must keep
+        // producing positional indices.
+        var (holder, handler) = CreateHolder();
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.BroadCars = new CarBag(car);
+
+        // Assert
+        Assert.Contains(handler.GetEvents(), e => e.Contains("BroadCars[0] -> Car1") && e.Contains("attached"));
+        Assert.Equal(0, Assert.Single(car.GetParents()).Index);
+    }
+
+    [Fact]
+    public void WhenADictionaryEnumeratesAsValuesInsteadOfPairs_ThenItsChildrenAreStillAttached()
+    {
+        // Arrange: classifying the value as keyed is only half the answer, the keyed arm also has
+        // to handle a dictionary type whose enumerator yields values rather than pairs.
+        var (holder, handler) = CreateHolder();
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.BroadCars = new ValueEnumeratingCarDictionary(new Dictionary<string, Car> { ["first"] = car });
+
+        // Assert
+        Assert.Contains(handler.GetEvents(), e => e.Contains("BroadCars[0] -> Car1") && e.Contains("attached"));
+        Assert.Equal(0, Assert.Single(car.GetParents()).Index);
+    }
+
+    [Fact]
+    public void WhenAPreciselyDeclaredDictionaryEnumeratesAsValuesInsteadOfPairs_ThenItsChildrenAreAttachedByPosition()
+    {
+        // Arrange: the declaration already says keyed, so only the totality of the keyed arm keeps
+        // this child from being dropped, and it can only place it by position because the
+        // enumerator yields values that carry no key.
+        var (holder, handler) = CreateHolder();
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.PreciseCars = new ValueEnumeratingCarDictionary(new Dictionary<string, Car> { ["first"] = car });
+
+        // Assert
+        Assert.Contains(handler.GetEvents(), e => e.Contains("PreciseCars[0] -> Car1") && e.Contains("attached"));
+        Assert.Equal(0, Assert.Single(car.GetParents()).Index);
+
+        var property = holder
+            .TryGetRegisteredSubject()!
+            .TryGetProperty(nameof(BroadlyDeclaredHolder.PreciseCars))!;
+
+        Assert.Equal(0, Assert.Single(property.Children).Index);
+
+        // The declared type still reports keyed, so key based path resolution cannot reach a child
+        // recorded at a position. Attaching it positionally is what the totality arm buys.
+        Assert.True(property.IsSubjectDictionary);
+    }
+
+    [Fact]
+    public void WhenAnEnumerableOfPairsIsNotADictionary_ThenItsPairsAreNotUnwrapped()
+    {
+        // Arrange: the keyed arm is chosen by the value's own type, never by the shape of the items
+        // it happens to yield. Keeping a non-dictionary sequence ordinal is what makes the
+        // classifier and this handler answer the same question.
+        var (holder, handler) = CreateHolder();
+        var car = new Car { Name = "Car1" };
+
+        // Act
+        holder.BroadCars = new CarPairSequence(new KeyValuePair<string, Car>("first", car));
+
+        // Assert
+        Assert.DoesNotContain(handler.GetEvents(), e => e.Contains("Car1") && e.Contains("attached"));
+        Assert.Empty(car.GetParents());
+    }
+}

--- a/src/Namotion.Interceptor.Tracking.Tests/Models/BroadlyDeclaredHolder.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Models/BroadlyDeclaredHolder.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Tracking.Tests.Models;
+
+/// <summary>
+/// Holds a structural value behind a declaration too broad to say whether it is keyed or ordinal,
+/// so the structural scan has to dispatch from the value instead.
+/// </summary>
+[InterceptorSubject]
+public partial class BroadlyDeclaredHolder
+{
+    public partial object? BroadCars { get; set; }
+
+    public partial IReadOnlyDictionary<string, Car>? PreciseCars { get; set; }
+}
+
+/// <summary>
+/// A dictionary that enumerates as its values rather than as key value pairs, so the keyed dispatch
+/// arm has to cope with items that are subjects instead of pairs.
+/// </summary>
+public sealed class ValueEnumeratingCarDictionary(Dictionary<string, Car> cars)
+    : IReadOnlyDictionary<string, Car>, IEnumerable<Car>
+{
+    public Car this[string key] => cars[key];
+
+    public IEnumerable<string> Keys => cars.Keys;
+
+    public IEnumerable<Car> Values => cars.Values;
+
+    public int Count => cars.Count;
+
+    public bool ContainsKey(string key) => cars.ContainsKey(key);
+
+    public bool TryGetValue(string key, out Car value) => cars.TryGetValue(key, out value!);
+
+    public IEnumerator<Car> GetEnumerator() => cars.Values.GetEnumerator();
+
+    IEnumerator<KeyValuePair<string, Car>> IEnumerable<KeyValuePair<string, Car>>.GetEnumerator() => cars.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <summary>
+/// A sequence of pairs that is not a dictionary: it yields KeyValuePair items but implements no
+/// dictionary interface, so classification has to keep it ordinal.
+/// </summary>
+public sealed class CarPairSequence(params KeyValuePair<string, Car>[] pairs) : IEnumerable<KeyValuePair<string, Car>>
+{
+    public IEnumerator<KeyValuePair<string, Car>> GetEnumerator()
+        => ((IEnumerable<KeyValuePair<string, Car>>)pairs).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
@@ -485,33 +485,30 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
                 return;
 
             case IEnumerable enumerable:
-                // Read-only types (no ICollection): dispatch on declared property shape.
-                if (property.Metadata.Type.IsSubjectDictionaryType())
+            {
+                // A pair carries its key, but a dictionary type is free to enumerate as its values
+                // instead, and a broad declaration (object, plain interface) never classifies as a
+                // dictionary, so the value's own type has to answer when the declared one cannot.
+                var isKeyed = property.Metadata.Type.IsSubjectDictionaryType() ||
+                              enumerable.GetType().IsSubjectDictionaryType();
+                var index = 0;
+                foreach (var item in enumerable)
                 {
-                    foreach (var item in enumerable)
+                    if (isKeyed && item is not null &&
+                        SubjectLookup.TryGetSubjectFromKeyValuePair(item, out var key, out var keyedItem))
                     {
-                        if (item is null) continue;
-                        if (SubjectLookup.TryGetSubjectFromKeyValuePair(item, out var key, out var subjectItem))
-                        {
-                            touchedSubjects?.Add(subjectItem);
-                            collectedSubjects.Add((subjectItem, property, key));
-                        }
+                        touchedSubjects?.Add(keyedItem);
+                        collectedSubjects.Add((keyedItem, property, key));
                     }
-                }
-                else
-                {
-                    var i = 0;
-                    foreach (var item in enumerable)
+                    else if (item is IInterceptorSubject subjectItem)
                     {
-                        if (item is IInterceptorSubject subjectItem)
-                        {
-                            touchedSubjects?.Add(subjectItem);
-                            collectedSubjects.Add((subjectItem, property, i));
-                        }
-                        i++;
+                        touchedSubjects?.Add(subjectItem);
+                        collectedSubjects.Add((subjectItem, property, index));
                     }
+                    index++;
                 }
                 return;
+            }
         }
     }
 


### PR DESCRIPTION
A subject held in a read-only dictionary was silently dropped from the graph when the property holding it is declared with a broad type. No exception: the child simply never attached, never appeared in the registry, and never detached.

## Why

Keyed versus ordinal handling was decided from the property's **declared** type alone. A property declared `object?` passes the subject pre-filter but can never satisfy `IsSubjectDictionaryType()`, so a wrapper implementing neither `IDictionary` nor non-generic `ICollection` fell into the ordinal arm, where every boxed `KeyValuePair` fails the subject test.

Two halves were needed, and the second only surfaced in review:

1. Classification consults the **value's own runtime type** when the declared type is too broad to answer.
2. The keyed arm is now **total**. A dictionary type is free to enumerate as its values rather than as pairs, which is an ordinary idiom (`class Registry : IReadOnlyDictionary<string, Device>, IEnumerable<Device>`). With only the first half, such a value matched the keyed arm and then yielded nothing: measured, master attached a car and its four tires, the first attempt attached **nothing at all**. The arm now falls back to the subject test at a positional index.

Half 2 also fixes the same drop behind a **precisely** declared `IReadOnlyDictionary<,>`, which master got wrong too.

## Scope boundary, worth reading before approving

`RegisteredSubjectProperty.IsSubjectDictionary` still answers from the declared type, and that produces one **new** pairing: a precisely declared dictionary whose value enumerates as values now carries positional children while the property still reports itself as keyed, so `PreciseCars[0]` does not resolve while `PreciseCars[first]` does. That could not happen before, because the child was dropped and there was nothing to resolve under either index. It is not a regression, and it is pinned by a test.

For a broadly declared property the equivalent gap is **not** new: such a property holding an ordinal collection already carried children no indexed path could resolve.

## AOT

The change adds no dynamic code generation of its own. It does widen who reaches the pre-existing `Expression.Lambda<>().Compile()` in `SubjectLookup`, since broadly declared properties now reach the keyed arm. That is the right trade, because the alternative is dropping the child.

## Verification

- [x] Unit tests: Core 157, Tracking 571, Registry 158, Connectors 787
- [x] Differential harness over 2,222 shape combinations plus mid-enumeration throws, byte-identical before and after the loop merge, with negative controls
- [x] Every entry `master` collects also appears here at the same index (strict superset)
- [ ] Benchmarks: not run. The added check is one cached lookup on an arm that arrays, `List<T>`, `Dictionary<K,V>` and the immutable collections never reach
