### PR TITLE
fix: repeat [SetsRequiredMembers] on generated constructors

### DIFF
--- a/src/Namotion.Interceptor.Generator.Tests/GeneratorShapeBehaviorTests.cs
+++ b/src/Namotion.Interceptor.Generator.Tests/GeneratorShapeBehaviorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Generator.Tests.Models;
 using Namotion.Interceptor.Interceptors;
@@ -110,6 +111,50 @@ public partial class SealedOverrideBase
 public partial class SealedOverrideSubject : SealedOverrideBase
 {
     public sealed override partial string Label { get; set; }
+}
+
+#endregion
+
+#region Case RM: a required partial property initialized by a [SetsRequiredMembers] constructor
+
+[InterceptorSubject]
+public partial class RequiredMemberSubject
+{
+    public required partial string Name { get; set; }
+
+    [SetsRequiredMembers]
+    public RequiredMemberSubject()
+    {
+        Name = "default";
+    }
+}
+
+#endregion
+
+#region Case RM3: a subject chain whose root constructor sets required members
+
+[InterceptorSubject]
+public partial class RequiredMemberBaseSubject
+{
+    public required partial string Id { get; set; }
+
+    [SetsRequiredMembers]
+    public RequiredMemberBaseSubject()
+    {
+        Id = "base-default";
+    }
+}
+
+[InterceptorSubject]
+public partial class RequiredMemberMiddleSubject : RequiredMemberBaseSubject
+{
+    public partial string Name { get; set; }
+}
+
+[InterceptorSubject]
+public partial class RequiredMemberLeafSubject : RequiredMemberMiddleSubject
+{
+    public partial string Label { get; set; }
 }
 
 #endregion
@@ -397,4 +442,38 @@ public class GeneratorShapeBehaviorTests
         Assert.Equal(["Label"], firedEvents);
     }
 
+    [Fact]
+    public void WhenChainedConstructorSetsRequiredMembers_ThenTheContextConstructorNeedsNoInitializer()
+    {
+        // Arrange (case RM)
+        var context = InterceptorSubjectContext.Create();
+
+        // Act: the required member is satisfied by the chained constructor, so this call compiles
+        // without an object initializer.
+        var subject = new RequiredMemberSubject(context);
+
+        // Assert
+        Assert.Equal("default", subject.Name);
+    }
+
+    [Fact]
+    public void WhenBaseConstructorSetsRequiredMembers_ThenTheDerivedConstructorsNeedNoInitializer()
+    {
+        // Arrange (case RM3): the generated constructors of the middle subject and of the leaf below
+        // it chain implicitly up to the base constructor, so all four inherit its claim and none of
+        // these calls needs an object initializer.
+        var context = InterceptorSubjectContext.Create();
+
+        // Act
+        var middleSubject = new RequiredMemberMiddleSubject();
+        var middleContextSubject = new RequiredMemberMiddleSubject(context);
+        var leafSubject = new RequiredMemberLeafSubject();
+        var leafContextSubject = new RequiredMemberLeafSubject(context);
+
+        // Assert
+        Assert.Equal("base-default", middleSubject.Id);
+        Assert.Equal("base-default", middleContextSubject.Id);
+        Assert.Equal("base-default", leafSubject.Id);
+        Assert.Equal("base-default", leafContextSubject.Id);
+    }
 }

--- a/src/Namotion.Interceptor.Generator.Tests/GeneratorShapeTests.cs
+++ b/src/Namotion.Interceptor.Generator.Tests/GeneratorShapeTests.cs
@@ -777,4 +777,204 @@ namespace Repro
         Assert.Contains(skipped, diagnostic => diagnostic.GetMessage().Contains("PullWithoutInterceptor"));
         Assert.Contains(skipped, diagnostic => diagnostic.GetMessage().Contains("MixWithoutInterceptor"));
     }
+
+    [Fact]
+    public void WhenTheOnlyDeclaredConstructorIsStatic_ThenBothConstructorsAreGenerated()
+    {
+        // Arrange: a static constructor is not an instance constructor, so nothing can chain to it
+        // and the subject still needs a generated parameterless one.
+        const string source = @"
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class Machine
+    {
+        public static readonly string Fallback;
+
+        static Machine()
+        {
+            Fallback = ""fallback"";
+        }
+
+        public partial string Name { get; set; }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Contains("public Machine()", generated.SingleSource());
+        Assert.Contains("public Machine(IInterceptorSubjectContext context) : this()", generated.SingleSource());
+    }
+
+    [Fact]
+    public void WhenChainedConstructorSetsRequiredMembers_ThenGeneratedContextConstructorRepeatsTheAttribute()
+    {
+        // Arrange (case RM): the generated context constructor chains to the declared parameterless
+        // one with ": this()", and C# rejects that chain with CS9039 unless the chaining constructor
+        // repeats [SetsRequiredMembers].
+        const string source = @"
+using System.Diagnostics.CodeAnalysis;
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class Machine
+    {
+        public required partial string Name { get; set; }
+
+        [SetsRequiredMembers]
+        public Machine()
+        {
+            Name = ""default"";
+        }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        Assert.Contains(
+            "        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]" + Environment.NewLine +
+            "        public Machine(IInterceptorSubjectContext context) : this()",
+            generated.SingleSource());
+    }
+
+    [Fact]
+    public void WhenBaseConstructorSetsRequiredMembers_ThenEveryDerivedGeneratedConstructorRepeatsTheAttribute()
+    {
+        // Arrange (case RM3): each generated parameterless constructor chains implicitly to its base
+        // one, and CS9039 applies to that chain too. The leaf sits two levels below the attributed
+        // constructor: while it is extracted, the attributed constructor the generator emits for the
+        // middle subject does not exist yet, so the middle type only shows an implicit, unattributed
+        // one and the base has to be found through it.
+        const string source = @"
+using System.Diagnostics.CodeAnalysis;
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class BaseMachine
+    {
+        public required partial string Id { get; set; }
+
+        [SetsRequiredMembers]
+        public BaseMachine()
+        {
+            Id = ""base-default"";
+        }
+    }
+
+    [InterceptorSubject]
+    public partial class MiddleMachine : BaseMachine
+    {
+        public partial string Name { get; set; }
+    }
+
+    [InterceptorSubject]
+    public partial class LeafMachine : MiddleMachine
+    {
+        public partial string Label { get; set; }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert
+        var generatedSources = generated.AllSources();
+        Assert.Contains(
+            "        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]" + Environment.NewLine +
+            "        public MiddleMachine()",
+            generatedSources);
+        Assert.Contains(
+            "        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]" + Environment.NewLine +
+            "        public MiddleMachine(IInterceptorSubjectContext context) : this()",
+            generatedSources);
+        Assert.Contains(
+            "        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]" + Environment.NewLine +
+            "        public LeafMachine()",
+            generatedSources);
+        Assert.Contains(
+            "        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]" + Environment.NewLine +
+            "        public LeafMachine(IInterceptorSubjectContext context) : this()",
+            generatedSources);
+    }
+
+    [Fact]
+    public void WhenDerivedSubjectDeclaresItsOwnRequiredMember_ThenGeneratedConstructorsOmitTheAttribute()
+    {
+        // Arrange: the base constructor sets the base's required member, but nothing sets the one the
+        // derived subject adds. A generated constructor carrying the attribute would turn the CS9039
+        // this shape has always produced into a member that is silently null after 'new DerivedMachine()'.
+        const string source = @"
+using System.Diagnostics.CodeAnalysis;
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{
+    [InterceptorSubject]
+    public partial class BaseMachine
+    {
+        public required partial string Id { get; set; }
+
+        [SetsRequiredMembers]
+        public BaseMachine()
+        {
+            Id = ""base-default"";
+        }
+    }
+
+    [InterceptorSubject]
+    public partial class DerivedMachine : BaseMachine
+    {
+        public required partial string Name { get; set; }
+    }
+}";
+
+        // Act
+        var generated = GeneratorTestHost.Run(source);
+
+        // Assert: the derived subject keeps the compile error and has to declare the initializing
+        // constructor itself.
+        var derivedSource = generated.Sources
+            .Single(generatedSource => generatedSource.HintName == "Repro.DerivedMachine.g.cs")
+            .SourceText
+            .ToString();
+        Assert.DoesNotContain("SetsRequiredMembers", derivedSource);
+        Assert.Contains(generated.CompilationErrors, diagnostic => diagnostic.Id == "CS9039");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("public Machine() { }")]
+    public void WhenNoChainedConstructorSetsRequiredMembers_ThenGeneratedContextConstructorOmitsTheAttribute(
+        string constructorDeclaration)
+    {
+        // Arrange (case RM2): both a generated and a plain declared parameterless constructor leave
+        // the required member uninitialized, for the generator-emitted constructor as much as for
+        // the caller.
+        var source = $@"
+using Namotion.Interceptor.Attributes;
+namespace Repro
+{{
+    [InterceptorSubject]
+    public partial class Machine
+    {{
+        public required partial string Name {{ get; set; }}
+
+        {constructorDeclaration}
+    }}
+}}";
+
+        // Act
+        var generated = GeneratorTestHost.RunExpectingNoWarnings(source);
+
+        // Assert: claiming the attribute here would tell the compiler the required member is
+        // initialized when nothing initializes it, and every caller would lose the diagnostic.
+        Assert.DoesNotContain("SetsRequiredMembers", generated.SingleSource());
+        Assert.Contains("public Machine(IInterceptorSubjectContext context) : this()", generated.SingleSource());
+    }
 }

--- a/src/Namotion.Interceptor.Generator/KnownTypes.cs
+++ b/src/Namotion.Interceptor.Generator/KnownTypes.cs
@@ -7,4 +7,5 @@ internal static class KnownTypes
     public const string IInterceptorSubject = "Namotion.Interceptor.IInterceptorSubject";
     public const string IRaisePropertyChanged = "Namotion.Interceptor.IRaisePropertyChanged";
     public const string SubjectPropertyMetadata = "Namotion.Interceptor.SubjectPropertyMetadata";
+    public const string SetsRequiredMembersAttribute = "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute";
 }

--- a/src/Namotion.Interceptor.Generator/Models/SubjectMetadata.cs
+++ b/src/Namotion.Interceptor.Generator/Models/SubjectMetadata.cs
@@ -11,6 +11,7 @@ internal sealed record SubjectMetadata(
     ContainingType[] ContainingTypes,
     bool NeedsGeneratedParameterlessConstructor,
     bool HasOrWillHaveParameterlessConstructor,
+    bool ParameterlessConstructorSetsRequiredMembers,
     SubjectBaseClass BaseClass,
     IReadOnlyList<PropertyMetadata> Properties,
     IReadOnlyList<MethodMetadata> Methods);

--- a/src/Namotion.Interceptor.Generator/SubjectCodeGenerator.cs
+++ b/src/Namotion.Interceptor.Generator/SubjectCodeGenerator.cs
@@ -271,11 +271,25 @@ internal static class SubjectCodeGenerator
         builder.AppendLine();
     }
 
+    /// <summary>
+    /// Fully qualified rather than imported, so generated files of subjects without the attribute stay
+    /// byte-identical, and rooted at global:: so the name still reaches a consumer-declared polyfill
+    /// when the subject's own namespace shadows System.
+    /// </summary>
+    private static void EmitSetsRequiredMembersAttribute(StringBuilder builder, SubjectMetadata metadata)
+    {
+        if (metadata.ParameterlessConstructorSetsRequiredMembers)
+        {
+            builder.AppendLine("        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
+        }
+    }
+
     private static void EmitConstructors(StringBuilder builder, SubjectMetadata metadata)
     {
         // Generate parameterless constructor only if no constructor exists
         if (metadata.NeedsGeneratedParameterlessConstructor)
         {
+            EmitSetsRequiredMembersAttribute(builder, metadata);
             builder.AppendLine($"        public {metadata.ClassName}()");
             builder.AppendLine("        {");
             builder.AppendLine("        }");
@@ -285,6 +299,7 @@ internal static class SubjectCodeGenerator
         // Generate constructor with context parameter if we have or will have a parameterless constructor
         if (metadata.HasOrWillHaveParameterlessConstructor)
         {
+            EmitSetsRequiredMembersAttribute(builder, metadata);
             builder.AppendLine($"        public {metadata.ClassName}(IInterceptorSubjectContext context) : this()");
             builder.AppendLine("        {");
             builder.AppendLine("            ((IInterceptorSubject)this).Context.AddFallbackContext(context);");

--- a/src/Namotion.Interceptor.Generator/SubjectMetadataExtractor.cs
+++ b/src/Namotion.Interceptor.Generator/SubjectMetadataExtractor.cs
@@ -127,8 +127,8 @@ internal static class SubjectMetadataExtractor
         var methods = CollectMethods(typeSymbol, semanticModel, location, diagnostics, cancellationToken);
 
         // Detect constructor state
-        var (needsGeneratedParameterlessConstructor, hasOrWillHaveParameterlessConstructor) =
-            DetectConstructorState(allTypeDeclarations);
+        var (needsGeneratedParameterlessConstructor, hasOrWillHaveParameterlessConstructor,
+            parameterlessConstructorSetsRequiredMembers) = DetectConstructorState(typeSymbol, allTypeDeclarations);
 
         return new ExtractionResult(
             new SubjectMetadata(
@@ -140,6 +140,7 @@ internal static class SubjectMetadataExtractor
                 containingTypes,
                 needsGeneratedParameterlessConstructor,
                 hasOrWillHaveParameterlessConstructor,
+                parameterlessConstructorSetsRequiredMembers,
                 baseClass,
                 properties,
                 methods),
@@ -808,29 +809,70 @@ internal static class SubjectMetadataExtractor
     /// Returns a tuple of:
     /// - NeedsGeneratedParameterlessConstructor: true if no constructor exists and we need to generate one
     /// - HasOrWillHaveParameterlessConstructor: true if we have or will generate a parameterless constructor
+    /// - ParameterlessConstructorSetsRequiredMembers: true if the emitted constructors have to carry [SetsRequiredMembers]
     /// </summary>
-    private static (bool NeedsGeneratedParameterlessConstructor, bool HasOrWillHaveParameterlessConstructor) DetectConstructorState(
+    private static (bool NeedsGeneratedParameterlessConstructor, bool HasOrWillHaveParameterlessConstructor, bool ParameterlessConstructorSetsRequiredMembers) DetectConstructorState(
+        INamedTypeSymbol typeSymbol,
         TypeDeclarationSyntax[] allTypeDeclarations)
     {
+        // A static constructor is not an instance constructor, so nothing can chain to it and it
+        // never stands in for the parameterless one the emitted constructors need.
         var firstConstructor = allTypeDeclarations
             .SelectMany(c => c.Members)
             .OfType<ConstructorDeclarationSyntax>()
-            .FirstOrDefault();
+            .FirstOrDefault(constructor => !constructor.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.StaticKeyword)));
 
-        // If no constructor exists, we need to generate a parameterless one
-        if (firstConstructor == null)
+        // No constructor at all: generate a parameterless one. A first constructor with parameters
+        // means there is no parameterless one to chain to, so nothing is generated.
+        var needsGeneratedParameterlessConstructor = firstConstructor is null;
+        var hasOrWillHaveParameterlessConstructor = firstConstructor is null or { ParameterList.Parameters.Count: 0 };
+
+        return (
+            needsGeneratedParameterlessConstructor,
+            hasOrWillHaveParameterlessConstructor,
+            hasOrWillHaveParameterlessConstructor && ChainedConstructorSetsRequiredMembers(typeSymbol));
+    }
+
+    /// <summary>
+    /// Whether the parameterless constructor the emitted constructors chain to carries
+    /// [SetsRequiredMembers]. CS9039 rejects a constructor that chains to one with the attribute unless
+    /// it repeats it, for the implicit base chain as much as for ": this()", so the emitted constructors
+    /// mirror it. Read off symbols because the constructor may sit in another partial file than the one
+    /// this extraction's semantic model belongs to.
+    /// </summary>
+    /// <remarks>
+    /// The walk passes through implicitly declared constructors: on a subject the generator replaces
+    /// each of those with an explicit one that mirrors its own base, and that emitted constructor is
+    /// not visible in this compilation's symbols. Passing through a non-subject one is safe too,
+    /// because an implicit constructor above an attributed one is already CS9039 in its own right.
+    /// Constructors read from metadata are never implicit, so a referenced assembly ends the walk on
+    /// its real attribute state. The walk stops at a type that declares required members of its own,
+    /// because an emitted constructor claiming to set them would be lying; that subject keeps the
+    /// CS9039 and has to declare the initializing constructor itself.
+    /// </remarks>
+    private static bool ChainedConstructorSetsRequiredMembers(INamedTypeSymbol typeSymbol)
+    {
+        for (var type = typeSymbol; type is not null; type = type.BaseType)
         {
-            return (NeedsGeneratedParameterlessConstructor: true, HasOrWillHaveParameterlessConstructor: true);
+            var constructor = type.InstanceConstructors.FirstOrDefault(candidate => candidate.Parameters.Length == 0);
+            if (constructor is null)
+            {
+                return false;
+            }
+
+            if (!constructor.IsImplicitlyDeclared)
+            {
+                return constructor.GetAttributes().Any(attribute =>
+                    SymbolExtensions.IsTypeOrInheritsFrom(attribute.AttributeClass, KnownTypes.SetsRequiredMembersAttribute));
+            }
+
+            if (type.GetMembers().Any(member => member is IPropertySymbol { IsRequired: true } or IFieldSymbol { IsRequired: true }))
+            {
+                return false;
+            }
         }
 
-        // If first constructor is parameterless, we already have one
-        if (firstConstructor.ParameterList.Parameters.Count == 0)
-        {
-            return (NeedsGeneratedParameterlessConstructor: false, HasOrWillHaveParameterlessConstructor: true);
-        }
-
-        // First constructor has parameters, so we don't have a parameterless constructor
-        return (NeedsGeneratedParameterlessConstructor: false, HasOrWillHaveParameterlessConstructor: false);
+        return false;
     }
 
     private static string GetAccessModifier(SyntaxTokenList modifiers)


### PR DESCRIPTION
A subject with a `required` partial property and a `[SetsRequiredMembers]` constructor did not compile: the generated context-taking constructor chains to that constructor without repeating the attribute, which is `CS9039`. The generator now walks the base chain and repeats it where the chained constructor carries it.

Fixed alongside, in the same function: the constructor scan also matched static constructors, so a subject whose only declared constructor was static failed with `CS7036`.

Follow-up: #524

## Why

C# requires `[SetsRequiredMembers]` to be repeated on a constructor that chains to one carrying it, for the implicit base chain as much as for `: this()`.

Two properties of the walk are non-obvious and are the parts worth reviewing:

- It walks **through** implicitly declared constructors. On a subject the generator replaces each with an explicit one this compilation cannot see yet, so reading them as unattributed would be wrong. On anything else, an implicit constructor above an attributed one is already `CS9039` in its own right, so the shape cannot occur in a build that compiles.
- Constructors read from **metadata** are never implicit, so a referenced assembly ends the walk on its real attribute state. Verified directly, including with the attributed constructor two levels up in metadata.

The walk stops at a type declaring required members of its own, because an emitted constructor claiming to set them would be lying. An earlier revision of this branch did exactly that, turning master's `CS9039` build error into a type that compiled and left the member null.

## Contract

- A generated constructor carries `[SetsRequiredMembers]` exactly when the constructor it chains to does, transitively through generated ancestors.
- The generator never claims the attribute for a type that declares required members it does not set. Such a subject keeps its `CS9039` and has to declare the initializing constructor itself.

## Breaking changes

**API.** None.

**Behavior.** Three shapes that compiled before no longer do, all of which only worked because the static constructor was mistaken for a parameterless instance one:

- a primary constructor next to a static one now collides with the generated parameterless constructor (`CS0111`)
- a static constructor followed by a `params`-only or optional-only constructor now generates no context constructor at all, which is the silent one and the sharper of the two

Both only ever worked by luck. The generated context constructor is a single `AddFallbackContext` call a consumer can write by hand, so this costs convenience rather than capability, and no such shape exists in this repository.

**Contract.** None.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 4 | 73 | 14 | +59 |
| Tests and benchmarks | 2 | 279 | 0 | +279 |
| **Total** | **6** | **352** | **14** | **+338** |

The +59 breaks down as 31 code and 24 doc: the new walk is 21 code lines under 17 doc lines, and those comments answer the two non-obvious points above rather than restating the code.

## Verification

- [x] Documentation updated: ~~no public docs describe generated constructor shape~~
- [x] Unit tests: Generator 252, Core 157, Tracking 565, Validation 3
- [ ] Integration tests: ~~no connector or HomeBlaze UI code changed~~
- [ ] Benchmarks: ~~compile-time only, the emitted runtime code is unchanged for every existing subject~~
- [ ] Load tests: ~~not applicable~~
- [ ] Chaos tests: ~~not applicable~~

A whole-solution build under both generators with `EmitCompilerGeneratedFiles` produced identical output except this PR's own fixtures, so the emission delta for every existing subject is zero. The netstandard2.0 consumer polyfill binding was verified on a real project. The public API snapshot is unchanged.
