### PR TITLE
test: replace wall-clock budgets in MQTT monitor tests

### DIFF
--- a/src/Namotion.Interceptor.Mqtt.Tests/MqttConnectionMonitorTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/MqttConnectionMonitorTests.cs
@@ -1,9 +1,13 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using MQTTnet;
 using Namotion.Interceptor.Mqtt.Client;
 using Namotion.Interceptor.Mqtt.Mapping;
 using Namotion.Interceptor.Registry.Paths;
+using Namotion.Interceptor.Testing;
 using Xunit;
 
 namespace Namotion.Interceptor.Mqtt.Tests;
@@ -17,11 +21,25 @@ namespace Namotion.Interceptor.Mqtt.Tests;
 /// PingAsync succeeds → TryPingAsync returns true; PingAsync throws → TryPingAsync returns false.
 /// All tests mock PingAsync accordingly.
 ///
-/// Timeouts are generous (2-5s) to avoid flakiness on slow CI build agents.
+/// Every test drives the monitoring loop until the mock observes the behavior under test and then cancels,
+/// so no test paces itself with a wall clock. The cancellation sources are fail-fast watchdogs: they are
+/// reached only when the monitor never produces the expected observation, and a passing test never waits
+/// for them.
 /// </remarks>
-[Trait("Category", "Integration")]
 public class MqttConnectionMonitorTests
 {
+    /// <summary>Budget for an observation the monitor produces within milliseconds. Reached only on a genuine failure.</summary>
+    private static readonly TimeSpan ObservationTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>Hard stop for the monitoring loop so a hang fails the run instead of blocking the test host.</summary>
+    private static readonly TimeSpan MonitorWatchdogTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Poll interval for observations. The monitor reacts within a few milliseconds when it is configured that way.</summary>
+    private static readonly TimeSpan ObservationPollInterval = TimeSpan.FromMilliseconds(2);
+
+    /// <summary>Log fragment for the stale-signal branch, asserted present in one test and absent in another.</summary>
+    private const string StaleSignalIgnoredMessage = "Stale disconnect signal ignored";
+
     private static MqttClientConfiguration CreateConfiguration(
         TimeSpan? healthCheckInterval = null,
         TimeSpan? reconnectDelay = null,
@@ -34,8 +52,8 @@ public class MqttConnectionMonitorTests
         {
             BrokerHost = "localhost",
             Mapper = new MqttPathProviderMapper(new AttributeBasedPathProvider("test", '/')),
-            HealthCheckInterval = healthCheckInterval ?? TimeSpan.FromMilliseconds(100),
-            ReconnectDelay = reconnectDelay ?? TimeSpan.FromMilliseconds(10),
+            HealthCheckInterval = healthCheckInterval ?? TimeSpan.FromMilliseconds(5),
+            ReconnectDelay = reconnectDelay ?? TimeSpan.FromMilliseconds(5),
             MaximumReconnectDelay = maximumReconnectDelay ?? TimeSpan.FromSeconds(1),
             CircuitBreakerFailureThreshold = circuitBreakerFailureThreshold,
             CircuitBreakerCooldown = circuitBreakerCooldown ?? TimeSpan.FromMilliseconds(500),
@@ -48,16 +66,52 @@ public class MqttConnectionMonitorTests
         .Build();
 
     /// <summary>Helper: configure mock so PingAsync succeeds (→ TryPingAsync returns true).</summary>
-    private static void SetupPingHealthy(Mock<IMqttClient> client)
+    private static void SetupPingHealthy(Mock<IMqttClient> client, Action? onPing = null)
     {
-        client.Setup(c => c.PingAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        client.Setup(c => c.PingAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => onPing?.Invoke())
+            .Returns(Task.CompletedTask);
     }
 
     /// <summary>Helper: configure mock so PingAsync throws (→ TryPingAsync returns false).</summary>
-    private static void SetupPingUnhealthy(Mock<IMqttClient> client)
+    private static void SetupPingUnhealthy(Mock<IMqttClient> client, Action? onPing = null)
     {
         client.Setup(c => c.PingAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => onPing?.Invoke())
             .ThrowsAsync(new Exception("Ping failed"));
+    }
+
+    /// <summary>
+    /// Runs the monitoring loop until the observation holds, then cancels it and waits for it to unwind so that
+    /// every mock callback has completed before the caller reads its counters.
+    /// </summary>
+    private static async Task RunMonitorUntilAsync(
+        MqttConnectionMonitor monitor,
+        Func<bool> observation,
+        string observationDescription)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var monitorTask = monitor.MonitorConnectionAsync(cancellation.Token);
+        try
+        {
+            await AsyncTestHelpers.WaitUntilAsync(
+                observation, ObservationTimeout, ObservationPollInterval, observationDescription);
+        }
+        finally
+        {
+            // Unwind even when the observation never landed, otherwise the loop keeps running against a
+            // cancellation source that this method is about to dispose.
+            await cancellation.CancelAsync();
+            try
+            {
+                // Bounded join: a monitor that ignores its token fails the test at the watchdog
+                // instead of hanging the class.
+                await monitorTask.WaitAsync(MonitorWatchdogTimeout);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
     }
 
     [Fact]
@@ -66,24 +120,27 @@ public class MqttConnectionMonitorTests
         // Arrange
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.IsConnected).Returns(true);
-        SetupPingHealthy(client);
+
+        var healthCheckCount = 0;
+        SetupPingHealthy(client, () => Interlocked.Increment(ref healthCheckCount));
 
         var reconnectedCount = 0;
         var disconnectedCount = 0;
 
         var monitor = new MqttConnectionMonitor(
             client.Object,
-            CreateConfiguration(healthCheckInterval: TimeSpan.FromMilliseconds(50)),
+            CreateConfiguration(),
             CreateOptions,
-            onReconnected: _ => { reconnectedCount++; return Task.CompletedTask; },
-            onDisconnected: () => { disconnectedCount++; return Task.CompletedTask; },
+            onReconnected: _ => { Interlocked.Increment(ref reconnectedCount); return Task.CompletedTask; },
+            onDisconnected: () => { Interlocked.Increment(ref disconnectedCount); return Task.CompletedTask; },
             onError: _ => { },
             NullLogger.Instance);
 
-        // Act: let it run for several health check intervals
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        // Act: let the monitor complete several periodic health checks
+        await RunMonitorUntilAsync(
+            monitor,
+            () => Volatile.Read(ref healthCheckCount) >= 3,
+            "monitor did not complete three health checks");
 
         // Assert: healthy connection should never trigger reconnection or disconnect handlers
         Assert.Equal(0, reconnectedCount);
@@ -117,9 +174,10 @@ public class MqttConnectionMonitorTests
             NullLogger.Instance);
 
         // Act
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        await RunMonitorUntilAsync(
+            monitor,
+            () => Volatile.Read(ref reconnectedCount) >= 1,
+            "failed health check did not lead to a reconnection");
 
         // Assert
         Assert.True(reconnectedCount >= 1, $"Expected at least 1 reconnection but got {reconnectedCount}");
@@ -136,7 +194,6 @@ public class MqttConnectionMonitorTests
         var isBuffering = false;
         var transportTerminated = false;
         var reconnectAttempted = false;
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         client.Setup(c => c.IsConnected).Returns(() => isConnected);
         SetupPingUnhealthy(client);
@@ -159,13 +216,15 @@ public class MqttConnectionMonitorTests
             })
             .ReturnsAsync(new MqttClientConnectResult());
 
+        var reconnectedCount = 0;
+
         var monitor = new MqttConnectionMonitor(
             client.Object,
             CreateConfiguration(
                 healthCheckInterval: TimeSpan.FromMilliseconds(10),
                 reconnectDelay: TimeSpan.Zero),
             CreateOptions,
-            onReconnected: _ => cancellation.CancelAsync(),
+            onReconnected: _ => { Interlocked.Increment(ref reconnectedCount); return Task.CompletedTask; },
             onDisconnected: () =>
             {
                 isOperational = false;
@@ -176,7 +235,10 @@ public class MqttConnectionMonitorTests
             NullLogger.Instance);
 
         // Act
-        await monitor.MonitorConnectionAsync(cancellation.Token);
+        await RunMonitorUntilAsync(
+            monitor,
+            () => Volatile.Read(ref reconnectedCount) >= 1,
+            "failed ping on a connected client did not lead to a reconnection");
 
         // Assert
         Assert.False(isOperational);
@@ -188,10 +250,12 @@ public class MqttConnectionMonitorTests
     [Fact]
     public async Task WhenTransportTerminationFailsDuringShutdown_ThenTheFailureIsNotReported()
     {
-        // Arrange
+        // Arrange: the transport termination cancels the monitor and then fails, which is what a shutdown looks like
         var client = new Mock<IMqttClient>();
-        using var cancellation = new CancellationTokenSource();
+        using var watchdog = new CancellationTokenSource(MonitorWatchdogTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(watchdog.Token);
         var errorCount = 0;
+        var transportTerminationAttempted = false;
 
         client.Setup(c => c.IsConnected).Returns(true);
         SetupPingUnhealthy(client);
@@ -201,12 +265,14 @@ public class MqttConnectionMonitorTests
                 It.IsAny<CancellationToken>()))
             .Returns(() =>
             {
+                transportTerminationAttempted = true;
                 cancellation.Cancel();
                 return Task.FromException(new InvalidOperationException("transport stopped"));
             });
 
         var monitor = new MqttConnectionMonitor(
             client.Object,
+            // Long health check interval so the pending signal, not the periodic check, drives the single iteration
             CreateConfiguration(healthCheckInterval: TimeSpan.FromSeconds(30)),
             CreateOptions,
             onReconnected: _ => Task.CompletedTask,
@@ -225,6 +291,7 @@ public class MqttConnectionMonitorTests
         }
 
         // Assert
+        Assert.True(transportTerminationAttempted, "monitor never attempted to terminate the unhealthy transport");
         Assert.Equal(0, errorCount);
     }
 
@@ -255,21 +322,19 @@ public class MqttConnectionMonitorTests
             CreateConfiguration(healthCheckInterval: TimeSpan.FromSeconds(30)),
             CreateOptions,
             onReconnected: _ => Task.CompletedTask,
-            onDisconnected: () => { disconnectedCalled = true; return Task.CompletedTask; },
+            onDisconnected: () => { Volatile.Write(ref disconnectedCalled, true); return Task.CompletedTask; },
             onError: _ => { },
             NullLogger.Instance);
 
-        // Signal disconnect after a short delay (enough time for MonitorConnectionAsync to start waiting)
-        _ = Task.Run(async () =>
-        {
-            await Task.Delay(200);
-            monitor.SignalReconnectNeeded();
-        });
+        // The signal is a SemaphoreSlim(0, 1) that the monitoring loop waits on as its first statement, so
+        // releasing it before the loop starts is equivalent to releasing it once the loop is parked there.
+        monitor.SignalReconnectNeeded();
 
         // Act
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        await RunMonitorUntilAsync(
+            monitor,
+            () => Volatile.Read(ref disconnectedCalled) && Volatile.Read(ref connectCallCount) >= 1,
+            "disconnect signal did not lead to a reconnection");
 
         // Assert
         Assert.True(disconnectedCalled, "Expected onDisconnected to be called");
@@ -282,9 +347,17 @@ public class MqttConnectionMonitorTests
         // Arrange: client is connected and ping succeeds
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.IsConnected).Returns(true);
-        SetupPingHealthy(client);
+
+        // The long health check interval means the only ping in this test is the staleness verification of
+        // the signal, so a completed ping proves the monitor processed the signal.
+        var stalenessVerificationCount = 0;
+        SetupPingHealthy(client, () => Interlocked.Increment(ref stalenessVerificationCount));
 
         var disconnectedCount = 0;
+
+        // The sibling test asserts this log fragment is absent, which rots into a vacuous pass if the
+        // message is reworded. Recording it here, where the branch actually fires, makes a reword fail loudly.
+        var logger = new RecordingLogger();
 
         var monitor = new MqttConnectionMonitor(
             client.Object,
@@ -294,21 +367,20 @@ public class MqttConnectionMonitorTests
             onReconnected: _ => Task.CompletedTask,
             onDisconnected: () => { Interlocked.Increment(ref disconnectedCount); return Task.CompletedTask; },
             onError: _ => { },
-            NullLogger.Instance);
+            logger);
 
-        // Signal disconnect after a short delay — this is a "stale" signal because client is actually healthy
-        _ = Task.Run(async () =>
-        {
-            await Task.Delay(200);
-            monitor.SignalReconnectNeeded();
-        });
+        // This is a "stale" signal because the client is actually healthy
+        monitor.SignalReconnectNeeded();
 
-        // Act: run long enough for the signal to be received and verified via ping
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        // Act: run until the signal has been received and verified via ping
+        await RunMonitorUntilAsync(
+            monitor,
+            () => Volatile.Read(ref stalenessVerificationCount) >= 1,
+            "monitor did not verify the disconnect signal with a ping");
 
         // Assert: disconnect handler should NOT be called because ping confirmed healthy
+        Assert.True(logger.ContainsMessage(StaleSignalIgnoredMessage),
+            "the stale signal was not reported as ignored");
         Assert.Equal(0, disconnectedCount);
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -326,52 +398,50 @@ public class MqttConnectionMonitorTests
             .Callback(() => Interlocked.Increment(ref failureCount))
             .ThrowsAsync(new InvalidOperationException("Connection refused"));
 
+        // An open circuit breaker blocks the attempt before it reaches the client, so the log is the only
+        // place where the block becomes observable from outside the monitor.
+        var logger = new RecordingLogger();
+
         var monitor = new MqttConnectionMonitor(
             client.Object,
             CreateConfiguration(
-                healthCheckInterval: TimeSpan.FromMilliseconds(50),
-                reconnectDelay: TimeSpan.FromMilliseconds(10),
                 circuitBreakerFailureThreshold: 3,
-                // Long cooldown — once tripped, no more retries within the test window
+                // Long cooldown: once tripped, no more retries within the test window
                 circuitBreakerCooldown: TimeSpan.FromSeconds(60)),
             CreateOptions,
             onReconnected: _ => Task.CompletedTask,
             onDisconnected: () => Task.CompletedTask,
             onError: _ => { },
-            NullLogger.Instance);
+            logger);
 
-        // Act: run long enough for failures to accumulate then circuit breaker to block further attempts
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        // Act: run until the breaker refuses an attempt
+        await RunMonitorUntilAsync(
+            monitor,
+            () => logger.ContainsMessage("Circuit breaker open"),
+            "circuit breaker never blocked a reconnect attempt");
 
-        // Assert: exactly threshold failures should occur, then circuit breaker blocks the rest.
-        // Allow a small margin (up to threshold + 2) for timing races at the boundary.
-        Assert.True(failureCount >= 3, $"Expected at least 3 failures (threshold) but got {failureCount}");
-        Assert.True(failureCount <= 8, $"Expected circuit breaker to limit failures but got {failureCount}");
+        // Assert: the threshold number of attempts reaches the client, everything after it is blocked
+        Assert.Equal(3, failureCount);
     }
 
     [Fact]
     public async Task ExponentialBackoff_LimitsRetryRate()
     {
-        // Arrange: ConnectAsync always fails, so we can observe backoff through attempt count.
-        // With exponential backoff starting at 100ms (100, 200, 400, 800ms), in 2s we expect ~4-5 attempts.
-        // Without backoff (fixed 100ms), we'd get ~20 attempts. The count difference proves backoff works.
+        // Arrange: ConnectAsync always fails, so the delay between attempts is observable through their timestamps
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.IsConnected).Returns(false);
         SetupPingUnhealthy(client);
 
-        var failureCount = 0;
+        var attemptTimestamps = new ConcurrentQueue<long>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
-            .Callback(() => Interlocked.Increment(ref failureCount))
+            .Callback(() => attemptTimestamps.Enqueue(Stopwatch.GetTimestamp()))
             .ThrowsAsync(new Exception("Connection refused"));
 
         var monitor = new MqttConnectionMonitor(
             client.Object,
             CreateConfiguration(
-                healthCheckInterval: TimeSpan.FromMilliseconds(50),
-                reconnectDelay: TimeSpan.FromMilliseconds(100),
-                maximumReconnectDelay: TimeSpan.FromSeconds(2)),
+                reconnectDelay: TimeSpan.FromMilliseconds(5),
+                maximumReconnectDelay: TimeSpan.FromSeconds(1)),
             CreateOptions,
             onReconnected: _ => Task.CompletedTask,
             onDisconnected: () => Task.CompletedTask,
@@ -379,16 +449,18 @@ public class MqttConnectionMonitorTests
             NullLogger.Instance);
 
         // Act
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        await RunMonitorUntilAsync(
+            monitor,
+            () => attemptTimestamps.Count >= 5,
+            "monitor did not make five reconnect attempts");
 
-        // Assert: with exponential backoff (100, 200, 400, 800ms...) we expect significantly
-        // fewer attempts than we would with a fixed 100ms delay (~30 attempts in 3s).
-        // Allow generous bounds: at least 2 attempts, at most 12 (well below ~30 without backoff).
-        Assert.True(failureCount >= 2, $"Expected at least 2 attempts but got {failureCount}");
-        Assert.True(failureCount <= 12,
-            $"Expected exponential backoff to limit attempts but got {failureCount} (too many — backoff may not be working)");
+        // Assert: with the 5ms base delay doubling per failure, attempts 2 to 5 wait 10 + 20 + 40 + 80 = 150ms
+        // in total, against 20ms for a fixed delay. This is a lower bound on elapsed time and a delay never
+        // expires early, so a slow agent can only push the measurement further above the bound.
+        var timestamps = attemptTimestamps.ToArray();
+        var elapsedOverFourBackoffs = Stopwatch.GetElapsedTime(timestamps[0], timestamps[4]);
+        Assert.True(elapsedOverFourBackoffs >= TimeSpan.FromMilliseconds(100),
+            $"Expected exponential backoff to spread five attempts over at least 100ms but they took {elapsedOverFourBackoffs.TotalMilliseconds:F1}ms");
     }
 
     [Fact]
@@ -397,23 +469,29 @@ public class MqttConnectionMonitorTests
         // Arrange
         var client = new Mock<IMqttClient>();
         MqttConnectionMonitor? monitorRef = null;
+        var healthCheckAfterReconnectCount = 0;
 
-        // First health check: disconnected. After reconnect: connected.
+        // First health check: disconnected. After reconnect: connected, so every healthy ping is a
+        // health check that follows the reconnection.
         client.Setup(c => c.IsConnected).Returns(false);
         SetupPingUnhealthy(client);
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .Callback(() =>
             {
                 client.Setup(c => c.IsConnected).Returns(true);
-                SetupPingHealthy(client);
+                SetupPingHealthy(client, () => Interlocked.Increment(ref healthCheckAfterReconnectCount));
             })
             .ReturnsAsync(new MqttClientConnectResult());
 
         var disconnectedCount = 0;
 
+        // A drained signal and a signal that survived the drain both end in a ping against a healthy client,
+        // so the debug log is the only place where the difference becomes observable.
+        var logger = new RecordingLogger();
+
         var monitor = new MqttConnectionMonitor(
             client.Object,
-            CreateConfiguration(healthCheckInterval: TimeSpan.FromMilliseconds(100)),
+            CreateConfiguration(),
             CreateOptions,
             onReconnected: _ =>
             {
@@ -424,20 +502,21 @@ public class MqttConnectionMonitorTests
             },
             onDisconnected: () => { Interlocked.Increment(ref disconnectedCount); return Task.CompletedTask; },
             onError: _ => { },
-            NullLogger.Instance);
+            logger);
 
         monitorRef = monitor;
 
-        // Act
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        try { await monitor.MonitorConnectionAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        // Act: run until the monitoring loop has taken its first decision after the reconnection
+        await RunMonitorUntilAsync(
+            monitor,
+            () => Volatile.Read(ref healthCheckAfterReconnectCount) >= 1,
+            "monitor did not complete a health check after reconnecting");
 
-        // Assert: the stale signal should be drained after reconnect, so the client should
-        // NOT see additional disconnect calls beyond the initial one. We allow 1 because the
-        // signal may be picked up before the drain on the very first cycle.
-        Assert.True(disconnectedCount <= 1,
-            $"Expected at most 1 disconnect call (stale signals should be drained) but got {disconnectedCount}");
+        // Assert: the stale signal was drained, so the loop went back to periodic health checks instead of
+        // processing a signal it had raised itself, and the client never saw a second disconnect.
+        Assert.False(logger.ContainsMessage(StaleSignalIgnoredMessage),
+            "the disconnect signal raised during reconnection was not drained");
+        Assert.Equal(1, disconnectedCount);
     }
 
     [Fact]
@@ -509,5 +588,30 @@ public class MqttConnectionMonitorTests
 
         Assert.Throws<ArgumentNullException>(() => new MqttConnectionMonitor(
             client.Object, configuration, optionsBuilder, onReconnected, onDisconnected, onError, null!));
+    }
+
+    /// <summary>
+    /// Captures log messages so a test can observe a monitor decision that leaves no trace on the mocked client.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Enqueue(formatter(state, exception));
+        }
+
+        public bool ContainsMessage(string fragment)
+            => _messages.Any(message => message.Contains(fragment, StringComparison.Ordinal));
     }
 }

--- a/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
+++ b/src/Namotion.Interceptor.Tracking.Tests/Transactions/SubjectTransactionTests.cs
@@ -935,6 +935,7 @@ public class SubjectTransactionTests
         }, null));
 
         // Act
+        bool writerStopped;
         try
         {
             writerThread.Start();
@@ -945,10 +946,14 @@ public class SubjectTransactionTests
         {
             transaction.Dispose();
             continueComparison.Set();
-            Assert.True(writerThread.Join(TimeSpan.FromSeconds(10)), "writer did not stop");
+
+            // Only capture here: an assertion inside the finally would replace a failure from the try body,
+            // and a writer parked elsewhere never stops, so the join failure would hide the real one.
+            writerStopped = writerThread.Join(TimeSpan.FromSeconds(10));
         }
 
         // Assert
+        Assert.True(writerStopped, "writer did not stop");
         Assert.Null(escapedException);
         Assert.Same(valueWrittenAfterDispose, subject.Value);
         Assert.Empty(transaction.GetPendingChanges());


### PR DESCRIPTION
Zero production lines. `MqttConnectionMonitorTests` used fixed 2 to 5 second `CancellationTokenSource` deadlines as each test's **normal** end condition, the only place in the repo using a CTS that way rather than as a fail-fast watchdog. Twelve tests, 18 seconds.

Each test now waits for the observable it actually cares about and keeps a CTS purely as a watchdog. **18 s to 0.39 s**, and the whole MQTT project from 27 s to 9 s.

## Why this is worth doing, beyond the time

The original case was mechanical (a wall clock is what stopped the monitor) and neither the author nor the reviewer could reproduce flakiness: the old suite passed 22 of 22 runs under `taskset -c 0,1` with CPU burners. The stronger reason came out of defect injection:

- **The old suite hung the test host.** `WhenTransportTerminationFailsDuringShutdown` used a `CancellationTokenSource` with no timeout at all, and its only cancel path was inside the mocked `DisconnectAsync`. With that call skipped in production, the old suite ran past 120 s with no output and had to be killed. The new version fails at its watchdog in 30 s.
- **Two old assertions could not fail.** `failureCount >= 3 && <= 8` is now `Assert.Equal(3, ...)`, which is structurally exact. A `<= 1` assertion that could not fail now also checks the log the drain branch writes.
- Two defects are caught **only** by the new tests: removing the stale-signal drain, and an off-by-one in the circuit breaker threshold.

A log-message canary was added after review found the negative log assertion could rot silently: rewording the production line made a real defect invisible while all twelve tests stayed green. The canary now fails loudly in the test where that branch fires.

## Category tag

The class carried `[Trait("Category", "Integration")]` but is pure Moq: no socket, no broker, no port. The default CI filter `Category!=Integration` was skipping it on every PR, and the integration job that would run it is gated on MQTT paths, so a shared-core change breaking the reconnect monitor never ran it. The tag is removed, which adds about 0.4 s to every PR and 12 tests of real coverage.

## Known limitation, recorded rather than papered over

A `ReconnectDelay` regression that ignores configuration is caught by the old suite and **not** by this one: the generous observation budget swallows it. An upper bound on the backoff span was tried and withdrawn after measurement, because under two contended cores the span reaches 850 to 1177 ms against a 176 ms nominal maximum, so any bound tight enough to catch it is too unstable. The mitigating fact is that this defect class shows as a 60x jump in suite wall time.

## Also folded in

`SubjectTransactionTests` had the repo's only `Assert` inside a `finally`, which could replace a real assertion failure with "writer did not stop".

## Verification

- [x] Unit tests: MQTT 103, Tracking 565
- [x] 20 runs including under `taskset -c 0,1`, 0 failures
- [x] Defect injection: five injections, each caught by exactly the expected test
- [x] Zero production lines changed
