### PR TITLE
fix: gate the HomeBlaze E2E fixture on the loaded root subject

### DIFF
--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/HomeBlaze.E2E.Tests.csproj
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/HomeBlaze.E2E.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Namotion.Interceptor.Testing\Namotion.Interceptor.Testing.csproj" />
     <ProjectReference Include="..\HomeBlaze\HomeBlaze.csproj" />
     <ProjectReference Include="..\MyCompany.SamplePlugin1.HomeBlaze\MyCompany.SamplePlugin1.HomeBlaze.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/PlaywrightFixture.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/PlaywrightFixture.cs
@@ -1,5 +1,8 @@
 using HomeBlaze.Components;
+using HomeBlaze.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
+using Namotion.Interceptor.Testing;
 
 namespace HomeBlaze.E2E.Tests.Infrastructure;
 
@@ -25,6 +28,16 @@ public class PlaywrightFixture : IAsyncLifetime
         // Force server to start by accessing ServerAddress which calls EnsureServer
         var address = _factory.ServerAddress;
         Console.WriteLine($"Test server started at: {address}");
+
+        // The root subject is loaded by a background service, so the server serves requests before
+        // the object graph behind them exists. A page that renders the browser in that window gets
+        // an empty pane list and never rebuilds it, so whichever test runs first waits out its full
+        // timeout for a button that will not appear.
+        var rootManager = _factory.ServerServices.GetRequiredService<RootManager>();
+        await AsyncTestHelpers.WaitUntilAsync(
+            () => rootManager.IsLoaded,
+            TimeSpan.FromSeconds(60),
+            message: "The root subject was not loaded before the tests started");
 
         // Initialize Playwright and launch browser
         _playwright = await Playwright.CreateAsync();

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/WebTestingHostFactory.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/WebTestingHostFactory.cs
@@ -28,6 +28,20 @@ public class WebTestingHostFactory<TProgram> : WebApplicationFactory<TProgram>
         }
     }
 
+    /// <summary>
+    /// The services of the Kestrel host that serves the tests. This is a different container from
+    /// <see cref="WebApplicationFactory{TProgram}.Services"/>, which belongs to the TestServer host
+    /// the base class requires and which no request ever reaches.
+    /// </summary>
+    public IServiceProvider ServerServices
+    {
+        get
+        {
+            EnsureServer();
+            return _kestrelHost!.Services;
+        }
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseUrls("http://127.0.0.1:0");

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/MarkdownEditorTests.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/MarkdownEditorTests.cs
@@ -77,12 +77,6 @@ public class MarkdownEditorTests
         var editorContent = page.Locator(".monaco-editor .view-lines");
         await editorContent.ClickAsync();
 
-        // Assert: Edit expression button may be visible if cursor is in an expression
-        var editButton = page.Locator("[data-testid='edit-expression-button']");
-        // Allow for the button not appearing if cursor is not in the right place
-        var isVisible = await editButton.IsVisibleAsync();
-        // Note: This test verifies the button exists when we're in the right spot
-        // We don't fail if it's not visible since cursor positioning is tricky
     }
 
     [Fact]
@@ -95,18 +89,11 @@ public class MarkdownEditorTests
         await page.GotoAsync($"{_fixture.ServerAddress}pages/Demo/Inline.md");
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        // Initially, edit buttons on widgets should not be visible
-        var widgetEditButton = page.Locator("[data-testid='edit-subject-button']").First;
-        var initiallyVisible = await widgetEditButton.IsVisibleAsync();
-
         // Open Inline mode via dropdown menu (enables IsEditing on widgets)
         var editMenu = page.Locator("[data-testid='edit-mode-menu']");
         await Assertions.Expect(editMenu).ToBeVisibleAsync(new() { Timeout = 30000 });
         await editMenu.ClickAsync();
         await page.GetByText("Inline").ClickAsync();
-
-        // Wait for edit mode to activate
-        await page.WaitForTimeoutAsync(500);
 
         // After enabling edit mode, edit buttons on widgets should be visible
         var editButtonAfter = page.Locator("[data-testid='edit-subject-button']").First;
@@ -133,16 +120,11 @@ public class MarkdownEditorTests
         var monacoEditor = page.Locator(".monaco-editor");
         await Assertions.Expect(monacoEditor).ToBeVisibleAsync(new() { Timeout = 30000 });
 
-        // Wait for decorations to be applied
-        await page.WaitForTimeoutAsync(1000);
-
-        // Assert: Decoration CSS classes should be present
-        // Note: The .subject-block-decoration class should be applied to decorated regions
+        // Assert: the decorations are applied from the editor's OnDidInit callback, a round trip
+        // after .monaco-editor appears, so assert on the locator, which retries, instead of
+        // counting once.
         var decorations = page.Locator(".subject-block-decoration");
-        var decorationCount = await decorations.CountAsync();
-
-        // There should be at least one decoration if the file has subject blocks
-        // If no decorations, the test still passes (decoration application is async)
+        await Assertions.Expect(decorations.First).ToBeVisibleAsync(new() { Timeout = 30000 });
     }
 
     [Fact]

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/SubjectSetupDialogTests.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/SubjectSetupDialogTests.cs
@@ -12,10 +12,7 @@ namespace HomeBlaze.E2E.Tests;
 public class SubjectSetupDialogTests
 {
     private const int PageLoadTimeout = 30000;
-    private const int NetworkIdleTimeout = 15000;
     private const int ElementVisibilityTimeout = 5000;
-    private const int BlazorRenderDelay = 500;
-    private const int InputBindingDelay = 300;
 
     private readonly PlaywrightFixture _fixture;
 
@@ -26,7 +23,16 @@ public class SubjectSetupDialogTests
 
     #region Helper Methods
 
-    private async Task NavigateToDemoFolderAsync(IPage page)
+    /// <summary>
+    /// The Create operation of the subject pane the wizard is opened from. Scoped to the pane
+    /// container so it cannot resolve to the wizard's own Create button on step 2.
+    /// </summary>
+    private static ILocator PaneCreateButton(IPage page)
+    {
+        return page.Locator("#scrollContainer button:has-text('Create')").First;
+    }
+
+    private async Task OpenSubjectBrowserAsync(IPage page)
     {
         await page.GotoAsync($"{_fixture.ServerAddress}");
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
@@ -36,28 +42,34 @@ public class SubjectSetupDialogTests
         await browserLink.ClickAsync();
         await page.WaitForURLAsync(url => url.Contains("/browser"), new() { Timeout = PageLoadTimeout });
 
-        var demoFolder = page.GetByText("demo").First;
-        await demoFolder.ClickAsync();
-        await page.WaitForTimeoutAsync(BlazorRenderDelay);
+        // The URL changes before the browser has built its panes, and the pane's Create operation is
+        // what the wizard is opened from, so that button is the condition the next step depends on.
+        var createButton = PaneCreateButton(page);
+        await Assertions.Expect(createButton).ToBeVisibleAsync(new() { Timeout = PageLoadTimeout });
     }
 
     private async Task OpenWizardAsync(IPage page)
     {
-        var createButton = page.Locator("button:has-text('Create')").First;
-        await createButton.ClickAsync();
+        await PaneCreateButton(page).ClickAsync();
 
         var wizard = page.Locator("[data-testid='create-subject-wizard']");
         await Assertions.Expect(wizard).ToBeVisibleAsync(new() { Timeout = ElementVisibilityTimeout });
 
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = NetworkIdleTimeout });
-        await page.WaitForTimeoutAsync(BlazorRenderDelay);
+        // The dialog frame appears before its content, and Step1_OnOpen counts type cards with
+        // CountAsync, which does not retry, so the cards are the condition to hold for.
+        var firstTypeCard = page.Locator("[data-testid^='type-card-']").First;
+        await Assertions.Expect(firstTypeCard).ToBeVisibleAsync(new() { Timeout = ElementVisibilityTimeout });
     }
 
     private async Task EnterNameAsync(IPage page, string name)
     {
         var nameInput = page.GetByLabel("Name");
         await nameInput.FillAsync(name);
-        await page.WaitForTimeoutAsync(InputBindingDelay);
+
+        // The field binds immediately and the circuit delivers events in order, so a later click
+        // cannot overtake the name this fill sends. This assertion only catches Blazor
+        // reverting the field; it is not a round trip to the server.
+        await Assertions.Expect(nameInput).ToHaveValueAsync(name, new() { Timeout = ElementVisibilityTimeout });
     }
 
     private async Task SelectTypeAsync(IPage page, string typeTestId)
@@ -89,7 +101,7 @@ public class SubjectSetupDialogTests
     public async Task Step1_OnOpen_ShowsExpectedUIElements()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         // Wizard dialog should be visible
@@ -127,7 +139,7 @@ public class SubjectSetupDialogTests
     public async Task Step1_TypeSelection_ShowsNextButtonAndHighlight()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         // Click type card without entering name
@@ -151,7 +163,7 @@ public class SubjectSetupDialogTests
     public async Task Step1_EnterNameAndSelectType_AutoAdvancesToStep2()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         // Enter name first, then select type - should auto-advance
@@ -174,7 +186,7 @@ public class SubjectSetupDialogTests
     public async Task Step2_OnAdvance_ShowsConfigurationAndCreateButton()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         // Advance to step 2 with Motor type
@@ -212,7 +224,7 @@ public class SubjectSetupDialogTests
     public async Task Navigation_CancelButton_ClosesDialog()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         var cancelButton = page.Locator("[data-testid='cancel-button']");
@@ -226,7 +238,7 @@ public class SubjectSetupDialogTests
     public async Task Navigation_BackButton_ReturnsToStep1AndPreservesState()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         // Enter a specific name and advance to step 2
@@ -265,7 +277,7 @@ public class SubjectSetupDialogTests
     public async Task Validation_NameErrors_PreventAdvancing()
     {
         var page = await _fixture.CreatePageAsync();
-        await NavigateToDemoFolderAsync(page);
+        await OpenSubjectBrowserAsync(page);
         await OpenWizardAsync(page);
 
         // Test 1: Empty name shows required error


### PR DESCRIPTION
Zero production lines. `SubjectSetupDialogTests.Validation_NameErrors_PreventAdvancing` failed on about two of three CI runs with a 30 second Playwright timeout inside `OpenWizardAsync`.

## Why

The fixture started driving the UI before the application had a root subject. `RootManager` is a `BackgroundService` that assigns `Root` inside `ExecuteAsync`, so `IHost.Start()` returns while `Root` is still null and Kestrel is already serving. `SubjectBrowser.RebuildFromPath` returns early when `Root` is null, and `OnParametersSet` only rebuilds when the pane list is empty, which nothing triggers again after the route settles. So the pane list stays empty **for the life of that circuit** and the Create button never appears.

Only the first test in the assembly is affected, which matches the CI timeline. The decisive evidence is the CI call log: `waiting for Locator("button:has-text('Create')").First` with no `locator resolved to` line, so the element never matched at all rather than being briefly unactionable.

The fixture now waits for `RootManager.IsLoaded` before launching the browser.

## Two things a reviewer should know

**The container choice cannot be justified by any test.** `WebApplicationFactory.Services` is the TestServer host's container, bound to no real port; the gate uses a new `ServerServices` property exposing the **Kestrel** host's container. They are two full applications with two `RootManager` singletons. Waiting on the wrong one passes every test today, because both load within microseconds of each other, so the choice rests on the identity proof and not on a green suite. The comment on the property exists to stop a later reader shortening it.

**`NavigateToDemoFolderAsync` never navigated to the demo folder.** Its `GetByText("demo")` locator matched a `MudNavGroup` header button, which only expands the drawer group. All seven tests in the file have always opened the wizard from the **root** container. The helper is now `OpenSubjectBrowserAsync` and drops the misleading click, which also removes a locator that was one render-order change from matching a real navigation link and steering the page off `/browser`.

## Also

Six hardcoded waits are replaced with condition waits, so no `WaitForTimeoutAsync`, `Task.Delay`, `Thread.Sleep` or `NetworkIdle` remains in the assembly. Two dead reads (assigned, never used) are deleted, and the markdown decoration test now asserts on a retrying locator instead of counting once and discarding the result, which made it pass with a CSS class that cannot exist.

## Product defect found, deliberately not fixed here

A user who opens `/browser` during the first seconds after process start gets a permanently blank browser until they navigate away or reload. `NavMenu` masks the same race with a refresh timer; `SubjectBrowser` has no equivalent and no subscription to root loading. The clean fix is upstream, moving the root load into host startup, and it would let this fixture gate be deleted afterwards. Filing separately.

## Verification

- [x] E2E suite 26/26, three consecutive runs
- [x] Reproduced with an injected 6 s delay in `RootManager.LoadAsync`: 3/3 failures on the baseline with the exact CI signature, passes with the fix
- [x] Gate-removal control reproduces the CI failure, so the gate is what prevents it
- [x] 16 runs across unconstrained, 2-core, and 2-core-plus-burners: 0 failures
- [x] Zero production lines changed
