### PR TITLE
fix: gate the HomeBlaze UI on the loaded root subject

### DIFF
--- a/src/HomeBlaze/HomeBlaze.AI/McpBuilderExtensions.cs
+++ b/src/HomeBlaze/HomeBlaze.AI/McpBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class McpBuilderExtensions
         params Func<McpToolProviderContext, IMcpToolProvider>[] additionalToolProviders)
     {
         return builder.WithSubjectRegistryTools(
-            sp => sp.GetRequiredService<RootManager>().Root!,
+            GetLoadedRoot,
             sp =>
             {
                 var typeRegistry = sp.GetRequiredService<SubjectTypeRegistry>();
@@ -59,7 +59,7 @@ public static class McpBuilderExtensions
                     .Where(type => type.GetCustomAttributes(typeof(ExcludeFromBrowsingAttribute), true).Length > 0)
                     .ToArray();
 
-                var rootSubjectProvider = () => sp.GetRequiredService<RootManager>().Root!;
+                var rootSubjectProvider = () => GetLoadedRoot(sp);
                 var configuration = new McpServerConfiguration
                 {
                     PathProvider = pathProvider,
@@ -86,5 +86,21 @@ public static class McpBuilderExtensions
 
                 return configuration;
             });
+    }
+
+    /// <summary>
+    /// Resolves the root subject for a request. The root is loaded by a background service, so a
+    /// request arriving before it exists gets a diagnosable error rather than a null reference,
+    /// and a failed load surfaces its own exception.
+    /// </summary>
+    private static IInterceptorSubject GetLoadedRoot(IServiceProvider serviceProvider)
+    {
+        var rootLoaded = serviceProvider.GetRequiredService<RootManager>().RootLoaded;
+        if (!rootLoaded.IsCompleted)
+        {
+            throw new InvalidOperationException("The root subject is still loading, try again shortly.");
+        }
+
+        return rootLoaded.GetAwaiter().GetResult();
     }
 }

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/HomeBlaze.E2E.Tests.csproj
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/HomeBlaze.E2E.Tests.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Namotion.Interceptor.Testing\Namotion.Interceptor.Testing.csproj" />
     <ProjectReference Include="..\HomeBlaze\HomeBlaze.csproj" />
     <ProjectReference Include="..\MyCompany.SamplePlugin1.HomeBlaze\MyCompany.SamplePlugin1.HomeBlaze.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/PlaywrightFixture.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/Infrastructure/PlaywrightFixture.cs
@@ -2,7 +2,6 @@ using HomeBlaze.Components;
 using HomeBlaze.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
-using Namotion.Interceptor.Testing;
 
 namespace HomeBlaze.E2E.Tests.Infrastructure;
 
@@ -29,15 +28,18 @@ public class PlaywrightFixture : IAsyncLifetime
         var address = _factory.ServerAddress;
         Console.WriteLine($"Test server started at: {address}");
 
-        // The root subject is loaded by a background service, so the server serves requests before
-        // the object graph behind them exists. A page that renders the browser in that window gets
-        // an empty pane list and never rebuilds it, so whichever test runs first waits out its full
-        // timeout for a button that will not appear.
+        // The root subject is loaded by a background service, so the server serves requests before the
+        // object graph behind them exists. The UI waits that window out on its own, but the wait would
+        // otherwise land inside the first test's own timeout instead of here.
         var rootManager = _factory.ServerServices.GetRequiredService<RootManager>();
-        await AsyncTestHelpers.WaitUntilAsync(
-            () => rootManager.IsLoaded,
-            TimeSpan.FromSeconds(60),
-            message: "The root subject was not loaded before the tests started");
+        try
+        {
+            await rootManager.RootLoaded.WaitAsync(TimeSpan.FromSeconds(60));
+        }
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException("The root subject was not loaded before the tests started", exception);
+        }
 
         // Initialize Playwright and launch browser
         _playwright = await Playwright.CreateAsync();

--- a/src/HomeBlaze/HomeBlaze.Host/Components/Layout/MainLayout.razor
+++ b/src/HomeBlaze/HomeBlaze.Host/Components/Layout/MainLayout.razor
@@ -45,10 +45,26 @@
             <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End"/>
         </MudAppBar>
         <MudDrawer id="nav-drawer" @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
-            <NavMenu/>
+            <NavMenu Root="@RootManager.Root"/>
         </MudDrawer>
         <MudMainContent Class="pt-16 px-4 pt-4">
-            @Body
+            @if (_isRootLoaded || IsErrorPage)
+            {
+                @Body
+            }
+            else if (_rootLoadFailed)
+            {
+                <MudAlert Severity="Severity.Error">
+                    The configuration could not be loaded. See the server log for details.
+                </MudAlert>
+            }
+            else
+            {
+                <div class="d-flex flex-column justify-center align-center" style="height: calc(100vh - 128px);">
+                    <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large"/>
+                    <MudText Class="mt-4">Loading configuration...</MudText>
+                </div>
+            }
         </MudMainContent>
     </MudLayout>
 </CascadingValue>
@@ -60,9 +76,13 @@
 </div>
 
 @code {
+    private readonly CancellationTokenSource _disposalTokenSource = new();
+
     private bool _drawerOpen = true;
     private bool _isDarkMode = true;
     private MudTheme? _theme;
+    private bool _isRootLoaded;
+    private bool _rootLoadFailed;
 
     protected override void OnInitialized()
     {
@@ -70,12 +90,41 @@
         DeveloperMode.OnChange += OnStateHasChanged;
         NavigationManager.LocationChanged += OnLocationChanged;
 
+        _isRootLoaded = RootManager.RootLoaded.IsCompletedSuccessfully;
+
         _theme = new()
         {
             PaletteLight = _lightPalette,
             PaletteDark = _darkPalette,
             LayoutProperties = new LayoutProperties()
         };
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || _isRootLoaded)
+        {
+            return;
+        }
+
+        // Not in OnInitializedAsync: prerendering withholds the response until every initialization task completes.
+        try
+        {
+            await RootManager.RootLoaded.WaitAsync(_disposalTokenSource.Token);
+            _isRootLoaded = true;
+        }
+        catch (OperationCanceledException) when (_disposalTokenSource.IsCancellationRequested || RootManager.RootLoaded.IsCanceled)
+        {
+            // Either this component or the host is going away, so there is nothing to report. A
+            // cancellation from anywhere else is a failed load and falls through to the alert.
+            return;
+        }
+        catch (Exception)
+        {
+            _rootLoadFailed = true;
+        }
+
+        StateHasChanged();
     }
 
     private void DrawerToggle()
@@ -105,6 +154,9 @@
     {
         DeveloperMode.OnChange -= OnStateHasChanged;
         NavigationManager.LocationChanged -= OnLocationChanged;
+
+        _disposalTokenSource.Cancel();
+        _disposalTokenSource.Dispose();
     }
 
     private void OnStateHasChanged()
@@ -125,6 +177,12 @@
         return NavigationResolver.GetChildItems(RootManager.Root)
             .Where(item => item.Location == NavigationLocation.AppBar && item.IsPage && item.Alignment == alignment);
     }
+
+    // The error page is shown exactly when the system is unhealthy, so it must render even if the
+    // root never loads.
+    private bool IsErrorPage => NavigationManager
+        .ToBaseRelativePath(NavigationManager.Uri)
+        .StartsWith("Error", StringComparison.OrdinalIgnoreCase);
 
     private bool IsActive(NavigationItem item)
     {

--- a/src/HomeBlaze/HomeBlaze.Host/Components/Layout/NavMenu.razor
+++ b/src/HomeBlaze/HomeBlaze.Host/Components/Layout/NavMenu.razor
@@ -1,7 +1,6 @@
 @using HomeBlaze.Components.Abstractions.Pages
 @using Microsoft.Extensions.Logging
 
-@inject RootManager RootManager
 @inject NavigationItemResolver NavigationResolver
 @inject NavigationManager NavigationManager
 @inject ILogger<NavMenu> Logger
@@ -9,7 +8,7 @@
 @implements IDisposable
 
 <MudNavMenu>
-    @if (RootManager.Root != null)
+    @if (Root != null)
     {
         @foreach (var item in GetRootItems().Where(i => i.Location == NavigationLocation.NavBar))
         {
@@ -37,6 +36,11 @@
 </MudNavMenu>
 
 @code {
+    // Taken as a parameter rather than read from the RootManager: a child with no parameters is not
+    // re-rendered when its parent re-renders, so the menu would miss the root appearing.
+    [Parameter]
+    public IInterceptorSubject? Root { get; set; }
+
     private Timer? _refreshTimer;
     private string _currentPath = string.Empty;
 
@@ -63,12 +67,12 @@
 
     private IEnumerable<NavigationItem> GetRootItems()
     {
-        if (RootManager.Root == null)
+        if (Root == null)
             return Enumerable.Empty<NavigationItem>();
 
         try
         {
-            return NavigationResolver.GetChildItems(RootManager.Root);
+            return NavigationResolver.GetChildItems(Root);
         }
         catch (Exception ex)
         {

--- a/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaServer.cs
+++ b/src/HomeBlaze/HomeBlaze.OpcUa/OpcUaServer.cs
@@ -223,13 +223,14 @@ public partial class OpcUaServer : BackgroundService, IConfigurable, ITitleProvi
                 return;
             }
 
-            // Wait for root to be loaded
-            while (!_rootManager.IsLoaded && !cancellationToken.IsCancellationRequested)
+            try
             {
-                await Task.Delay(100, cancellationToken);
+                // WaitAsync does not observe the token when the task is already complete, so the
+                // caller's cancellation has to be checked in its own right.
+                cancellationToken.ThrowIfCancellationRequested();
+                await _rootManager.RootLoaded.WaitAsync(cancellationToken);
             }
-
-            if (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested || _rootManager.RootLoaded.IsCanceled)
             {
                 Status = ServiceStatus.Stopped;
                 return;

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/RootManagerRootLoadedTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/RootManagerRootLoadedTests.cs
@@ -1,0 +1,120 @@
+using HomeBlaze.Services.Tests.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Namotion.Interceptor;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking;
+
+namespace HomeBlaze.Services.Tests;
+
+public class RootManagerRootLoadedTests : IDisposable
+{
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly List<IDisposable> _disposables = [];
+    private readonly List<string> _configurationFiles = [];
+
+    [Fact]
+    public async Task WhenWaiterSubscribesBeforeTheRootIsLoaded_ThenItReceivesTheRoot()
+    {
+        // Arrange
+        var rootManager = CreateRootManager(CreateConfigurationFile());
+        var waitTask = rootManager.RootLoaded;
+
+        // Act
+        await rootManager.StartAsync(CancellationToken.None);
+        var root = await waitTask.WaitAsync(WaitTimeout);
+
+        // Assert
+        Assert.Same(rootManager.Root, root);
+    }
+
+    [Fact]
+    public async Task WhenWaiterSubscribesAfterTheRootIsLoaded_ThenTheWaitIsAlreadyCompleted()
+    {
+        // Arrange
+        var rootManager = CreateRootManager(CreateConfigurationFile());
+        await rootManager.StartAsync(CancellationToken.None);
+        await rootManager.ExecuteTask!.WaitAsync(WaitTimeout);
+
+        // Act
+        var waitTask = rootManager.RootLoaded;
+
+        // Assert
+        Assert.True(waitTask.IsCompletedSuccessfully);
+        Assert.Same(rootManager.Root, await waitTask);
+    }
+
+    [Fact]
+    public async Task WhenTheRootFailsToLoad_ThenTheWaitFaultsWithTheLoadException()
+    {
+        // Arrange
+        var missingFile = Path.Combine(Path.GetTempPath(), $"homeblaze-missing-root-{Guid.NewGuid():N}.json");
+        var rootManager = CreateRootManager(missingFile);
+        var waitTask = rootManager.RootLoaded;
+
+        // Act
+        await rootManager.StartAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsAsync<FileNotFoundException>(() => waitTask.WaitAsync(WaitTimeout));
+        await Assert.ThrowsAsync<FileNotFoundException>(() => rootManager.ExecuteTask!.WaitAsync(WaitTimeout));
+        Assert.False(rootManager.IsLoaded);
+    }
+
+    private RootManager CreateRootManager(string configurationFilePath)
+    {
+        var typeProvider = new TypeProvider();
+        typeProvider.AddTypes([typeof(TestSubject)]);
+
+        var typeRegistry = new SubjectTypeRegistry(typeProvider);
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var serializer = new ConfigurableSubjectSerializer(typeProvider, serviceProvider);
+
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithFullPropertyTracking()
+            .WithRegistry();
+
+        var configuration = new Mock<IConfiguration>();
+        configuration
+            .Setup(instance => instance["HomeBlaze:RootConfigFile"])
+            .Returns(configurationFilePath);
+
+        RootManager? rootManager = null;
+        var pathResolver = new SubjectPathResolver(() => rootManager!.Root);
+        rootManager = new RootManager(typeRegistry, serializer, context, pathResolver, configuration.Object);
+
+        _disposables.Add(serviceProvider);
+        _disposables.Add(rootManager);
+        return rootManager;
+    }
+
+    private string CreateConfigurationFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"homeblaze-root-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, $$"""
+            {
+              "$type": "{{typeof(TestSubject).FullName}}",
+              "configProperty": "loaded"
+            }
+            """);
+
+        _configurationFiles.Add(path);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+
+        foreach (var configurationFile in _configurationFiles)
+        {
+            File.Delete(configurationFile);
+        }
+    }
+}

--- a/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
@@ -30,7 +30,8 @@ public class RootManager : BackgroundService, IConfigurationWriter
     public IInterceptorSubject? Root { get; internal set; }
 
     /// <summary>
-    /// Whether the root has been loaded.
+    /// Whether the root has been loaded. This turns true before the root's context is wired, so it
+    /// is a state probe rather than a gate. Wait on <see cref="RootLoaded"/> to use the graph.
     /// </summary>
     public bool IsLoaded => Root != null;
 

--- a/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
@@ -18,6 +18,10 @@ public class RootManager : BackgroundService, IConfigurationWriter
     private readonly IInterceptorSubjectContext _context;
     private readonly IConfiguration? _configuration;
     private readonly ILogger<RootManager>? _logger;
+
+    // Continuations run off the loading thread so a UI waiter cannot resume inline inside the load.
+    private readonly TaskCompletionSource<IInterceptorSubject> _rootLoaded = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     private string? _configurationPath;
 
     /// <summary>
@@ -63,16 +67,37 @@ public class RootManager : BackgroundService, IConfigurationWriter
         }
     }
 
+    /// <summary>
+    /// Completes with the root subject once the background load has attached its context, and faults
+    /// with the load exception so waiters do not hang on a root that will never appear.
+    /// Assigning <see cref="Root"/> directly does not complete it.
+    /// </summary>
+    public Task<IInterceptorSubject> RootLoaded => _rootLoaded.Task;
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await LoadAsync(stoppingToken);
+        try
+        {
+            _rootLoaded.TrySetResult(await LoadAsync(stoppingToken));
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Cancelled rather than faulted, so a waiting UI treats a normal shutdown as one.
+            _rootLoaded.TrySetCanceled(stoppingToken);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _rootLoaded.TrySetException(exception);
+            throw;
+        }
     }
 
-    private async Task LoadAsync(CancellationToken cancellationToken)
+    private async Task<IInterceptorSubject> LoadAsync(CancellationToken cancellationToken)
     {
         if (Root != null)
         {
-            return;
+            return Root;
         }
 
         var configFileName = _configuration?["HomeBlaze:RootConfigFile"] ?? "root.json";
@@ -93,6 +118,8 @@ public class RootManager : BackgroundService, IConfigurationWriter
 
         _logger?.LogInformation("Root loaded: {Type}", Root.GetType().FullName);
         _context.AddService(Root);
+
+        return Root;
     }
 
     /// <summary>


### PR DESCRIPTION
`RootManager` loads the root subject from a background service while Kestrel is already serving requests, so a page could render while `Root` was still null and never recover. The landing page stayed blank for good, because its redirect runs once in `OnInitialized` and returns silently on a null root. The subject browser kept an empty pane strip until the next navigation, because it rebuilds only when its pane list is empty and returns early on a null root. The pages route showed "Subject not found at path" for the whole window, and the nav drawer and app bar rendered empty.

`RootManager` now exposes `RootLoaded`, a task completed with the root once the background load has attached its context and registered it, and faulted with the load exception so nothing waits on a root that will never appear. `MainLayout` withholds `@Body` behind that task, so no page component is ever constructed against a null root. Startup itself is untouched: the host still starts, Kestrel still listens immediately, and only the rendering of the page body waits.

The root's two consumers outside the Blazor UI move onto the same signal. The OPC UA server waited by polling `IsLoaded` every 100 ms, which releases before the context is wired and spins forever on a load cancelled at shutdown. The MCP endpoint dereferenced `Root!` on every request and threw a `NullReferenceException` inside the tool pipeline; its provider is synchronous and its signature belongs to a shipped package, so it cannot wait and instead fails at the boundary with a message naming the cause.

## Why

The pages were not failing to *update*, they were being *constructed* too early and then left stale. Every one of them reads the graph once during initialization, so the fix has to keep them from being constructed at all until the graph exists, which is what withholding `@Body` does. Patching each page to re-check would have been four fixes that each have to stay correct forever.

Three things about the implementation are non-obvious and are the parts worth reviewing:

- **The signal is published from `ExecuteAsync`, not from inside the load.** A waiter released any earlier would see a root whose context has no registry yet, since `Root` is assigned before `AddFallbackContext` runs. Completing the task with `LoadAsync`'s return value makes that ordering a property of the code shape rather than a convention held in place by a comment. It is also strictly stronger than the `IsLoaded` flag it does not replace, which flips before the context is wired.
- **The wait lives in `OnAfterRenderAsync`, not `OnInitializedAsync`.** Under prerendering the endpoint renderer treats a pending initialization task as a non-streaming pending task and withholds the entire HTTP response until it completes, so awaiting there would have turned a cold-start request into a hung request with no bound anywhere on the path. `OnAfterRenderAsync` is not called during prerendering, so the prerendered pass emits the indicator immediately and the interactive circuit fills in the body.
- **`NavMenu` now takes the root as a parameter.** A child component emitted with no parameters is skipped when its parent re-renders, so the nav drawer was not refreshed when the gate opened and healed only through its own five second timer. The app bar needed nothing, because its items sit inside a `RenderFragment` parameter, which always counts as changed.

## Contract

- `RootLoaded` completes only after the root's context is attached and the root is registered as a context service. Assigning `Root` directly does not complete it.
- A failed load faults the task with the load exception. Host shutdown cancels it.
- The error route renders without waiting, so a broken system can still show its error page.

## Breaking changes

**API.** None.

**Behavior.** During the startup window a request now renders the chrome plus a loading indicator instead of a page built against a missing graph. Once the root is loaded, rendering is identical to before: the flag is already set in `OnInitialized`, the first render emits `@Body`, and no extra render or lifecycle call is introduced.

**Contract.** None.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 5 | 124 | 17 | +107 |
| Tests and test infrastructure | 3 | 131 | 10 | +121 |
| **Total** | **8** | **255** | **27** | **+228** |

`MainLayout` carries most of the production lines: the three-way gate in the markup, the wait, and the disposal token.

## Verification

- [x] Unit tests: `HomeBlaze.Services.Tests` 225 (including three new `RootManagerRootLoadedTests`), `HomeBlaze.Host.Services.Tests` 48, `HomeBlaze.Storage.Tests` 50, `HomeBlaze.Storage.Blazor.Tests` 11, `HomeBlaze.Plugins.Tests` 7, `HomeBlaze.AI.Tests` 27
- [x] Integration tests: HomeBlaze E2E 26 passing, with the fixture waiting on `RootLoaded` instead of polling `IsLoaded`
- [ ] Documentation updated: ~~the invariant lives on `RootLoaded`'s XML doc, and `docs/` carries no HomeBlaze host page~~
- [ ] Benchmarks: ~~UI only, no library code touched~~
- [ ] Load tests: ~~not applicable~~
- [ ] Chaos tests: ~~not applicable~~

The layout gate itself has no automated coverage. There is no bUnit in the repository, and the E2E fixture waits the load window out before the first test, so nothing exercises the indicator, the re-render when the gate opens, or the failure branch. The three unit tests cover `RootManager` only. Recorded rather than papered over.

## Follow-ups

- `OpcUaServer` has no test project at all, so neither the removed poll nor the new wait is covered by anything. A small `HomeBlaze.OpcUa.Tests` pinning the four status outcomes would be the cheapest way to close that.
