### PR TITLE
fix: Stop the Hue poll tripping the bridge rate limiter

### DIFF
--- a/src/HomeBlaze/HomeBlaze/Data/Docs/devices/PhilipsHue.md
+++ b/src/HomeBlaze/HomeBlaze/Data/Docs/devices/PhilipsHue.md
@@ -15,7 +15,7 @@ The Philips Hue integration connects to a Hue Bridge on the local network and ex
 |----------|------|---------|-------------|
 | `BridgeId` | string? | null | Bridge identifier from discovery |
 | `AppKey` | string? | null | Authentication key from Link button registration (secret) |
-| `PollingInterval` | TimeSpan | 500ms | UI polling interval for state updates |
+| `PollingInterval` | TimeSpan | 60s | Interval of the device set reconciliation poll |
 | `RetryInterval` | TimeSpan | 30s | Retry interval on connection failure |
 
 ### JSON Configuration
@@ -25,7 +25,7 @@ The Philips Hue integration connects to a Hue Bridge on the local network and ex
   "$type": "Namotion.Devices.Philips.Hue.HueBridge",
   "bridgeId": "MY_BRIDGE_ID",
   "appKey": "MY_APP_KEY",
-  "pollingInterval": "00:00:00.250",
+  "pollingInterval": "00:01:00",
   "retryInterval": "00:00:30"
 }
 ```
@@ -34,7 +34,7 @@ The Philips Hue integration connects to a Hue Bridge on the local network and ex
 
 ### Bridge Discovery
 
-When `BridgeId` and `AppKey` are configured, the bridge uses `HueBridgeDiscovery.FastDiscoveryWithNetworkScanFallbackAsync` to locate the bridge on the local network. It first tries mDNS/UPnP discovery (5-second timeout) and falls back to a network scan (30-second timeout).
+When `BridgeId` and `AppKey` are configured, the bridge tries each locator in turn until one reports the configured `BridgeId`: the Philips discovery endpoint, mDNS, SSDP (5-second budget each), then a local network scan (30-second budget). Each locator runs under its own timeout and a failure is kept local to it, so one locator being unavailable does not end the discovery. This matters in practice: the discovery endpoint answers 429 once it has been asked too often, and on macOS the mDNS locator can never bind port 5353 because the system resolver holds it.
 
 ### Link Button Registration
 
@@ -154,7 +154,7 @@ The Hue Bridge publishes real-time updates via Server-Sent Events (SSE). The `Hu
 
 ### Polling Cycle
 
-As a backup to the event stream, a full state refresh runs every 60 seconds. This catches any updates that may have been missed by the event stream (e.g., during brief disconnections).
+As a backup to the event stream, a full state refresh runs every 60 seconds. This catches any updates that may have been missed by the event stream (e.g., during brief disconnections). Its eleven resource requests are issued one at a time rather than concurrently, because the bridge rate limits a burst and answers the excess with a 429 and an HTML error page that the Hue SDK cannot parse.
 
 ## Resilience
 
@@ -164,7 +164,7 @@ The bridge runs in a reconnect loop inside `ExecuteAsync`:
 
 1. If `BridgeId` or `AppKey` is missing, the bridge enters an error state and waits for configuration changes via `IConfigurable.ApplyConfigurationAsync`
 2. On successful connection, it starts the event stream and polling loop in parallel
-3. If either task fails, the connection is torn down and retried after `RetryInterval`
+3. If the event stream fails, the connection is torn down and retried after `RetryInterval`. A failed poll is tolerated: the event stream carries the state changes and the poll only reconciles the device set, so the connection is kept until three consecutive polls fail
 4. Configuration changes (e.g., changing `BridgeId`) signal the bridge to restart the connection loop immediately
 
 ### Failure Modes and Recovery
@@ -174,7 +174,7 @@ The bridge runs in a reconnect loop inside `ExecuteAsync`:
 | Missing configuration       | Enters error state with message "Bridge not configured. Set BridgeId and AppKey." Waits for config change |
 | Bridge not found on network | Retries discovery every `RetryInterval` (default 30s)                                                     |
 | Event stream disconnect     | Connection teardown triggers reconnect loop                                                               |
-| API errors                  | Logged as warning, connection retried after `RetryInterval`                                               |
+| Poll errors                 | Logged as warning, connection kept; torn down and retried after three consecutive failures                |
 | Host shutdown               | Graceful stop via `CancellationToken`, status set to Stopped                                              |
 
 ## Known Limitations

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue.Tests/HuePollResponseTests.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue.Tests/HuePollResponseTests.cs
@@ -39,6 +39,24 @@ public class HuePollResponseTests
     }
 
     [Fact]
+    public void WhenTheBridgeReturnsDataAlongsideErrors_ThenTheResponseIsAccepted()
+    {
+        // Arrange - the SDK fills Errors from the body on the success path too, so a non-empty error
+        // list is not on its own a reason to discard a poll that carried usable data.
+        var response = new HueResponse<Device>
+        {
+            Data = [TestHelpers.CreateDevice("TEST001")],
+            Errors = [new HueError { Description = "Partial failure" }]
+        };
+
+        // Act
+        var result = response.ThrowOnError("device");
+
+        // Assert
+        Assert.Same(response, result);
+    }
+
+    [Fact]
     public void WhenTheBridgeReturnsNeitherDataNorErrors_ThenTheEmptyResponseIsAccepted()
     {
         // Arrange - a bridge with nothing of a given resource type is a legitimate answer, so an

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue.Tests/HuePollResponseTests.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue.Tests/HuePollResponseTests.cs
@@ -1,0 +1,55 @@
+using HueApi.Models;
+using Xunit;
+
+namespace Namotion.Devices.Philips.Hue.Tests;
+
+public class HuePollResponseTests
+{
+    [Fact]
+    public void WhenTheBridgeReturnsErrorsInsteadOfData_ThenTheResponseIsRejected()
+    {
+        // Arrange - the SDK does not throw for a non-success status that carries a JSON body. It
+        // returns an empty Data list, which the poll would otherwise read as "the bridge has no
+        // devices" and use to empty the model.
+        var response = new HueResponse<Device>
+        {
+            Errors = [new HueError { Description = "Rate limit exceeded" }]
+        };
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(() => response.ThrowOnError("device"));
+        Assert.Contains("device", exception.Message);
+        Assert.Contains("Rate limit exceeded", exception.Message);
+    }
+
+    [Fact]
+    public void WhenTheBridgeReturnsData_ThenTheResponseIsReturnedUnchanged()
+    {
+        // Arrange
+        var response = new HueResponse<Device>
+        {
+            Data = [TestHelpers.CreateDevice("TEST001")]
+        };
+
+        // Act
+        var result = response.ThrowOnError("device");
+
+        // Assert
+        Assert.Same(response, result);
+    }
+
+    [Fact]
+    public void WhenTheBridgeReturnsNeitherDataNorErrors_ThenTheEmptyResponseIsAccepted()
+    {
+        // Arrange - a bridge with nothing of a given resource type is a legitimate answer, so an
+        // empty list on its own must not be mistaken for a failure.
+        var response = new HueResponse<Device>();
+
+        // Act
+        var result = response.ThrowOnError("device");
+
+        // Assert
+        Assert.Same(response, result);
+        Assert.Empty(result.Data);
+    }
+}

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
@@ -306,10 +306,10 @@ public partial class HueBridge : BackgroundService,
                 IsConnected = true;
                 StatusMessage = null;
 
-                // Initial poll
-                await PollDevicesAsync(client, linkedCts.Token);
-
-                // Run event stream + periodic poll in parallel
+                // The polling loop reconciles before its first delay, so the first poll is covered by
+                // the same tolerance as every later one. Its failure counter is per connection, so
+                // leaving the first poll outside meant a bridge that rejected every poll reconnected
+                // forever without the tolerance ever running.
                 var eventStreamTask = RunEventStreamAsync(client, linkedCts.Token);
                 var pollingTask = RunPollingLoopAsync(client, linkedCts.Token);
 
@@ -430,8 +430,6 @@ public partial class HueBridge : BackgroundService,
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            await Task.Delay(EffectivePollingInterval, cancellationToken);
-
             try
             {
                 await PollDevicesAsync(client, cancellationToken);
@@ -457,6 +455,8 @@ public partial class HueBridge : BackgroundService,
                     "Keeping the connection and reconciling at the next interval.",
                     consecutiveFailures, MaxConsecutivePollFailures);
             }
+
+            await Task.Delay(EffectivePollingInterval, cancellationToken);
         }
     }
 

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
@@ -451,9 +451,14 @@ public partial class HueBridge : BackgroundService,
                 // Status stays Running because the connection and its event stream are live, so the
                 // message is the only signal that the device set is not being reconciled. Without it a
                 // bridge whose first poll failed would look healthy while exposing nothing at all.
-                StatusMessage = Devices.Length == 0
-                    ? $"No device list yet, reconciliation poll failed ({consecutiveFailures} of {MaxConsecutivePollFailures})."
-                    : $"Device list may be stale, reconciliation poll failed ({consecutiveFailures} of {MaxConsecutivePollFailures}).";
+                // LastUpdated rather than an empty device set, which is also what a bridge that owns
+                // nothing reports. The cause is appended because this message is the only one a caller
+                // sees while the failure is tolerated, and GetOrCreateClient splices it into its refusal.
+                StatusMessage =
+                    (LastUpdated is null
+                        ? $"No device list yet, reconciliation poll failed ({consecutiveFailures} of {MaxConsecutivePollFailures}): "
+                        : $"Device list may be stale, reconciliation poll failed ({consecutiveFailures} of {MaxConsecutivePollFailures}): ")
+                    + exception.Message;
 
                 // A teardown takes the event stream with it, and that stream carries the state
                 // changes; this poll only reconciles the device set.

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
@@ -9,6 +9,7 @@ using HomeBlaze.Abstractions.Networking;
 using HomeBlaze.Abstractions.Sensors;
 using HueApi;
 using HueApi.BridgeLocator;
+using HueApi.Models;
 using HueApi.Models.Responses;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -40,6 +41,8 @@ public partial class HueBridge : BackgroundService,
     /// so the brightness is remembered for the next time the light is turned on.
     /// </summary>
     internal const int SetBrightnessWhileOffDelayMs = 3000;
+
+    private const int MaxConsecutivePollFailures = 3;
 
     private readonly ILogger<HueBridge> _logger;
     private readonly SemaphoreSlim _configChangedSignal = new(0, 1);
@@ -181,11 +184,16 @@ public partial class HueBridge : BackgroundService,
                 throw new InvalidOperationException("Bridge is not configured or not discovered.");
             }
 
+            // The SDK passes no timeout, leaving HttpClient's 100s default. A poll is 11 sequential
+            // requests, so an unresponsive bridge would otherwise stall one for nearly twenty minutes.
             var httpClient = new HttpClient(new HttpClientHandler
             {
                 ServerCertificateCustomValidationCallback =
                     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-            });
+            })
+            {
+                Timeout = TimeSpan.FromSeconds(10)
+            };
 
             try
             {
@@ -272,10 +280,7 @@ public partial class HueBridge : BackgroundService,
                 }
 
                 // Discovery
-                var bridges = await HueBridgeDiscovery.FastDiscoveryWithNetworkScanFallbackAsync(
-                    TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30));
-
-                var bridge = bridges.FirstOrDefault(locatedBridge => locatedBridge.BridgeId == BridgeId);
+                var bridge = await DiscoverBridgeAsync(stoppingToken);
                 if (bridge == null)
                 {
                     StatusMessage = "Bridge not found on network";
@@ -352,6 +357,55 @@ public partial class HueBridge : BackgroundService,
         StatusMessage = null;
     }
 
+    /// <summary>
+    /// Finds the configured bridge, keeping a failure local to the locator that caused it: the SDK's
+    /// aggregate helpers let one locator's exception abandon the whole discovery.
+    /// </summary>
+    private async Task<LocatedBridge?> DiscoverBridgeAsync(CancellationToken cancellationToken)
+    {
+        IBridgeLocator[] locators =
+        [
+            new HttpBridgeLocator(),
+            new MdnsBridgeLocator(),
+            new SsdpBridgeLocator(),
+            new LocalNetworkScanBridgeLocator()
+        ];
+
+        foreach (var locator in locators)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // The network scan probes the whole subnet, so it gets the longer budget and goes last.
+            var timeout = locator is LocalNetworkScanBridgeLocator
+                ? TimeSpan.FromSeconds(30)
+                : TimeSpan.FromSeconds(5);
+
+            using var locatorCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            locatorCancellation.CancelAfter(timeout);
+
+            LocatedBridge? bridge;
+            try
+            {
+                // Enumerated inside the try: the interface returns IEnumerable, so a lazy locator
+                // would otherwise throw past the catch that exists to contain it.
+                var bridges = await locator.LocateBridgesAsync(locatorCancellation.Token);
+                bridge = bridges.FirstOrDefault(locatedBridge => locatedBridge.BridgeId == BridgeId);
+            }
+            catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning(exception, "Hue locator {Locator} failed.", locator.GetType().Name);
+                continue;
+            }
+
+            if (bridge is not null)
+            {
+                return bridge;
+            }
+        }
+
+        return null;
+    }
+
     private async Task RunEventStreamAsync(LocalHueApi client, CancellationToken cancellationToken)
     {
         client.OnEventStreamMessage += OnEventStreamMessage;
@@ -372,45 +426,63 @@ public partial class HueBridge : BackgroundService,
 
     private async Task RunPollingLoopAsync(LocalHueApi client, CancellationToken cancellationToken)
     {
+        var consecutiveFailures = 0;
+
         while (!cancellationToken.IsCancellationRequested)
         {
             await Task.Delay(EffectivePollingInterval, cancellationToken);
-            await PollDevicesAsync(client, cancellationToken);
+
+            try
+            {
+                await PollDevicesAsync(client, cancellationToken);
+                consecutiveFailures = 0;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                consecutiveFailures++;
+                if (consecutiveFailures >= MaxConsecutivePollFailures)
+                {
+                    throw;
+                }
+
+                // A teardown takes the event stream with it, and that stream carries the state
+                // changes; this poll only reconciles the device set.
+                _logger.LogWarning(
+                    exception,
+                    "Hue poll failed ({FailureCount} in a row, connection dropped after {MaxFailureCount}). " +
+                    "Keeping the connection and reconciling at the next interval.",
+                    consecutiveFailures, MaxConsecutivePollFailures);
+            }
         }
     }
 
     private async Task PollDevicesAsync(LocalHueApi client, CancellationToken cancellationToken)
     {
-        var zigbeeConnectivitiesTask = client.ZigbeeConnectivity.GetAllAsync();
-        var devicePowersTask = client.DevicePower.GetAllAsync();
-        var devicesTask = client.Device.GetAllAsync();
-        var roomsTask = client.Room.GetAllAsync();
-        var zonesTask = client.Zone.GetAllAsync();
-        var lightsTask = client.Light.GetAllAsync();
-        var buttonsTask = client.Button.GetAllAsync();
-        var motionsTask = client.Motion.GetAllAsync();
-        var groupedLightsTask = client.GroupedLight.GetAllAsync();
-        var temperaturesTask = client.Temperature.GetAllAsync();
-        var lightLevelsTask = client.LightLevel.GetAllAsync();
+        // Issued one at a time: 11 at once trips the bridge's rate limiter, which answers 429 with an
+        // HTML error page that the SDK then fails to parse as JSON.
+        async Task<HueResponse<T>> PollAsync<T>(Func<Task<HueResponse<T>>> request, string resource)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return (await request()).ThrowOnError(resource);
+        }
 
-        await Task.WhenAll(
-            zigbeeConnectivitiesTask, devicePowersTask, devicesTask, roomsTask, zonesTask,
-            lightsTask, buttonsTask, motionsTask, groupedLightsTask, temperaturesTask, lightLevelsTask);
-
-        var zigbeeConnectivities = zigbeeConnectivitiesTask.Result;
-        var devicePowers = devicePowersTask.Result;
-        var devices = devicesTask.Result;
-        var rooms = roomsTask.Result;
-        var zones = zonesTask.Result;
-        var lights = lightsTask.Result;
-        var buttons = buttonsTask.Result;
-        var motions = motionsTask.Result;
-        var groupedLights = groupedLightsTask.Result;
-        var temperatures = temperaturesTask.Result;
-        var lightLevels = lightLevelsTask.Result;
+        var zigbeeConnectivities = await PollAsync(() => client.ZigbeeConnectivity.GetAllAsync(), "zigbee_connectivity");
+        var devicePowers = await PollAsync(() => client.DevicePower.GetAllAsync(), "device_power");
+        var devices = await PollAsync(() => client.Device.GetAllAsync(), "device");
+        var rooms = await PollAsync(() => client.Room.GetAllAsync(), "room");
+        var zones = await PollAsync(() => client.Zone.GetAllAsync(), "zone");
+        var lights = await PollAsync(() => client.Light.GetAllAsync(), "light");
+        var buttons = await PollAsync(() => client.Button.GetAllAsync(), "button");
+        var motions = await PollAsync(() => client.Motion.GetAllAsync(), "motion");
+        var groupedLights = await PollAsync(() => client.GroupedLight.GetAllAsync(), "grouped_light");
+        var temperatures = await PollAsync(() => client.Temperature.GetAllAsync(), "temperature");
+        var lightLevels = await PollAsync(() => client.LightLevel.GetAllAsync(), "light_level");
 
         var existingDevices = Devices;
-
         var allDevices = devices.Data
             .Select(device =>
             {
@@ -733,7 +805,7 @@ public partial class HueBridge : BackgroundService,
         // pair a snapshot. Reading the client and then closing the door separately let an operation
         // racing the shutdown install a replacement in between, and nothing was left to release it.
         // Cancel first. base.Dispose() is what cancels the stopping token, and running it last let the
-        // loop start a fresh iteration after the door was closed: it would spend up to half a minute
+        // loop start a fresh iteration after the door was closed: it would spend the discovery budget
         // rediscovering the bridge, then fail on the disposed check and overwrite the Stopped status
         // written above with an Error one.
         base.Dispose();

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueBridge.cs
@@ -434,6 +434,7 @@ public partial class HueBridge : BackgroundService,
             {
                 await PollDevicesAsync(client, cancellationToken);
                 consecutiveFailures = 0;
+                StatusMessage = null;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -446,6 +447,13 @@ public partial class HueBridge : BackgroundService,
                 {
                     throw;
                 }
+
+                // Status stays Running because the connection and its event stream are live, so the
+                // message is the only signal that the device set is not being reconciled. Without it a
+                // bridge whose first poll failed would look healthy while exposing nothing at all.
+                StatusMessage = Devices.Length == 0
+                    ? $"No device list yet, reconciliation poll failed ({consecutiveFailures} of {MaxConsecutivePollFailures})."
+                    : $"Device list may be stale, reconciliation poll failed ({consecutiveFailures} of {MaxConsecutivePollFailures}).";
 
                 // A teardown takes the event stream with it, and that stream carries the state
                 // changes; this poll only reconciles the device set.

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueCommandResult.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueCommandResult.cs
@@ -28,10 +28,12 @@ internal static class HueCommandResult
     /// Returns the response, or throws when the bridge answered with errors instead of data. A
     /// non-success status carrying a JSON body is not an exception in the SDK: it yields an empty
     /// Data list, which reads downstream as "the bridge has no devices" and empties the model.
+    /// A response that carries data is kept even when errors accompany it, because the SDK fills
+    /// Errors from the body on the success path too.
     /// </summary>
     public static HueResponse<T> ThrowOnError<T>(this HueResponse<T> response, string resource)
     {
-        if (response.Errors.Count == 0)
+        if (response.Errors.Count == 0 || response.Data.Count > 0)
         {
             return response;
         }

--- a/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueCommandResult.cs
+++ b/src/HomeBlaze/Namotion.Devices.Philips.Hue/HueCommandResult.cs
@@ -23,4 +23,21 @@ internal static class HueCommandResult
             "The Hue bridge rejected the command: " +
             string.Join("; ", response.Errors.Select(error => error.Description)));
     }
+
+    /// <summary>
+    /// Returns the response, or throws when the bridge answered with errors instead of data. A
+    /// non-success status carrying a JSON body is not an exception in the SDK: it yields an empty
+    /// Data list, which reads downstream as "the bridge has no devices" and empties the model.
+    /// </summary>
+    public static HueResponse<T> ThrowOnError<T>(this HueResponse<T> response, string resource)
+    {
+        if (response.Errors.Count == 0)
+        {
+            return response;
+        }
+
+        throw new InvalidOperationException(
+            $"The Hue bridge returned errors instead of {resource}: " +
+            string.Join("; ", response.Errors.Select(error => error.Description)));
+    }
 }


### PR DESCRIPTION
A Hue bridge would repeatedly drop to `Error` with `'<' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.`, roughly every other minute, taking its event stream down with it each time. This fixes that and two further faults found alongside it.

The device poll issued its eleven CLIP v2 requests concurrently. The bridge fronts its API with an nginx rate limiter that answers a burst with `429` and an HTML error page. `ProcessResponseAsync<T>` does branch on the status, but it then parses the *error* body as JSON without checking the content type, so the rejection surfaced as a `JsonException` about an unexpected `<`. Measured against a real bridge, about half of all polls failed, and in each failing poll eight of the eleven requests got through and three came back as HTML. Issuing them one at a time removes the cause.

Separately, discovery died on the first locator that threw. The SDK's aggregate helpers drive locators through their `CancellationToken` overload, which does not contain a failure, so one throw abandoned the whole discovery before the remaining locators were consulted. On macOS the mDNS locator always throws, because the system resolver holds port 5353, which left the bridge permanently unreachable for as long as `discovery.meethue.com` was rate limiting. Each locator now runs under its own linked timeout with its failure kept local.

Finally, a non-success response whose body is valid JSON never threw at all. `ProcessResponseAsync<T>` returns an empty `Data` list with the errors attached, which the poll read as "the bridge has no devices" and used to empty every device, room and zone, stamping `LastUpdated` so nothing even looked stale. Poll responses are now rejected when the bridge reports errors.

## Why

The three faults compound. A rate-limited poll tore down the client, which killed the SSE event stream that carries all real-time state, which forced a rediscovery, which hit `discovery.meethue.com` often enough to earn a `429` there too, at which point the mDNS bind failure ended discovery outright and the bridge stayed dead until the cloud endpoint relented. Fixing only the first would have left a bridge that still bricks itself whenever the Philips endpoint is unavailable.

## Contract

- A failed poll no longer drops the connection, including the first poll after connecting. The event stream carries state changes and the poll only reconciles the device set, so the connection survives until three consecutive polls fail.
- A poll response carrying bridge errors *and no data* is rejected rather than applied, so the previous device set is retained instead of being emptied. A response carrying data is still applied even when errors accompany it, because the SDK fills `Errors` from the body on the success path too.
- Discovery consults every locator. A locator that throws, times out or reports nothing no longer prevents the others from running.
- While poll failures are being tolerated, `Status` stays `Running` because the connection and its event stream are live, and `StatusMessage` carries the degradation: whether a device list exists at all, the consecutive failure count, and the underlying cause.

## Breaking changes

- **Behavior:** a single failed poll no longer transitions the bridge to `Error` or triggers a reconnect. Three consecutive failures do. Anything watching `Status` or `IsConnected` to detect a transient bridge hiccup will now see it later, by up to two polling intervals.
- **Behavior:** requests on the bridge client now time out after 10 seconds rather than `HttpClient`'s 100 second default. This covers user-initiated commands as well as polls, since they share the client. The SSE event stream is unaffected: `LocalHueApi.StartEventStream` builds its own client with an infinite timeout rather than reusing this one.
- **Behavior:** a poll response carrying errors throws instead of silently emptying the model. This is the intended fix, but it converts a previously silent state wipe into a logged failure.
- **Behavior:** the event stream now starts before the first reconciliation poll rather than after it. A bridge whose first poll fails reports `Running` with an empty device set while the failure is tolerated, where it previously went straight to `Error`. Events arriving before the first poll completes are discarded, which the event handler already did safely for unknown devices.

## Performance

Sequential polling is faster here, not slower, because the bridge was largely serialising the concurrent requests anyway and rejecting the overflow. Measured against a live bridge over eight consecutive poll cycles, a full poll went from 1495 ms concurrent to a steady 600 to 650 ms sequential. The failure rate over the same comparison went from about 50% of polls to zero.

Both figures are from polls that *completed*, so the comparison is like for like, but it is two concurrent samples (1495 ms and 1501 ms) against eight sequential ones on a single bridge. The mechanism is that `HttpClientHandler` places no limit on connections per server, so the concurrent version opened up to eleven TLS handshakes against an embedded device while the sequential version reuses one connection.

No BenchmarkDotNet row exists for this code and none can reach it, since the project is a HomeBlaze device library driven by a physical bridge, so the table below is omitted rather than filled with a benchmark that does not exercise the change. The numbers above are wall clock against real hardware, not a microbenchmark, and carry the variance that implies.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 2 | 143 | 39 | +104 |
| Tests and benchmarks | 1 | 73 | 0 | +73 |
| Documentation | 1 | 6 | 6 | 0 |
| **Total** | **4** | **222** | **45** | **+177** |

## Verification

Verified against a real Hue Bridge rather than a mock, since the fault only reproduces against the bridge's own rate limiter. Eight consecutive poll cycles completed with zero failures, zero teardowns and zero non-JSON responses, against a measured ~50% failure rate before. The bridge also recovered through the full locator chain with `discovery.meethue.com` returning `429`, being found by the network scan and later by SSDP, which is the path that was unreachable before.

- [x] Documentation updated
- [x] Unit tests (3926 across 34 projects, `Category!=Integration`, 0 failures; 4 new covering the error response rejection)
- [x] Integration tests (manual, against a live bridge as described above; the project has no automated integration suite)
- [ ] ~~Benchmarks~~ no benchmark reaches this project
- [ ] ~~Load tests~~ Connector Tester targets the Namotion.Interceptor connectors, not HomeBlaze device libraries
- [ ] ~~Chaos tests~~ as above

The tolerance loop itself has no unit test. Covering it needs a seam that does not exist today, because `RunPollingLoopAsync` is private and `LocalHueApi`'s endpoints are non-virtual concrete types. The four new tests cover the error response rejection, which is the part carrying the correctness risk.
