### PR TITLE
fix: run CI for pull requests targeting nested branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
   pull_request:
     branches:
-      - '*'
+      - '**'
   release:
     types:
       - published


### PR DESCRIPTION
Run pull-request CI for target branches containing `/`, including `rewrite/single-context-lifecycle`. The previous `*` filter excluded stacked PRs such as #527. Use `**`, which also matches branch names containing slashes according to [GitHub’s filter syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet).

Related to #494 and #527.

## Breaking changes

None.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Scripts and CI | 1 | 1 | 1 | 0 |
| **Total** | **1** | **1** | **1** | **0** |

## Verification

- [x] Parsed the workflow YAML and verified the branch pattern is the only semantic change.
- [x] `git diff --check`.
- [x] Release build and complete non-integration solution suite passed in [CI](https://github.com/RicoSuter/Namotion.Interceptor/actions/runs/34293113858).
- ~~Documentation update, integration tests, benchmarks, load and chaos tests~~: workflow trigger change only.
