### PR TITLE
fix: retry unresolved MQTT mappings after graph changes

### DIFF
--- a/src/Namotion.Interceptor.Mqtt.Tests/MqttMappingCacheTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/MqttMappingCacheTests.cs
@@ -224,6 +224,48 @@ public class MqttMappingCacheTests
         Assert.Null(after);
     }
 
+    [Fact]
+    public async Task WhenAMissingClientTopicBecomesReachable_ThenTheNextLookupResolvesIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var client = CreateClient(subject, mapper);
+        Assert.Null(await client.TryGetPropertyForTopicAsync("child/value"));
+
+        // Act
+        subject.Child = new MqttCacheTestChild();
+        var resolved = await client.TryGetPropertyForTopicAsync("child/value");
+        var cached = await client.TryGetPropertyForTopicAsync("child/value");
+
+        // Assert
+        Assert.Same(subject.Child, resolved?.Subject);
+        Assert.Equal(nameof(MqttCacheTestChild.Value), resolved?.Name);
+        Assert.Equal(resolved, cached);
+        Assert.Equal(2, mapper.PropertyLookupCount);
+    }
+
+    [Fact]
+    public async Task WhenAMissingServerPathBecomesReachable_ThenTheNextLookupResolvesIt()
+    {
+        // Arrange
+        var mapper = new CountingMapper(CreateMapper());
+        var subject = CreateRootSubject();
+        await using var server = CreateServer(subject, mapper);
+        Assert.Null(await server.TryGetPropertyForTopicAsync("child/value", CancellationToken.None));
+
+        // Act
+        subject.Child = new MqttCacheTestChild();
+        var resolved = await server.TryGetPropertyForTopicAsync("child/value", CancellationToken.None);
+        var cached = await server.TryGetPropertyForTopicAsync("child/value", CancellationToken.None);
+
+        // Assert
+        Assert.Same(subject.Child, resolved?.Subject);
+        Assert.Equal(nameof(MqttCacheTestChild.Value), resolved?.Name);
+        Assert.Equal(resolved, cached);
+        Assert.Equal(2, mapper.PropertyLookupCount);
+    }
+
     private static MqttCacheTestRoot CreateRootSubject()
     {
         var context = InterceptorSubjectContext

--- a/src/Namotion.Interceptor.Mqtt/Client/MqttSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.Mqtt/Client/MqttSubjectClientSource.cs
@@ -626,9 +626,9 @@ internal sealed class MqttSubjectClientSource : SubjectSourceBase, IFaultInjecta
             : await _configuration.Mapper.TryGetPropertyAsync(new MqttLookupKey(path), registered, CancellationToken.None).ConfigureAwait(false);
         var propertyReference = property?.Reference;
 
-        // Add first, then validate (guarantees no memory leak)
-        if (_topicToProperty.TryAdd(topic, propertyReference) &&
-            propertyReference is { } resolvedProperty &&
+        // A missing path can become reachable after a structural change; only cache resolved properties.
+        if (propertyReference is { } resolvedProperty &&
+            _topicToProperty.TryAdd(topic, propertyReference) &&
             !IsRetainable(resolvedProperty.Subject))
         {
             _topicToProperty.TryRemove(topic, out _);

--- a/src/Namotion.Interceptor.Mqtt/Server/MqttSubjectServer.cs
+++ b/src/Namotion.Interceptor.Mqtt/Server/MqttSubjectServer.cs
@@ -509,9 +509,9 @@ public class MqttSubjectServer : SubjectConnectorBase, IFaultInjectable, IAsyncD
             : await _configuration.Mapper.TryGetPropertyAsync(new MqttLookupKey(path), registered, cancellationToken).ConfigureAwait(false);
         var propertyReference = property?.Reference;
 
-        // Add first, then validate (guarantees no memory leak)
-        if (_pathToProperty.TryAdd(path, propertyReference) &&
-            propertyReference is { } resolvedProperty &&
+        // A missing path can become reachable after a structural change; only cache resolved properties.
+        if (propertyReference is { } resolvedProperty &&
+            _pathToProperty.TryAdd(path, propertyReference) &&
             !IsRetainable(resolvedProperty.Subject))
         {
             _pathToProperty.TryRemove(path, out _);


### PR DESCRIPTION
Retry MQTT topic/path lookups that previously returned no property, so messages can reach a child added to the subject graph later. Both the client and server currently cache a null result indefinitely; only resolved mappings are cached after this change.

Successful mapping caches, detach eviction, and the insertion-then-retainability check are preserved. Missing topics no longer retain dictionary entries. Repeated messages for an unresolved topic invoke the mapper again, which trades repeated lookup work for correct resolution after graph changes.

Related to #494 and #527.

## Breaking changes

None. No public API changes.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 2 | 6 | 6 | 0 |
| Tests and benchmarks | 1 | 42 | 0 | +42 |
| **Total** | **3** | **48** | **6** | **+42** |

## Verification

- [x] Both new regressions failed on master and passed after the fix. They also verify subsequent successful lookups are cached.
- [x] MQTT unit tests: 95 passed.
- [x] MQTT integration tests: 21 passed.
- [x] Cache-specific recheck: 13 passed, including detached-subject and insertion-during-detach coverage.
- [x] Independent code review and `git diff --check`.
- [ ] Full solution CI: pending this PR.
- ~~Documentation update~~: existing mapping API is unchanged; corrected cache behavior is described above.
- ~~Benchmarks, load tests and chaos tests~~: not run for this bounded cache condition change.

Local tests used the existing cached NuGet feed and package cache. CI will validate normal dependency restore.
