### PR TITLE
fix: avoid unrelated getters during method discovery

### DIFF
--- a/src/HomeBlaze/HomeBlaze.Services.Tests/RegisteredSubjectMethodExtensionsTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/RegisteredSubjectMethodExtensionsTests.cs
@@ -11,6 +11,24 @@ namespace HomeBlaze.Services.Tests;
 
 public class RegisteredSubjectMethodExtensionsTests
 {
+    [Fact]
+    public void WhenUnrelatedGettersThrow_ThenMethodDiscoveryStillFindsAllSupportedMetadataShapes()
+    {
+        // Arrange
+        var subject = new MethodDiscoveryGetterSubject(CreateContext());
+        var registered = subject.TryGetRegisteredSubject()!;
+
+        // Act
+        var all = registered.GetAllMethods();
+        var operations = registered.GetOperationMethods();
+        var queries = registered.GetQueryMethods();
+
+        // Assert
+        Assert.Equal(new[] { "Object", "Interface", "Subclass" }, all.Select(method => method.Title));
+        Assert.Equal(new[] { "Object", "Subclass" }, operations.Select(method => method.Title));
+        Assert.Equal("Interface", Assert.Single(queries).Title);
+    }
+
     private static IInterceptorSubjectContext CreateContext()
     {
         return InterceptorSubjectContext.Create()
@@ -132,4 +150,32 @@ public partial class MethodExtTestSubject
 
     [Query(Title = "Third", Position = 3)]
     public Task<string> ThirdAsync() => Task.FromResult("result");
+}
+
+public interface IMethodDiscoveryMarker;
+
+public sealed class MethodDiscoveryMetadata : MethodMetadata, IMethodDiscoveryMarker
+{
+    public MethodDiscoveryMetadata() : base(_ => Task.CompletedTask) { }
+}
+
+[InterceptorSubject]
+public partial class MethodDiscoveryGetterSubject
+{
+    public int UnavailableValue => throw new InvalidOperationException("Value is not ready");
+
+    public object ObjectMethod { get; } = new MethodMetadata(_ => Task.CompletedTask)
+    {
+        Title = "Object", Position = 0, Kind = MethodKind.Operation
+    };
+
+    public IMethodDiscoveryMarker InterfaceMethod { get; } = new MethodDiscoveryMetadata
+    {
+        Title = "Interface", Position = 1, Kind = MethodKind.Query
+    };
+
+    public MethodDiscoveryMetadata SubclassMethod { get; } = new()
+    {
+        Title = "Subclass", Position = 2, Kind = MethodKind.Operation
+    };
 }

--- a/src/HomeBlaze/HomeBlaze.Services/RegisteredSubjectMethodExtensions.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RegisteredSubjectMethodExtensions.cs
@@ -14,6 +14,7 @@ public static class RegisteredSubjectMethodExtensions
     public static IReadOnlyList<MethodMetadata> GetAllMethods(this RegisteredSubject subject)
     {
         return subject.Properties
+            .Where(CanContainMethodMetadata)
             .Select(p => p.GetValue())
             .OfType<MethodMetadata>()
             .OrderBy(m => m.Position)
@@ -26,6 +27,7 @@ public static class RegisteredSubjectMethodExtensions
     public static IReadOnlyList<MethodMetadata> GetOperationMethods(this RegisteredSubject subject)
     {
         return subject.Properties
+            .Where(CanContainMethodMetadata)
             .Select(p => p.GetValue())
             .OfType<MethodMetadata>()
             .Where(m => m.Kind == MethodKind.Operation)
@@ -39,10 +41,19 @@ public static class RegisteredSubjectMethodExtensions
     public static IReadOnlyList<MethodMetadata> GetQueryMethods(this RegisteredSubject subject)
     {
         return subject.Properties
+            .Where(CanContainMethodMetadata)
             .Select(p => p.GetValue())
             .OfType<MethodMetadata>()
             .Where(m => m.Kind == MethodKind.Query)
             .OrderBy(m => m.Position)
             .ToList();
+    }
+
+    private static bool CanContainMethodMetadata(RegisteredSubjectProperty property)
+    {
+        // A metadata subclass may implement an interface not implemented by MethodMetadata itself.
+        return property.Type.IsInterface ||
+            property.Type.IsAssignableFrom(typeof(MethodMetadata)) ||
+            typeof(MethodMetadata).IsAssignableFrom(property.Type);
     }
 }


### PR DESCRIPTION
Keep HomeBlaze method discovery from invoking getters whose declared property type cannot contain method metadata. For example, an unrelated integer getter that throws while a device is initializing currently prevents its operation and query methods from being discovered.

Filter by declared type before reading values in all three discovery entry points. Metadata subclasses and values exposed through object or interface properties remain supported, with existing method-kind filtering, ordering and exception propagation for eligible getters.

Related to #494 and #527.

## Breaking changes

None. No public API changes.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 1 | 11 | 0 | +11 |
| Tests and benchmarks | 1 | 46 | 0 | +46 |
| **Total** | **2** | **57** | **0** | **+57** |

## Verification

- [x] New regression failed on master and passed after the fix. It exercises all three entry points, a throwing unrelated getter, and metadata exposed through object, a subclass-specific interface, and the subclass itself.
- [x] HomeBlaze.Services tests: 226 passed.
- [x] Independent code review and `git diff --check`.
- [ ] Full solution and relevant integration CI: pending this PR.
- ~~Documentation update~~: no API or consumer migration change.
- ~~Benchmarks, load tests and chaos tests~~: not run for this property-type filter.

Local tests used the existing cached NuGet feed and package cache. CI will validate normal dependency restore.
