### PR TITLE
fix: preserve subject reference identity in registry and wire updates

### DIFF
--- a/docs/connectors-subject-updates.md
+++ b/docs/connectors-subject-updates.md
@@ -354,7 +354,7 @@ For complete updates (no `operations`), items at indices that don't exist locall
 
 ## Circular References
 
-Circular references are handled naturally by the flat structure. Each subject appears exactly once in the `subjects` dictionary, and references use string IDs:
+Circular references are handled naturally by the flat structure. Each subject instance appears exactly once in the `subjects` dictionary, and references use string IDs. Distinct instances retain distinct IDs even when their `Equals` implementation considers them equal:
 
 ```json
 {

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateIdentityTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateIdentityTests.cs
@@ -43,6 +43,37 @@ public class SubjectUpdateIdentityTests
         Assert.Equal(1, target.Children[0].Value);
         Assert.Equal(2, target.Children[1].Value);
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WhenEqualSubjectsAreReplacedOrReordered_ThenPartialUpdatesPreserveTheirValues(bool reorder)
+    {
+        // Arrange
+        var first = new ValueEqualWireSubject { EqualityKey = "child", Value = 1 };
+        var second = new ValueEqualWireSubject { EqualityKey = "child", Value = 2 };
+        var source = new ValueEqualWireSubject(InterceptorSubjectContext.Create().WithRegistry())
+        {
+            EqualityKey = "root",
+            Children = reorder ? [first, second] : [first]
+        };
+        var target = new ValueEqualWireSubject(InterceptorSubjectContext.Create().WithRegistry());
+        target.ApplySubjectUpdate(SubjectUpdate.CreateCompleteUpdate(source, []), DefaultSubjectFactory.Instance, ChangeOrigin.Local);
+        var previousChildren = source.Children;
+        source.Children = reorder ? [second, first] : [second];
+        SubjectPropertyChange[] changes =
+        [
+            SubjectPropertyChange.Create(new PropertyReference(source, nameof(ValueEqualWireSubject.Children)),
+                ChangeOrigin.Local, DateTimeOffset.UtcNow, null, previousChildren, source.Children)
+        ];
+
+        // Act
+        var update = SubjectUpdate.CreatePartialUpdateFromChanges(source, changes, []);
+        target.ApplySubjectUpdate(update, DefaultSubjectFactory.Instance, ChangeOrigin.Local);
+
+        // Assert
+        Assert.Equal(reorder ? [2, 1] : [2], target.Children.Select(child => child.Value));
+    }
 }
 
 [InterceptorSubject]

--- a/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateIdentityTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Updates/SubjectUpdateIdentityTests.cs
@@ -1,0 +1,62 @@
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Connectors.Updates;
+using Namotion.Interceptor.Registry;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Connectors.Tests.Updates;
+
+public class SubjectUpdateIdentityTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WhenDistinctSubjectsCompareEqual_ThenTheirWireIdsAndValuesRemainDistinct(bool partial)
+    {
+        // Arrange
+        var first = new ValueEqualWireSubject { EqualityKey = "child", Value = 1 };
+        var second = new ValueEqualWireSubject { EqualityKey = "child", Value = 2 };
+        var source = new ValueEqualWireSubject(InterceptorSubjectContext.Create().WithRegistry())
+        {
+            EqualityKey = "root",
+            Children = [first, second]
+        };
+        var target = new ValueEqualWireSubject(InterceptorSubjectContext.Create().WithRegistry())
+        {
+            Children = [new ValueEqualWireSubject(), new ValueEqualWireSubject()]
+        };
+        SubjectPropertyChange[] changes =
+        [
+            SubjectPropertyChange.Create(new PropertyReference(first, nameof(ValueEqualWireSubject.Value)), ChangeOrigin.Local, DateTimeOffset.UtcNow, null, 0, 1),
+            SubjectPropertyChange.Create(new PropertyReference(second, nameof(ValueEqualWireSubject.Value)), ChangeOrigin.Local, DateTimeOffset.UtcNow, null, 0, 2)
+        ];
+
+        // Act
+        var update = partial
+            ? SubjectUpdate.CreatePartialUpdateFromChanges(source, changes, [])
+            : SubjectUpdate.CreateCompleteUpdate(source, []);
+        target.ApplySubjectUpdate(update, DefaultSubjectFactory.Instance, ChangeOrigin.Local);
+
+        // Assert
+        var items = update.Subjects[update.Root][nameof(ValueEqualWireSubject.Children)].Items!;
+        Assert.Equal(2, items.Count);
+        Assert.NotEqual(items[0].Id, items[1].Id);
+        Assert.Equal(1, target.Children[0].Value);
+        Assert.Equal(2, target.Children[1].Value);
+    }
+}
+
+[InterceptorSubject]
+public partial class ValueEqualWireSubject
+{
+    public ValueEqualWireSubject() => Children = [];
+
+    public partial string? EqualityKey { get; set; }
+
+    public partial int Value { get; set; }
+
+    public partial ValueEqualWireSubject[] Children { get; set; }
+
+    public override bool Equals(object? obj) => obj is ValueEqualWireSubject other && other.EqualityKey == EqualityKey;
+
+    public override int GetHashCode() => EqualityKey?.GetHashCode() ?? 0;
+}

--- a/src/Namotion.Interceptor.Connectors/Updates/Internal/CollectionDiffBuilder.cs
+++ b/src/Namotion.Interceptor.Connectors/Updates/Internal/CollectionDiffBuilder.cs
@@ -87,7 +87,7 @@ internal sealed class CollectionDiffBuilder
         }
 
         // Detect reordering and compute intermediate indices for moves
-        if (_oldRetainedOrder.Count > 0 && !_oldRetainedOrder.SequenceEqual(_newRetainedOrder, ReferenceEqualityComparer.Instance))
+        if (_oldRetainedOrder.Count > 0 && !_oldRetainedOrder.SequenceEqual<IInterceptorSubject>(_newRetainedOrder, ReferenceEqualityComparer.Instance))
         {
             _oldRetainedIndexMap.Clear();
             for (var i = 0; i < _oldRetainedOrder.Count; i++)

--- a/src/Namotion.Interceptor.Connectors/Updates/Internal/CollectionDiffBuilder.cs
+++ b/src/Namotion.Interceptor.Connectors/Updates/Internal/CollectionDiffBuilder.cs
@@ -9,9 +9,9 @@ namespace Namotion.Interceptor.Connectors.Updates.Internal;
 internal sealed class CollectionDiffBuilder
 {
     // Reusable containers
-    private readonly Dictionary<IInterceptorSubject, int> _oldIndexMap = new();
-    private readonly Dictionary<IInterceptorSubject, int> _newIndexMap = new();
-    private readonly Dictionary<IInterceptorSubject, int> _oldRetainedIndexMap = new();
+    private readonly Dictionary<IInterceptorSubject, int> _oldIndexMap = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<IInterceptorSubject, int> _newIndexMap = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<IInterceptorSubject, int> _oldRetainedIndexMap = new(ReferenceEqualityComparer.Instance);
     private readonly List<IInterceptorSubject> _oldRetainedOrder = [];
     private readonly List<IInterceptorSubject> _newRetainedOrder = [];
     private readonly List<(object key, IInterceptorSubject item)> _retainedDictionaryItems = [];
@@ -87,7 +87,7 @@ internal sealed class CollectionDiffBuilder
         }
 
         // Detect reordering and compute intermediate indices for moves
-        if (_oldRetainedOrder.Count > 0 && !_oldRetainedOrder.SequenceEqual(_newRetainedOrder))
+        if (_oldRetainedOrder.Count > 0 && !_oldRetainedOrder.SequenceEqual(_newRetainedOrder, ReferenceEqualityComparer.Instance))
         {
             _oldRetainedIndexMap.Clear();
             for (var i = 0; i < _oldRetainedOrder.Count; i++)

--- a/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectUpdateBuilder.cs
+++ b/src/Namotion.Interceptor.Connectors/Updates/Internal/SubjectUpdateBuilder.cs
@@ -9,16 +9,16 @@ namespace Namotion.Interceptor.Connectors.Updates.Internal;
 internal sealed class SubjectUpdateBuilder
 {
     private int _nextId;
-    private readonly Dictionary<IInterceptorSubject, string> _subjectToId = new();
+    private readonly Dictionary<IInterceptorSubject, string> _subjectToId = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<SubjectPropertyUpdate, (RegisteredSubjectProperty Property, IDictionary<string, SubjectPropertyUpdate> Parent)> _propertyUpdates = new();
 
     public ISubjectUpdateProcessor[] Processors { get; private set; } = [];
     
     public Dictionary<string, Dictionary<string, SubjectPropertyUpdate>> Subjects { get; private set; } = new();
 
-    public HashSet<IInterceptorSubject> ProcessedSubjects { get; } = [];
+    public HashSet<IInterceptorSubject> ProcessedSubjects { get; } = new(ReferenceEqualityComparer.Instance);
 
-    public HashSet<IInterceptorSubject> PathVisited { get; } = [];
+    public HashSet<IInterceptorSubject> PathVisited { get; } = new(ReferenceEqualityComparer.Instance);
 
     public void Initialize(IInterceptorSubject rootSubject, ISubjectUpdateProcessor[] processors)
     {

--- a/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryTests.cs
+++ b/src/Namotion.Interceptor.Registry.Tests/SubjectRegistryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using Namotion.Interceptor.AspNetCore.Extensions;
+using Namotion.Interceptor.Attributes;
 using Namotion.Interceptor.Registry.Abstractions;
 using Namotion.Interceptor.Registry.Tests.Models;
 using Namotion.Interceptor.Testing;
@@ -387,4 +388,85 @@ public class SubjectRegistryTests
         Assert.Equal(1, child2.TryGetRegisteredSubject()!.Parents[0].Index);
         Assert.Equal(2, child3.TryGetRegisteredSubject()!.Parents[0].Index); // updated from 1 to 2
     }
+
+    [Fact]
+    public void WhenTwoEqualButDistinctSubjectsAreAttached_ThenBothAreRegisteredSeparately()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var first = new ValueEqualitySubject { Name = "same" };
+        var second = new ValueEqualitySubject { Name = "same" };
+
+        // Act
+        ((IInterceptorSubject)first).Context.AddFallbackContext(context);
+        ((IInterceptorSubject)second).Context.AddFallbackContext(context);
+
+        // Assert
+        var registry = context.GetService<ISubjectRegistry>();
+        Assert.Equal(2, registry.KnownSubjects.Count);
+        Assert.Same(first, registry.TryGetRegisteredSubject(first)?.Subject);
+        Assert.Same(second, registry.TryGetRegisteredSubject(second)?.Subject);
+    }
+
+    [Fact]
+    public void WhenTwoEqualButDistinctSubjectsShareACollection_ThenEachKeepsItsOwnPosition()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext
+            .Create()
+            .WithRegistry();
+
+        var first = new ValueEqualitySubject { Name = "same" };
+        var second = new ValueEqualitySubject { Name = "same" };
+        var parent = new ValueEqualitySubject(context) { Children = [first, second] };
+
+        // Act: a reorder refreshes every child's position against the live collection.
+        parent.Children = [second, first];
+
+        // Assert
+        Assert.Equal(0, second.TryGetRegisteredSubject()!.Parents[0].Index);
+        Assert.Equal(1, first.TryGetRegisteredSubject()!.Parents[0].Index);
+    }
+    [Fact]
+    public void WhenReplacingAChildWithAnEqualInstance_ThenOnlyTheReplacementRemainsRegistered()
+    {
+        // Arrange
+        var context = InterceptorSubjectContext.Create().WithRegistry();
+        var first = new ValueEqualitySubject { Name = "same" };
+        var second = new ValueEqualitySubject { Name = "same" };
+        var parent = new ValueEqualitySubject(context) { Children = [first] };
+
+        // Act
+        parent.Children = [second];
+
+        // Assert
+        var registry = context.GetService<ISubjectRegistry>();
+        Assert.Null(registry.TryGetRegisteredSubject(first));
+        Assert.Same(second, registry.TryGetRegisteredSubject(second)!.Subject);
+        Assert.Same(second, Assert.Single(parent.TryGetRegisteredProperty(nameof(parent.Children))!.Children).Subject);
+    }
+}
+
+/// <summary>
+/// A subject whose <see cref="object.Equals(object?)"/> and <see cref="object.GetHashCode"/> compare by value,
+/// which is legal for a hand-written subject and must not merge distinct graph nodes.
+/// </summary>
+[InterceptorSubject]
+public partial class ValueEqualitySubject
+{
+    public ValueEqualitySubject()
+    {
+        Children = [];
+    }
+
+    public partial string? Name { get; set; }
+
+    public partial ValueEqualitySubject[] Children { get; set; }
+
+    public override bool Equals(object? obj) => obj is ValueEqualitySubject other && other.Name == Name;
+
+    public override int GetHashCode() => Name?.GetHashCode() ?? 0;
 }

--- a/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubjectProperty.cs
+++ b/src/Namotion.Interceptor.Registry/Abstractions/RegisteredSubjectProperty.cs
@@ -447,7 +447,7 @@ public class RegisteredSubjectProperty
             {
                 if (list[index] is IInterceptorSubject subject)
                 {
-                    collectionPositions ??= _reusableCollectionPositions = new Dictionary<IInterceptorSubject, int>(capacityHint);
+                    collectionPositions ??= _reusableCollectionPositions = new Dictionary<IInterceptorSubject, int>(capacityHint, ReferenceEqualityComparer.Instance);
                     collectionPositions[subject] = index;
                 }
             }
@@ -459,7 +459,7 @@ public class RegisteredSubjectProperty
             {
                 if (item is IInterceptorSubject subject)
                 {
-                    collectionPositions ??= _reusableCollectionPositions = new Dictionary<IInterceptorSubject, int>(capacityHint);
+                    collectionPositions ??= _reusableCollectionPositions = new Dictionary<IInterceptorSubject, int>(capacityHint, ReferenceEqualityComparer.Instance);
                     collectionPositions[subject] = index;
                 }
                 index++;
@@ -472,7 +472,7 @@ public class RegisteredSubjectProperty
             {
                 if (item is IInterceptorSubject subject)
                 {
-                    collectionPositions ??= _reusableCollectionPositions = new Dictionary<IInterceptorSubject, int>(capacityHint);
+                    collectionPositions ??= _reusableCollectionPositions = new Dictionary<IInterceptorSubject, int>(capacityHint, ReferenceEqualityComparer.Instance);
                     collectionPositions[subject] = index;
                 }
                 index++;

--- a/src/Namotion.Interceptor.Registry/SubjectRegistry.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistry.cs
@@ -22,7 +22,7 @@ namespace Namotion.Interceptor.Registry;
 [RunsBefore(typeof(ParentTrackingHandler), typeof(ContextInheritanceHandler))]
 public class SubjectRegistry : ISubjectRegistry, ISubjectIdRegistry, ISubjectIdRegistryWriter, ILifecycleHandler, IPropertyLifecycleHandler
 {
-    private readonly Dictionary<IInterceptorSubject, RegisteredSubject> _knownSubjects = new();
+    private readonly Dictionary<IInterceptorSubject, RegisteredSubject> _knownSubjects = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<string, IInterceptorSubject> _subjectIdToSubject = new();
     private ImmutableDictionary<IInterceptorSubject, RegisteredSubject>? _knownSubjectsSnapshot;
 
@@ -45,7 +45,7 @@ public class SubjectRegistry : ISubjectRegistry, ISubjectIdRegistry, ISubjectIdR
             if (snapshot is not null)
                 return snapshot;
 
-            snapshot = _knownSubjects.ToImmutableDictionary();
+            snapshot = _knownSubjects.ToImmutableDictionary(ReferenceEqualityComparer.Instance);
             Volatile.Write(ref _knownSubjectsSnapshot, snapshot);
             return snapshot;
         }

--- a/src/Namotion.Interceptor.Registry/SubjectRegistry.cs
+++ b/src/Namotion.Interceptor.Registry/SubjectRegistry.cs
@@ -22,6 +22,9 @@ namespace Namotion.Interceptor.Registry;
 [RunsBefore(typeof(ParentTrackingHandler), typeof(ContextInheritanceHandler))]
 public class SubjectRegistry : ISubjectRegistry, ISubjectIdRegistry, ISubjectIdRegistryWriter, ILifecycleHandler, IPropertyLifecycleHandler
 {
+    private static readonly ImmutableDictionary<IInterceptorSubject, RegisteredSubject> EmptyKnownSubjects =
+        ImmutableDictionary.Create<IInterceptorSubject, RegisteredSubject>(ReferenceEqualityComparer.Instance);
+
     private readonly Dictionary<IInterceptorSubject, RegisteredSubject> _knownSubjects = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<string, IInterceptorSubject> _subjectIdToSubject = new();
     private ImmutableDictionary<IInterceptorSubject, RegisteredSubject>? _knownSubjectsSnapshot;
@@ -45,7 +48,7 @@ public class SubjectRegistry : ISubjectRegistry, ISubjectIdRegistry, ISubjectIdR
             if (snapshot is not null)
                 return snapshot;
 
-            snapshot = _knownSubjects.ToImmutableDictionary(ReferenceEqualityComparer.Instance);
+            snapshot = EmptyKnownSubjects.AddRange(_knownSubjects);
             Volatile.Write(ref _knownSubjectsSnapshot, snapshot);
             return snapshot;
         }

--- a/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
+++ b/src/Namotion.Interceptor.Tracking/Lifecycle/LifecycleInterceptor.cs
@@ -7,7 +7,7 @@ namespace Namotion.Interceptor.Tracking.Lifecycle;
 
 public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
 {
-    private readonly Dictionary<IInterceptorSubject, PropertyReferenceSet> _attachedSubjects = [];
+    private readonly Dictionary<IInterceptorSubject, PropertyReferenceSet> _attachedSubjects = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<PropertyReference, object?> _lastProcessedValues = new(PropertyReference.Comparer);
 
     [ThreadStatic]
@@ -525,7 +525,7 @@ public class LifecycleInterceptor : IWriteInterceptor, ILifecycleInterceptor
     private static HashSet<IInterceptorSubject> GetSubjectHashSet()
     {
         _subjectHashSetPool ??= new Stack<HashSet<IInterceptorSubject>>();
-        return _subjectHashSetPool.Count > 0 ? _subjectHashSetPool.Pop() : new HashSet<IInterceptorSubject>(8);
+        return _subjectHashSetPool.Count > 0 ? _subjectHashSetPool.Pop() : new HashSet<IInterceptorSubject>(8, ReferenceEqualityComparer.Instance);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Preserve distinct subject instances that compare equal in Registry bookkeeping and complete/partial wire updates. Value-based dictionaries currently coalesce registrations, mix up sibling indices and wire IDs, and omit collection replacements or moves between equal-but-distinct instances.

Use reference comparers in the existing Registry, lifecycle membership, wire traversal and collection-diff containers. The lifecycle comparers are necessary on master so Registry receives separate attachment and replacement events. Collection diffing also compares retained order by reference. The production change uses fourteen comparer substitutions, an explicit generic argument for allocation-free retained-order comparison, and a shared immutable empty dictionary for snapshot construction. Existing algorithms, locking and public APIs are preserved.

Related to #494 and #527.

## Breaking changes

None. Distinct instances that override value equality are correctly treated as separate subjects in the affected registration and wire paths. No public API changes.

## Performance

A focused comparison on ordinary subjects without equality overrides found no measured CPU regression. `AddLotsOfPreviousCars` and complete updates were effectively unchanged within run variation; the other measured identity-sensitive paths improved. Two small follow-up changes remove the initial 72-byte snapshot and 80-byte collection-diff allocation increases. Final allocation measurements on those paths match master.

The table compares master `bfa20df0` with the comparer changes at `0709e259`, before the allocation follow-up. Values average two fresh-process runs per revision in master/PR/PR/master order. BenchmarkDotNet 0.15.5, .NET 9.0.10, Apple M4 Max; each case used six warmups and fifteen measured iterations with a 250 ms iteration target and memory randomization. CPU frequency was not pinned, so small timing differences should not be treated as guaranteed improvements.

| Benchmark | Before | After | Delta | Allocated before → after |
|---|---:|---:|---:|---|
| AddLotsOfPreviousCars | 28.341 ms | 28.147 ms | -0.68%, within variation | approximately 19.67 MB, unchanged at this precision |
| CompleteUpdate | 2.929 μs | 2.861 μs | -2.29%, within variation | 5,904 → 5,904 B |
| LeafPartialUpdate | 1.107 μs | 1.059 μs | -4.39% | 2,656 → 2,656 B |
| RebuildRegistrySnapshot | 82.979 μs | 78.063 μs | -5.92% | 66,216 → 66,288 B |
| ReorderCollection | 11.973 μs | 10.611 μs | -11.38% | 14,288 → 14,368 B |
| ReplaceHalfCollection | 23.593 μs | 22.553 μs | -4.41% | 45,825 → 45,905 B |
| ServiceOrderResolver.LinearChain, noise reference | 0.9785 μs | 0.9820 μs | +0.36% | 3,720 → 3,720 B |

Final commit `710216a0` was then measured in two additional fresh-process runs with the same settings. These verify the allocation corrections; they are not another interleaved master comparison. Both runs allocated exactly 66,216 B for snapshot rebuilding, 14,288 B for reordering, 45,825 B for half replacement, and 3,720 B for the noise reference. Mean times across those two runs were 81.234 μs, 10.547 μs, 22.167 μs, and 0.9780 μs respectively. No additional per-operation allocations remain in the measured paths. This is a focused comparison, not the full benchmark suite or a sustained-load test.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 5 | 17 | 14 | +3 |
| Tests and benchmarks | 2 | 176 | 1 | +175 |
| Documentation | 1 | 1 | 1 | 0 |
| **Total** | **8** | **194** | **16** | **+178** |

## Verification

- [x] Seven regression cases failed before their corresponding fixes and passed afterward: separate registrations, collection positions, child replacement, complete/partial values, and structural partial replacement/reorder round trips.
- [x] Registry tests: 161 passed.
- [x] Tracking tests: 571 passed.
- [x] Connectors tests: 791 passed.
- [x] Subject-update documentation updated.
- [x] Fresh independent review of the entire final committed diff, including both allocation corrections: no actionable findings. `git diff --check` passed.
- [x] Final CI passed for commit `710216a0` against master containing #528, #529 and #530: full unit-test job plus MQTT, OPC UA and WebSocket integration jobs. [CI run](https://github.com/RicoSuter/Namotion.Interceptor/actions/runs/34297205263).
- [x] Focused benchmarks against master, including a noise reference, plus two final allocation verification runs.
- ~~Load tests and chaos tests~~: not run for these bounded comparer and allocation changes.

Registry (161) and Connectors (791) tests were rerun after both final allocation corrections. Tracking (571) passed earlier; its code is unchanged by those corrections. Local tests used the existing cached NuGet feed and package cache; final CI passed with normal dependency restore.
