### PR TITLE
fix: defer hosted startup until configuration completes

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -140,9 +140,26 @@ await person.AttachHostedServiceAsync(
     cancellationToken);
 ```
 
+## Construction and Configuration
+
+A context-taking constructor can attach a hosted subject before its object initializer or deserializer has populated configuration. There is no timing delay that guarantees initialization completes first. Construct and populate a detached subject before attaching it, or use a startup scope. The scope keeps context-taking construction available while delaying captured service starts:
+
+```csharp
+using (var startup = context.DeferHostedServiceStartup())
+{
+    var person = new Person(context) { FirstName = "John", LastName = "Doe" };
+    person.AttachHostedService(new PersonBackgroundService(person));
+    startup?.Complete();
+}
+```
+
+The scope follows the current execution flow for that context. Starts wait until the scope and all enclosing scopes are completed and disposed. Disposal without `Complete()` cancels captured starts, including when initialization throws. Cancellation does not detach subjects; normal detach and host shutdown still stop their attached services. The extension returns null when hosted services are not configured. Do not await an attaching service's startup inside its open scope, since that startup is waiting for scope disposal.
+
+`AddHostedSubject<T>()` holds a scope through its configuration callback. HomeBlaze deserialization uses this scope while populating configuration. Root loading holds an enclosing scope until the root is published, attached and registered as a context service.
+
 ## Deferred Starts and Startup Completion
 
-Attaching a hosted service queues its `StartAsync` rather than running it inline, so the service is not running when the attach returns. Any subsystem that treats "the graph has finished starting" as a completion point would otherwise pass that point while a queued start is still on its way in.
+Attaching a hosted service queues its `StartAsync` without waiting for it. Any subsystem that treats "the graph has finished starting" as a completion point would otherwise pass that point while a queued start is still on its way in.
 
 A subsystem says so by implementing `IStartupCompletionDeferrer` and registering it on the context. Before queueing a start, the hosting layer takes a hold on every reachable deferrer and releases it once the start has actually run, including when the start throws. Both attach paths do this, awaiting and fire-and-forget alike: awaiting the start blocks the caller, but it does not block whatever else is deciding that startup is finished, so the gap still needs holding open.
 

--- a/src/HomeBlaze/HomeBlaze.E2E.Tests/SubjectSetupDialogTests.cs
+++ b/src/HomeBlaze/HomeBlaze.E2E.Tests/SubjectSetupDialogTests.cs
@@ -37,6 +37,11 @@ public class SubjectSetupDialogTests
         await page.GotoAsync($"{_fixture.ServerAddress}");
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
+        // The automatic timezone resolves through JS after interactive rendering. Prerendered
+        // links are already clickable, but navigating then can race the old page's hydration.
+        await Assertions.Expect(page.GetByTitle(new System.Text.RegularExpressions.Regex(@"^Automatic \(")))
+            .ToBeVisibleAsync(new() { Timeout = PageLoadTimeout });
+
         var browserLink = page.GetByRole(AriaRole.Link, new() { Name = "Browser" });
         await Assertions.Expect(browserLink).ToBeVisibleAsync(new() { Timeout = PageLoadTimeout });
         await browserLink.ClickAsync();

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurableSubjectStartupTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurableSubjectStartupTests.cs
@@ -1,0 +1,182 @@
+using HomeBlaze.Abstractions;
+using HomeBlaze.Abstractions.Attributes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Namotion.Interceptor;
+using Namotion.Interceptor.Attributes;
+using Namotion.Interceptor.Hosting;
+
+namespace HomeBlaze.Services.Tests.Serialization;
+
+public class ConfigurableSubjectStartupTests
+{
+    [Fact]
+    public async Task WhenRootIsLoaded_ThenHostedStartupSeesPublicationAndServiceRegistration()
+    {
+        // Arrange
+        using var probe = new ConfigurableStartupProbe();
+        probe.Release.Set();
+        var services = new ServiceCollection().AddSingleton(probe)
+            .AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(Microsoft.Extensions.Logging.Abstractions.NullLogger<>));
+        var context = InterceptorSubjectContext.Create().WithHostedServices(services);
+        services.AddSingleton(context);
+        await using var provider = services.BuildServiceProvider();
+        var handler = Assert.Single(provider.GetServices<IHostedService>());
+        var types = new TypeProvider();
+        types.AddTypes([typeof(ConfigurableStartupSubject)]);
+        var path = Path.Combine(Path.GetTempPath(), $"root-startup-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, """
+            {"$type":"HomeBlaze.Services.Tests.Serialization.ConfigurableStartupSubject","configuration":"configured"}
+            """);
+        var configuration = new Mock<IConfiguration>();
+        configuration.Setup(value => value["HomeBlaze:RootConfigFile"]).Returns(path);
+        RootManager? manager = null;
+        using var rootManager = manager = new RootManager(new SubjectTypeRegistry(types),
+            new ConfigurableSubjectSerializer(types, provider), context,
+            new SubjectPathResolver(() => manager?.Root), configuration.Object);
+        var published = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        probe.Starting = subject => published.TrySetResult(ReferenceEquals(rootManager.Root, subject) &&
+            ReferenceEquals(context.TryGetService<ConfigurableStartupSubject>(), subject));
+        await handler.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Act
+            await rootManager.StartAsync(CancellationToken.None);
+            await rootManager.RootLoaded.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.True(await published.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Equal("configured", await probe.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+        finally
+        {
+            await handler.StopAsync(CancellationToken.None);
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task WhenConfigurationIsPopulated_ThenHostedStartupReadsTheConfiguredValue()
+    {
+        // Arrange
+        using var probe = new ConfigurableStartupProbe();
+        var services = new ServiceCollection().AddSingleton(probe)
+            .AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(Microsoft.Extensions.Logging.Abstractions.NullLogger<>));
+        var context = InterceptorSubjectContext.Create().WithHostedServices(services);
+        services.AddSingleton(context);
+        using var provider = services.BuildServiceProvider();
+        var handler = Assert.Single(provider.GetServices<IHostedService>());
+        probe.BeforeAssignment = () => handler.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+        var types = new TypeProvider();
+        var type = typeof(ConfigurableStartupSubject);
+        types.AddTypes([type]);
+        var serializer = new ConfigurableSubjectSerializer(types, provider);
+        var deserialize = Task.Run(() => serializer.Deserialize($$"""
+            {"$type":"{{type.FullName}}","configuration":"configured"}
+            """));
+        try
+        {
+            // Act
+            await probe.Populating.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            probe.Release.Set();
+            var subject = (IInterceptorSubject)(await deserialize.WaitAsync(TimeSpan.FromSeconds(10)))!;
+            var observed = await probe.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.Equal("configured", observed);
+            Assert.Same(handler, subject.Context.GetService<IHostedService>());
+        }
+        finally
+        {
+            probe.Release.Set();
+            await deserialize.WaitAsync(TimeSpan.FromSeconds(10));
+            await handler.StopAsync(CancellationToken.None);
+        }
+    }
+    [Fact]
+    public async Task WhenConfigurationPopulationThrows_ThenThePartiallyConfiguredServiceNeverStarts()
+    {
+        // Arrange
+        using var probe = new ConfigurableStartupProbe { FailPopulation = true };
+        probe.Release.Set();
+        var services = new ServiceCollection().AddSingleton(probe)
+            .AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(Microsoft.Extensions.Logging.Abstractions.NullLogger<>));
+        var context = InterceptorSubjectContext.Create().WithHostedServices(services);
+        services.AddSingleton(context);
+        using var provider = services.BuildServiceProvider();
+        var handler = Assert.Single(provider.GetServices<IHostedService>());
+        await handler.StartAsync(CancellationToken.None);
+        var types = new TypeProvider();
+        types.AddTypes([typeof(ConfigurableStartupSubject)]);
+        var serializer = new ConfigurableSubjectSerializer(types, provider);
+
+        try
+        {
+            // Act
+            Assert.Throws<System.Reflection.TargetInvocationException>(() => serializer.Deserialize("""
+                {"$type":"HomeBlaze.Services.Tests.Serialization.ConfigurableStartupSubject","configuration":"configured"}
+                """));
+            using var next = new ConfigurableStartupProbe();
+            _ = new ConfigurableStartupSubject(next, context);
+            await next.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.False(probe.Started.Task.IsCompleted);
+        }
+        finally
+        {
+            await handler.StopAsync(CancellationToken.None);
+        }
+    }
+}
+
+public sealed class ConfigurableStartupProbe : IDisposable
+{
+    public TaskCompletionSource Populating { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource<string> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public ManualResetEventSlim Release { get; } = new();
+    public bool FailPopulation { get; init; }
+    public Action? BeforeAssignment { get; set; }
+    public Action<ConfigurableStartupSubject>? Starting { get; set; }
+    public void Dispose() => Release.Dispose();
+}
+
+[InterceptorSubject]
+public partial class ConfigurableStartupSubject : IHostedService, IConfigurable
+{
+    private readonly ConfigurableStartupProbe _probe;
+    private string _configuration = string.Empty;
+
+    public ConfigurableStartupSubject(ConfigurableStartupProbe probe, IInterceptorSubjectContext context)
+    {
+        _probe = probe;
+        ((IInterceptorSubject)this).Context.AddFallbackContext(context);
+    }
+
+    [Configuration]
+    public string Configuration
+    {
+        get => _configuration;
+        set
+        {
+            _probe.Populating.TrySetResult();
+            if (!_probe.Release.Wait(TimeSpan.FromSeconds(10))) throw new TimeoutException();
+            _probe.BeforeAssignment?.Invoke();
+            if (_probe.FailPopulation) throw new InvalidOperationException("Invalid configuration");
+            _configuration = value;
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _probe.Starting?.Invoke(this);
+        _probe.Started.TrySetResult(Configuration);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task ApplyConfigurationAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/HomeBlaze/HomeBlaze.Services/ConfigurableSubjectSerializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/ConfigurableSubjectSerializer.cs
@@ -6,6 +6,7 @@ using HomeBlaze.Abstractions.Attributes;
 using HomeBlaze.Services.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Namotion.Interceptor;
+using Namotion.Interceptor.Hosting;
 using Namotion.Interceptor.Registry;
 
 namespace HomeBlaze.Services;
@@ -79,6 +80,7 @@ public class ConfigurableSubjectSerializer
             return null;
         }
 
+        using var startup = _serviceProvider.GetService<IInterceptorSubjectContext>()?.DeferHostedServiceStartup();
         // Create instance using ActivatorUtilities for DI-aware construction
         var subject = ActivatorUtilities.CreateInstance(_serviceProvider, type) as IConfigurable;
         if (subject == null)
@@ -86,9 +88,8 @@ public class ConfigurableSubjectSerializer
             return null;
         }
 
-        // Populate configuration properties from JSON using reflection
-        // (can't use UpdateConfiguration because subject isn't registered in a context yet)
         PopulateConfigurationProperties(subject, type, root);
+        startup?.Complete();
         return subject;
     }
 

--- a/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Namotion.Interceptor;
+using Namotion.Interceptor.Hosting;
 
 namespace HomeBlaze.Services;
 
@@ -111,6 +112,7 @@ public class RootManager : BackgroundService, IConfigurationWriter
         }
 
         var json = await File.ReadAllTextAsync(_configurationPath, cancellationToken);
+        using var startup = _context.DeferHostedServiceStartup();
         var root = _serializer.Deserialize(json);
 
         // All IConfigurable implementations are also IInterceptorSubject (via [InterceptorSubject] attribute)
@@ -119,6 +121,7 @@ public class RootManager : BackgroundService, IConfigurationWriter
 
         _logger?.LogInformation("Root loaded: {Type}", Root.GetType().FullName);
         _context.AddService(Root);
+        startup?.Complete();
 
         return Root;
     }

--- a/src/Namotion.Interceptor.Hosting.Tests/HostedServiceHandlerTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/HostedServiceHandlerTests.cs
@@ -17,7 +17,7 @@ public class HostedServiceHandlerTests
         await RunWithAppLifecycleAsync(async context =>
         {
             person = new PersonWithBackgroundService(context);
-            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John" && person.LastName == "Doe");
 
             // Assert
             Assert.Equal("John", person.FirstName);
@@ -41,7 +41,7 @@ public class HostedServiceHandlerTests
             var hostedService = new PersonBackgroundService(person);
             person.AttachHostedService(hostedService);
 
-            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John" && person.LastName == "Doe");
 
             // Assert
             Assert.Equal("John", person.FirstName);
@@ -65,7 +65,7 @@ public class HostedServiceHandlerTests
             person.AttachHostedService(hostedService);
             var attachedHostedServices = person.GetAttachedHostedServices();
 
-            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John" && person.LastName == "Doe");
 
             Assert.Equal("John", person.FirstName);
             Assert.Equal("Doe", person.LastName);
@@ -95,7 +95,7 @@ public class HostedServiceHandlerTests
             person.AttachHostedService(hostedService);
             var attachedHostedServices = person.GetAttachedHostedServices();
 
-            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John");
+            await AsyncTestHelpers.WaitUntilAsync(() => person.FirstName == "John" && person.LastName == "Doe");
             Assert.Single(attachedHostedServices);
 
             // Act

--- a/src/Namotion.Interceptor.Hosting.Tests/HostedServiceStartupScopeTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/HostedServiceStartupScopeTests.cs
@@ -1,0 +1,384 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Namotion.Interceptor.Hosting.Tests.Models;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Testing;
+
+namespace Namotion.Interceptor.Hosting.Tests;
+
+public class HostedServiceStartupScopeTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WhenScopeIsOpen_ThenIndependentFlowCanStartAndStopServices(bool alreadyStarted)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var subject = new Person(fixture.Context);
+        var scoped = new ProbeService(() => "scoped");
+        var independent = new ProbeService(() => "independent");
+        if (alreadyStarted)
+        {
+            await subject.AttachHostedServiceAsync(independent, CancellationToken.None);
+        }
+        var proceed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var independentFlow = Task.Run(async () =>
+        {
+            await proceed.Task;
+            if (!alreadyStarted)
+            {
+                await subject.AttachHostedServiceAsync(independent, CancellationToken.None);
+            }
+            await subject.DetachHostedServiceAsync(independent, CancellationToken.None);
+        });
+
+        // Act
+        using (var scope = fixture.Context.DeferHostedServiceStartup())
+        {
+            subject.AttachHostedService(scoped);
+            proceed.SetResult();
+            await independentFlow.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.False(scoped.Started.Task.IsCompleted);
+            scope!.Complete();
+        }
+        await scoped.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task WhenNestedScopeCompletes_ThenStartWaitsForTheOuterScope()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var configuration = "uninitialized";
+        var service = new ProbeService(() => configuration);
+        var subject = new Person(fixture.Context);
+
+        // Act
+        using (var outer = fixture.Context.DeferHostedServiceStartup())
+        {
+            using (var inner = fixture.Context.DeferHostedServiceStartup())
+            {
+                subject.AttachHostedService(service);
+                inner!.Complete();
+            }
+            await fixture.Handler.StartAsync(CancellationToken.None);
+            Assert.False(service.Started.Task.IsCompleted);
+            configuration = "configured";
+            outer!.Complete();
+        }
+
+        // Assert
+        Assert.Equal("configured", await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WhenAScopeFails_ThenItsQueuedStartIsCanceled(bool outerFails)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var service = new ProbeService(() => "started");
+        var subject = new Person(fixture.Context);
+        Task attachment;
+
+        // Act
+        using (var outer = fixture.Context.DeferHostedServiceStartup())
+        {
+            using (var inner = fixture.Context.DeferHostedServiceStartup())
+            {
+                attachment = subject.AttachHostedServiceAsync(service, CancellationToken.None);
+                if (outerFails) inner!.Complete();
+            }
+            if (!outerFails) outer!.Complete();
+        }
+
+        // Assert
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => attachment.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.False(service.Started.Task.IsCompleted);
+        await fixture.HoldsReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    public async Task WhenHandlerStopsDuringAnOpenScope_ThenAllStartsAreCanceledAndHoldsAreReleased(int count)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        var services = Enumerable.Range(0, count).Select(_ => new ProbeService(() => "started")).ToArray();
+        var subject = new Person(fixture.Context);
+        using var scope = fixture.Context.DeferHostedServiceStartup();
+        var attachments = services.Select(service => subject.AttachHostedServiceAsync(service, CancellationToken.None)).ToArray();
+        Assert.Equal(count, fixture.HoldsTaken);
+        Assert.Equal(0, fixture.HoldsDisposed);
+
+        // Act
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        await fixture.Handler.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+        scope!.Complete();
+        scope.Dispose();
+
+        // Assert
+        foreach (var attachment in attachments)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => attachment.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+        Assert.Equal(count, fixture.HoldsDisposed);
+        Assert.All(services, service => Assert.False(service.Started.Task.IsCompleted));
+    }
+
+    [Fact]
+    public async Task WhenShutdownCancellationDetachesADeferredService_ThenShutdownStillStopsIt()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var subject = new Person(fixture.Context);
+        var releaseStart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deferred = new ProbeService(() => "deferred", () => stopped.TrySetResult());
+        var blocking = new ProbeService(() => "blocking", startup: releaseStart.Task,
+            starting: token => token.Register(() => subject.DetachHostedService(deferred)));
+        subject.AttachHostedService(blocking);
+        await blocking.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        using var scope = fixture.Context.DeferHostedServiceStartup();
+        subject.AttachHostedService(deferred);
+        Task? stopping = null;
+
+        try
+        {
+            // Act
+            stopping = fixture.Handler.StopAsync(CancellationToken.None);
+
+            // Assert
+            await stopped.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.False(deferred.Started.Task.IsCompleted);
+        }
+        finally
+        {
+            releaseStart.TrySetResult();
+            await (stopping ?? fixture.Handler.StopAsync(CancellationToken.None)).WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        Assert.Equal(2, fixture.HoldsDisposed);
+    }
+
+    [Theory]
+    [InlineData("Stop")]
+    [InlineData("Dispose")]
+    [InlineData("Cancellation")]
+    public async Task WhenShutdownBeginsWhileAStartIsBlocked_ThenReattachmentTakesNoStartupHold(string shutdown)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        using var cancellation = new CancellationTokenSource();
+        await fixture.Handler.StartAsync(cancellation.Token);
+        var subject = new Person(fixture.Context);
+        var releaseStart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocking = new ProbeService(() => "blocking", startup: releaseStart.Task);
+        subject.AttachHostedService(blocking);
+        await blocking.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        using var scope = fixture.Context.DeferHostedServiceStartup();
+        var deferred = new ProbeService(() => "deferred", () => stopped.TrySetResult());
+        var attachment = subject.AttachHostedServiceAsync(deferred, CancellationToken.None);
+        Task? stopping = null;
+
+        try
+        {
+            // Act
+            if (shutdown == "Stop")
+            {
+                stopping = fixture.Handler.StopAsync(CancellationToken.None);
+                await stopped.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            else if (shutdown == "Dispose")
+            {
+                ((IDisposable)fixture.Handler).Dispose();
+            }
+            else
+            {
+                await cancellation.CancelAsync();
+            }
+            subject.DetachHostedService(deferred);
+            var exception = Record.Exception(() => subject.AttachHostedService(deferred));
+
+            // Assert
+            Assert.Null(exception);
+            Assert.Equal(2, fixture.HoldsTaken);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => subject.AttachHostedServiceAsync(
+                new ProbeService(() => "late"), CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Equal(2, fixture.HoldsTaken);
+        }
+        finally
+        {
+            releaseStart.TrySetResult();
+            await (stopping ?? fixture.Handler.StopAsync(CancellationToken.None)).WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => attachment.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Equal(2, fixture.HoldsDisposed);
+        Assert.False(deferred.Started.Task.IsCompleted);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WhenDeferredServiceIsDetached_ThenItsStartIsCanceledBeforeScopeRelease(bool reattach)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var events = new List<string>();
+        var service = new ProbeService(() => { events.Add("start"); return "started"; }, () => events.Add("stop"));
+        var subject = new Person(fixture.Context);
+        Task? secondAttachment = null;
+
+        // Act
+        using (var scope = fixture.Context.DeferHostedServiceStartup())
+        {
+            var firstAttachment = subject.AttachHostedServiceAsync(service, CancellationToken.None);
+            var detachment = subject.DetachHostedServiceAsync(service, CancellationToken.None);
+            if (reattach)
+            {
+                secondAttachment = subject.AttachHostedServiceAsync(service, CancellationToken.None);
+            }
+            await detachment.WaitAsync(TimeSpan.FromSeconds(10));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => firstAttachment.WaitAsync(TimeSpan.FromSeconds(10)));
+            await AsyncTestHelpers.WaitUntilAsync(() => Volatile.Read(ref fixture.HoldsDisposed) == 1);
+            Assert.False(service.Started.Task.IsCompleted);
+            scope!.Complete();
+        }
+        if (secondAttachment is not null)
+        {
+            await secondAttachment.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        // A queued independent start is a barrier for all previously eligible actions.
+        await subject.AttachHostedServiceAsync(new ProbeService(() => "barrier"), CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        Assert.Equal(reattach ? new[] { "stop", "start" } : new[] { "stop" }, events);
+        await AsyncTestHelpers.WaitUntilAsync(() => Volatile.Read(ref fixture.HoldsDisposed) == fixture.HoldsTaken);
+        Assert.Equal(fixture.HoldsTaken, fixture.HoldsDisposed);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WhenScopeReleasesSeveralStarts_ThenTheyRunInAttachmentOrder(bool nested)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var events = new List<string>();
+        var subject = new Person(fixture.Context);
+        var attachments = new List<Task>();
+
+        // Act
+        using (var outer = fixture.Context.DeferHostedServiceStartup())
+        {
+            using (var inner = nested ? fixture.Context.DeferHostedServiceStartup() : null)
+            {
+                attachments.Add(subject.AttachHostedServiceAsync(new ProbeService(() => { events.Add("first"); return "first"; }), CancellationToken.None));
+                inner?.Complete();
+            }
+            attachments.Add(subject.AttachHostedServiceAsync(new ProbeService(() => { events.Add("second"); return "second"; }), CancellationToken.None));
+            Assert.Equal(2, fixture.HoldsTaken);
+            Assert.Equal(0, fixture.HoldsDisposed);
+            outer!.Complete();
+        }
+        await Task.WhenAll(attachments).WaitAsync(TimeSpan.FromSeconds(10));
+        await fixture.HoldsReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        Assert.Equal(new[] { "first", "second" }, events);
+        Assert.Equal(2, fixture.HoldsDisposed);
+    }
+
+    [Fact]
+    public async Task WhenHandlerStartsInsideAFailedScope_ThenLaterServicesCanStartTheirChildren()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        using (fixture.Context.DeferHostedServiceStartup())
+        {
+            await fixture.Handler.StartAsync(CancellationToken.None);
+        }
+        var subject = new Person(fixture.Context);
+        var child = new ProbeService(() => "child");
+        var parent = new ProbeService(() =>
+        {
+            subject.AttachHostedService(child);
+            return "parent";
+        });
+
+        // Act
+        await subject.AttachHostedServiceAsync(parent, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        Assert.Equal("child", await child.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+    }
+
+    private sealed class Fixture : IAsyncDisposable, IStartupCompletionDeferrer
+    {
+        private readonly ServiceProvider _provider;
+        public IInterceptorSubjectContext Context { get; }
+        public IHostedService Handler { get; }
+        public int HoldsTaken;
+        public int HoldsDisposed;
+        public TaskCompletionSource HoldsReleased { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Fixture()
+        {
+            var services = new ServiceCollection().AddLogging();
+            Context = InterceptorSubjectContext.Create().WithHostedServices(services);
+            Context.AddService<IStartupCompletionDeferrer>(this);
+            _provider = services.BuildServiceProvider();
+            Handler = Assert.Single(_provider.GetServices<IHostedService>());
+        }
+
+        public IDisposable DeferCompletion()
+        {
+            Interlocked.Increment(ref HoldsTaken);
+            return new CompletionHold(() =>
+            {
+                if (Interlocked.Increment(ref HoldsDisposed) == Volatile.Read(ref HoldsTaken))
+                {
+                    HoldsReleased.TrySetResult();
+                }
+            });
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Handler.StopAsync(CancellationToken.None);
+            await _provider.DisposeAsync();
+        }
+    }
+
+    private sealed class CompletionHold(Action released) : IDisposable
+    {
+        public void Dispose() => released();
+    }
+
+    private sealed class ProbeService(Func<string> readConfiguration, Action? stopped = null, Task? startup = null, Action<CancellationToken>? starting = null) : IHostedService
+    {
+        public TaskCompletionSource<string> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            starting?.Invoke(cancellationToken);
+            Started.TrySetResult(readConfiguration());
+            return startup ?? Task.CompletedTask;
+        }
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            stopped?.Invoke();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Namotion.Interceptor.Hosting.Tests/HostedSubjectConfigurationTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/HostedSubjectConfigurationTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Namotion.Interceptor.Attributes;
+
+namespace Namotion.Interceptor.Hosting.Tests;
+
+public class HostedSubjectConfigurationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WhenHostedSubjectHasAConfigurationCallback_ThenItsServiceStartsAfterConfiguration(bool resolverReturnsNull)
+    {
+        // Arrange
+        var services = new ServiceCollection().AddLogging();
+        var context = InterceptorSubjectContext.Create().WithHostedServices(services);
+        var handler = Assert.Single(context.GetServices<IHostedService>());
+        services.AddSingleton(context);
+        services.AddHostedSubject<ConfiguredHostedSubject>(subject =>
+        {
+            handler.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+            subject.Configuration = "configured";
+        }, contextResolver: resolverReturnsNull ? _ => null : null);
+        await using var provider = services.BuildServiceProvider();
+
+        try
+        {
+            // Act
+            var subject = provider.GetRequiredService<ConfiguredHostedSubject>();
+
+            // Assert
+            Assert.Equal("configured", await subject.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+        finally
+        {
+            await handler.StopAsync(CancellationToken.None);
+        }
+    }
+}
+
+[InterceptorSubject]
+public partial class ConfiguredHostedSubject : IHostedService
+{
+    public string Configuration { get; set; } = string.Empty;
+    public TaskCompletionSource<string> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        Started.TrySetResult(Configuration);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Namotion.Interceptor.Hosting.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Hosting.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -2,6 +2,11 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
 namespace Namotion.Interceptor.Hosting
 {
+    public sealed class HostedServiceStartupScope : System.IDisposable
+    {
+        public void Complete() { }
+        public void Dispose() { }
+    }
     public static class HostedSubjectServiceCollectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddHostedSubject<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<T>? configure = null, System.Func<System.IServiceProvider, Namotion.Interceptor.IInterceptorSubjectContext?>? contextResolver = null)
@@ -17,6 +22,7 @@ namespace Namotion.Interceptor.Hosting
     }
     public static class InterceptorSubjectContextExtensions
     {
+        public static Namotion.Interceptor.Hosting.HostedServiceStartupScope? DeferHostedServiceStartup(this Namotion.Interceptor.IInterceptorSubjectContext context) { }
         public static Namotion.Interceptor.IInterceptorSubjectContext WithHostedServices(this Namotion.Interceptor.IInterceptorSubjectContext context, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
     }
 }

--- a/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
@@ -16,8 +16,14 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     private CancellationTokenSource? _stoppingCts;
 
     private readonly Func<ILogger?> _loggerResolver;
-    private readonly BufferBlock<Func<CancellationToken, Task>> _actions = new();
+    private readonly BufferBlock<(HostedServiceStartupScope? Scope, Task Ready, Func<CancellationToken, Task> Execute)> _actions = new();
+    private readonly Dictionary<IHostedService, CancellationTokenSource> _deferredStarts = [];
+    private bool _isStopping;
+    private bool IsStopping => _isStopping || _stoppingCts?.IsCancellationRequested == true;
     private readonly HashSet<IHostedService> _hostedServices = [];
+    private readonly AsyncLocal<HostedServiceStartupScope?> _startupScope = new();
+
+    internal HostedServiceStartupScope DeferStartup() => new(_startupScope);
 
     public HostedServiceHandler(Func<ILogger?> loggerResolver)
     {
@@ -74,21 +80,78 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
 
     private async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // The long-lived action loop must not inherit the scope in which the host was started.
+        _startupScope.Value = null;
         _logger ??= _loggerResolver();
 
-        while (!stoppingToken.IsCancellationRequested)
+        var pending = new List<(HostedServiceStartupScope? Scope, Task Ready, Func<CancellationToken, Task> Execute)>();
+        try
         {
-            try
+            while (!stoppingToken.IsCancellationRequested)
             {
-                var action = await _actions.ReceiveAsync(stoppingToken);
-                await action(stoppingToken);
-            }
-            catch (Exception exception)
-            {
-                if (exception is not OperationCanceledException)
+                try
                 {
-                    _logger?.LogError(exception, "Failed to execute hosted service action.");
+                    var readyIndex = pending.FindIndex(action => action.Scope?.IsReady == true || action.Ready.IsCompleted);
+                    if (readyIndex >= 0)
+                    {
+                        // A scope may release while the scan is in progress. Recheck earlier
+                        // entries so starts released together retain attachment order.
+                        if (readyIndex > 0)
+                        {
+                            readyIndex = pending.FindIndex(action => action.Scope?.IsReady == true || action.Ready.IsCompleted);
+                        }
+                        var action = pending[readyIndex];
+                        pending.RemoveAt(readyIndex);
+                        await action.Execute(stoppingToken);
+                    }
+                    else if (pending.Count == 0)
+                    {
+                        var action = await _actions.ReceiveAsync(stoppingToken);
+                        if (action.Scope?.IsReady == true || action.Ready.IsCompleted)
+                        {
+                            await action.Execute(stoppingToken);
+                        }
+                        else
+                        {
+                            pending.Add(action);
+                        }
+                    }
+                    else if (_actions.TryReceive(out var action))
+                    {
+                        pending.Add(action);
+                    }
+                    else
+                    {
+                        // Scope readiness must not occupy the consumer: unrelated starts and stops
+                        // can be queued while configuration waits for those services.
+                        using var wakeCancellation = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                        await Task.WhenAny(pending.Select(action => action.Ready)
+                            .Append(_actions.OutputAvailableAsync(wakeCancellation.Token)));
+                        await wakeCancellation.CancelAsync();
+                    }
                 }
+                catch (Exception exception)
+                {
+                    if (exception is not OperationCanceledException)
+                    {
+                        _logger?.LogError(exception, "Failed to execute hosted service action.");
+                    }
+                }
+            }
+        }
+        finally
+        {
+            lock (_hostedServices)
+            {
+                _isStopping = true;
+            }
+            while (_actions.TryReceive(out var action))
+            {
+                pending.Add(action);
+            }
+            foreach (var action in pending)
+            {
+                await action.Execute(new CancellationToken(true));
             }
         }
     }
@@ -98,6 +161,11 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
         if (_executeTask == null)
         {
             return;
+        }
+
+        lock (_hostedServices)
+        {
+            _isStopping = true;
         }
 
         try
@@ -145,7 +213,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     {
         lock (_hostedServices)
         {
-            if (_hostedServices.Add(hostedService))
+            if (!IsStopping && _hostedServices.Add(hostedService))
             {
                 // Starting is queued, not inline, so the service is NOT running when this returns.
                 // Anything that treats "the graph has finished starting" as a completion point would
@@ -192,7 +260,8 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     {
         lock (_hostedServices)
         {
-            if (_hostedServices.Remove(hostedService))
+            // Shutdown owns the stop once cancellation begins, including during its callbacks.
+            if (!IsStopping && _hostedServices.Remove(hostedService))
             {
                 PostStopService(hostedService, null);
             }
@@ -205,7 +274,11 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
         var tcs = new TaskCompletionSource();
         lock (_hostedServices)
         {
-            if (_hostedServices.Add(hostedService))
+            if (IsStopping)
+            {
+                tcs.TrySetCanceled();
+            }
+            else if (_hostedServices.Add(hostedService))
             {
                 // Holds here too, even though this overload's caller awaits the start: the caller
                 // being blocked does not block the startup-completion gate, so without a hold
@@ -227,7 +300,11 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
         var tcs = new TaskCompletionSource();
         lock (_hostedServices)
         {
-            if (_hostedServices.Remove(hostedService))
+            if (IsStopping)
+            {
+                tcs.TrySetCanceled();
+            }
+            else if (_hostedServices.Remove(hostedService))
             {
                 PostStopService(hostedService, tcs);
             }
@@ -243,15 +320,37 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     private void PostStartService(
         IHostedService hostedService, TaskCompletionSource? tcs, IDisposable[]? startupHolds = null)
     {
-        _actions.Post(async token =>
+        // The action loop has a different execution flow from the code constructing the subject.
+        var startupScope = _startupScope.Value;
+        var cancellation = startupScope is null ? null : new CancellationTokenSource();
+        if (cancellation is not null)
+        {
+            _deferredStarts.Add(hostedService, cancellation);
+        }
+        var readiness = startupScope?.WaitAsync(cancellation!.Token) ?? Task.CompletedTask;
+        _actions.Post((startupScope, readiness, async token =>
         {
             try
             {
-                await Task.Delay(50, token); // TODO: Fix small delay to let sync property assignments/deserialization complete
+                token.ThrowIfCancellationRequested();
+                if (cancellation is not null)
+                {
+                    await readiness.ConfigureAwait(false);
+                    lock (_hostedServices)
+                    {
+                        token.ThrowIfCancellationRequested();
+                        cancellation.Token.ThrowIfCancellationRequested();
+                        _deferredStarts.Remove(hostedService);
+                    }
+                }
 
                 _logger?.LogInformation("Starting attached hosted service {Service}.", hostedService.ToString());
                 await hostedService.StartAsync(token);
                 tcs?.TrySetResult();
+            }
+            catch (OperationCanceledException exception)
+            {
+                tcs?.TrySetCanceled(exception.CancellationToken);
             }
             catch (Exception ex)
             {
@@ -259,6 +358,19 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
             }
             finally
             {
+                if (cancellation is not null)
+                {
+                    lock (_hostedServices)
+                    {
+                        if (_deferredStarts.TryGetValue(hostedService, out var current) &&
+                            ReferenceEquals(current, cancellation))
+                        {
+                            _deferredStarts.Remove(hostedService);
+                        }
+                        cancellation.Cancel();
+                        cancellation.Dispose();
+                    }
+                }
                 // In a finally, so a start that throws or is cancelled releases its hold too.
                 // Leaking a hold would block every synchronization wait on the tree forever - a
                 // hang rather than a wrong answer, which is the safer direction, but still a hang.
@@ -281,12 +393,21 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
                     }
                 }
             }
-        });
+        }));
     }
 
     private void PostStopService(IHostedService hostedService, TaskCompletionSource? tcs)
     {
-        _actions.Post(async token =>
+        if (_deferredStarts.Remove(hostedService, out var cancellation))
+        {
+            cancellation.Cancel();
+        }
+        if (IsStopping)
+        {
+            tcs?.TrySetCanceled();
+            return;
+        }
+        _actions.Post((null, Task.CompletedTask, async token =>
         {
             try
             {
@@ -300,11 +421,15 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
             {
                 tcs?.TrySetException(ex);
             }
-        });
+        }));
     }
 
     public void Dispose()
     {
+        lock (_hostedServices)
+        {
+            _isStopping = true;
+        }
         _stoppingCts?.Cancel();
     }
 }

--- a/src/Namotion.Interceptor.Hosting/HostedServiceStartupScope.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceStartupScope.cs
@@ -1,0 +1,67 @@
+namespace Namotion.Interceptor.Hosting;
+
+/// <summary>
+/// Defers hosted-service starts captured in this scope until it and its enclosing scopes complete.
+/// </summary>
+/// <remarks>
+/// Call <see cref="Complete"/> before disposal to allow startup. Otherwise captured starts are canceled.
+/// Do not await a captured service's startup before completing and disposing the scope.
+/// Scopes must be disposed in reverse creation order in the creating execution flow.
+/// Canceling startup does not detach subjects; normal detach and host shutdown still stop attached services.
+/// </remarks>
+public sealed class HostedServiceStartupScope : IDisposable
+{
+    private readonly AsyncLocal<HostedServiceStartupScope?> _current;
+    private readonly HostedServiceStartupScope? _parent;
+    private readonly TaskCompletionSource<bool> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private bool _completed;
+    private bool _disposed;
+
+    internal HostedServiceStartupScope(AsyncLocal<HostedServiceStartupScope?> current)
+    {
+        _current = current;
+        _parent = current.Value;
+        current.Value = this;
+    }
+
+    /// <summary>
+    /// Allows captured starts after this scope and all enclosing scopes are successfully disposed.
+    /// </summary>
+    public void Complete()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _completed = true;
+    }
+
+    /// <summary>
+    /// Releases successful startup or cancels captured starts when <see cref="Complete"/> was not called.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        if (!ReferenceEquals(_current.Value, this))
+        {
+            throw new InvalidOperationException("Hosted-service startup scopes must be disposed in reverse creation order.");
+        }
+
+        _disposed = true;
+        _current.Value = _parent;
+        _completion.TrySetResult(_completed);
+    }
+
+    internal bool IsReady => _completion.Task.IsCompleted &&
+        (!_completion.Task.Result || _parent is null || _parent.IsReady);
+
+    internal async Task WaitAsync(CancellationToken cancellationToken)
+    {
+        if (!await _completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new OperationCanceledException("Hosted-service initialization did not complete.", cancellationToken);
+        }
+
+        if (_parent is not null)
+        {
+            await _parent.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Namotion.Interceptor.Hosting/HostedSubjectServiceCollectionExtensions.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedSubjectServiceCollectionExtensions.cs
@@ -19,8 +19,8 @@ public static class HostedSubjectServiceCollectionExtensions
     /// <param name="contextResolver">
     /// Optional resolver for the <see cref="IInterceptorSubjectContext"/>.
     /// If null, attempts to resolve from DI; if not registered in DI, no context is used.
-    /// If provided, uses the resolver's return value (which may be null for explicitly no context).
-    /// The context is only passed to the constructor if the subject has a constructor that accepts it.
+    /// A non-null result is passed explicitly when the subject has a context-taking constructor.
+    /// A null result leaves constructor argument resolution to dependency injection.
     /// </param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddHostedSubject<T>(
@@ -31,24 +31,18 @@ public static class HostedSubjectServiceCollectionExtensions
     {
         services.TryAddSingleton<T>(serviceProvider =>
         {
-            T instance;
-         
-            if (HasContextConstructor<T>())
-            {
-                var context = contextResolver != null
+            var context = HasContextConstructor<T>()
+                ? contextResolver != null
                     ? contextResolver(serviceProvider)
-                    : serviceProvider.GetService<IInterceptorSubjectContext>();
-
-                instance = context is not null ?
-                    ActivatorUtilities.CreateInstance<T>(serviceProvider, context) :
-                    ActivatorUtilities.CreateInstance<T>(serviceProvider);
-            }
-            else
-            {
-                instance = ActivatorUtilities.CreateInstance<T>(serviceProvider);
-            }
+                    : serviceProvider.GetService<IInterceptorSubjectContext>()
+                : null;
+            using var startup = (context ?? serviceProvider.GetService<IInterceptorSubjectContext>())?.DeferHostedServiceStartup();
+            var instance = context is not null
+                ? ActivatorUtilities.CreateInstance<T>(serviceProvider, context)
+                : ActivatorUtilities.CreateInstance<T>(serviceProvider);
 
             configure?.Invoke(instance);
+            startup?.Complete();
             return instance;
         });
 

--- a/src/Namotion.Interceptor.Hosting/InterceptorSubjectContextExtensions.cs
+++ b/src/Namotion.Interceptor.Hosting/InterceptorSubjectContextExtensions.cs
@@ -6,6 +6,13 @@ namespace Namotion.Interceptor.Hosting;
 
 public static class InterceptorSubjectContextExtensions
 {
+    /// <summary>
+    /// Defers hosted-service starts attached in the current execution flow until the scope completes.
+    /// Returns null when hosted services are not configured on this context.
+    /// </summary>
+    public static HostedServiceStartupScope? DeferHostedServiceStartup(this IInterceptorSubjectContext context)
+        => context.TryGetService<HostedServiceHandler>()?.DeferStartup();
+
     public static IInterceptorSubjectContext WithHostedServices(this IInterceptorSubjectContext context, IServiceCollection serviceCollection)
     {
         context


### PR DESCRIPTION
Replace the fixed 50 ms hosted-service startup delay with an explicit configuration scope. `AddHostedSubject` and HomeBlaze deserialization/root loading hold that scope until configuration and root publication are complete, so a hosted service cannot start against partially populated configuration.

This extracts the hosting startup fix from #527 onto master so #494 can remain focused on lifecycle ownership. It preserves master’s fallback-context implementation. No generator, core lifecycle, attachment-anchor or root-readiness changes are included.

- Related to #494
- Related to #527

## Contract

- `context.DeferHostedServiceStartup()` captures starts in the current execution flow for the resolved hosting handler. Call `Complete()` and dispose the scope to release them; nested scopes also wait for their enclosing scopes.
- Disposal without `Complete()` cancels captured starts. Cancellation does not detach the subjects; normal detach and host shutdown still stop their attached services.
- An open scope does not block unrelated ready starts or stops. Starts released together preserve attachment order. Service actions still execute serially, so an already-running `StartAsync` can delay subsequent actions.
- Detaching a scoped service cancels its pending start. Reattachment receives a separate cancellation generation. Shutdown closes admission before draining pending work and releases startup-completion holds as those actions finish cancellation.
- The extension returns null when hosting is not configured. Scopes must be disposed in reverse creation order in their creating execution flow. Do not await captured startup while its scope is open.

## Breaking changes

No existing public signature is removed or changed. The additive API is `HostedServiceStartupScope` (`Complete`, `Dispose`) and nullable `DeferHostedServiceStartup()`.

The implicit 50 ms startup grace period is removed. Code that constructs an already-attached hosted subject and then configures it must use a startup scope, or configure it before attaching. `AddHostedSubject` configuration callbacks and HomeBlaze configuration loading use scopes automatically. Unscoped starts remain queued but can execute immediately.

Pending canceled starts now report task cancellation. Attach/detach requests reaching a stopping handler are rejected by cancellation on the awaiting path; fire-and-forget requests do not queue more handler work.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| HomeBlaze.Services | 2 | 6 | 2 | +4 |
| Namotion.Interceptor.Hosting | 4 | 229 | 36 | +193 |
| Tests and benchmarks | 6 | 635 | 4 | +631 |
| Documentation | 1 | 18 | 1 | +17 |
| **Total** | **13** | **888** | **43** | **+845** |

## Verification

- [x] Documentation updated in `docs/hosting.md`, including the construction/configuration migration pattern.
- [x] Unit tests: all 3,960 tests in 34 nonempty suites passed in Release (`Category!=Integration`). This includes 27 Hosting tests and 229 HomeBlaze Services tests. The unchanged master Hosting baseline passed all 9 tests before extraction.
- [x] Integration tests: all 26 HomeBlaze browser tests passed in Release (`Category=Integration`).
- [x] CI: [run 34400133519](https://github.com/RicoSuter/Namotion.Interceptor/actions/runs/34400133519) passed on `4fc77396`, including unit, HomeBlaze, MQTT, OPC UA and WebSocket jobs.
- [ ] ~~Benchmarks~~ Not run; no benchmark claims are made for this extraction.
- [ ] ~~Load tests~~ Not applicable; no connector implementation changes.
- [ ] ~~Chaos tests~~ Not applicable; no connector implementation changes.

The first CI run exposed a browser-test hydration race: the wizard helper could click the prerendered Browser link before the existing dashboard circuit became interactive. Under sixfold Chromium CPU throttling, this reproduced with the browser URL displaying dashboard content instead of its Create button. The helper now waits for the automatic timezone indicator, which resolves only through an interactive JS roundtrip, before navigating. Existing navigation, Create-button and wizard assertions remain; no production behavior or timeouts changed. All 26 browser tests passed under the same throttling after the fix.

Independent review: completed against master with no actionable findings. The follow-up browser readiness check was independently reviewed as well. Review covered the entire extraction, including new tests and the public API snapshot.

Existing hosting limitations outside this extraction remain: stopping before the handler has ever started does not drain its queue, and a service’s already-running `StartAsync` may overlap shutdown `StopAsync`. This PR does not redesign service ownership or the entire host lifetime.
