### PR TITLE
fix: simplify the hosted startup scope and close its shutdown gaps

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -152,11 +152,11 @@ using (context.DeferHostedServiceStartup())
 }
 ```
 
-The scope follows the current execution flow for that context. Starts wait until the scope and all enclosing scopes are disposed, so the `using` is the whole contract. An exception unwinding through it releases the captured starts like any other exit: the scope decides when a start runs, not whether the subject is fit to run, so a subject whose configuration threw still starts and reports its own failure. The extension returns null when hosted services are not configured. Do not await an attaching service's startup inside its open scope, since that startup is waiting for scope disposal.
+The scope follows the current execution flow for that context. Captured starts wait until it and all enclosing scopes are disposed, including when configuration throws. Services and consumers remain responsible for configuration validity. The extension returns null when hosted services are not configured. Do not await a captured service's startup inside its open scope.
 
-Scopes should be disposed in reverse creation order in the execution flow that created them. Nothing enforces it: disposal out of order, from another flow, or more than once releases the scope's own starts and is otherwise ignored, so a misuse is silent rather than loud. A scope that is never disposed at all holds the starts it captured for the lifetime of the host.
+Dispose scopes in reverse creation order in the creating flow. Incorrect or repeated disposal does not throw, but ambient-scope cleanup is not guaranteed for misuse. An undisposed scope holds captured starts until host shutdown.
 
-`AddHostedSubject<T>()` holds a scope through its configuration callback. HomeBlaze deserialization uses this scope while populating configuration. Root loading holds an enclosing scope until the root is published, attached, registered as a context service and signalled through `RootLoaded`, so a service that waits on that task inside its own `StartAsync` is not racing it.
+`AddHostedSubject<T>()` defers startup through its configuration callback. HomeBlaze deserialization defers it through configuration population; root loading also waits until the root is published, attached, registered as a context service and signalled through `RootLoaded`.
 
 ## Deferred Starts and Startup Completion
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -145,17 +145,18 @@ await person.AttachHostedServiceAsync(
 A context-taking constructor can attach a hosted subject before its object initializer or deserializer has populated configuration. There is no timing delay that guarantees initialization completes first. Construct and populate a detached subject before attaching it, or use a startup scope. The scope keeps context-taking construction available while delaying captured service starts:
 
 ```csharp
-using (var startup = context.DeferHostedServiceStartup())
+using (context.DeferHostedServiceStartup())
 {
     var person = new Person(context) { FirstName = "John", LastName = "Doe" };
     person.AttachHostedService(new PersonBackgroundService(person));
-    startup?.Complete();
 }
 ```
 
-The scope follows the current execution flow for that context. Starts wait until the scope and all enclosing scopes are completed and disposed. Disposal without `Complete()` cancels captured starts, including when initialization throws. Cancellation does not detach subjects; normal detach and host shutdown still stop their attached services. The extension returns null when hosted services are not configured. Do not await an attaching service's startup inside its open scope, since that startup is waiting for scope disposal.
+The scope follows the current execution flow for that context. Starts wait until the scope and all enclosing scopes are disposed, so the `using` is the whole contract. An exception unwinding through it releases the captured starts like any other exit: the scope decides when a start runs, not whether the subject is fit to run, so a subject whose configuration threw still starts and reports its own failure. The extension returns null when hosted services are not configured. Do not await an attaching service's startup inside its open scope, since that startup is waiting for scope disposal.
 
-`AddHostedSubject<T>()` holds a scope through its configuration callback. HomeBlaze deserialization uses this scope while populating configuration. Root loading holds an enclosing scope until the root is published, attached and registered as a context service.
+Scopes should be disposed in reverse creation order in the execution flow that created them. Nothing enforces it: disposal out of order, from another flow, or more than once releases the scope's own starts and is otherwise ignored, so a misuse is silent rather than loud. A scope that is never disposed at all holds the starts it captured for the lifetime of the host.
+
+`AddHostedSubject<T>()` holds a scope through its configuration callback. HomeBlaze deserialization uses this scope while populating configuration. Root loading holds an enclosing scope until the root is published, attached, registered as a context service and signalled through `RootLoaded`, so a service that waits on that task inside its own `StartAsync` is not racing it.
 
 ## Deferred Starts and Startup Completion
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -140,9 +140,11 @@ await person.AttachHostedServiceAsync(
     cancellationToken);
 ```
 
-## Construction and Configuration
+## Configuration Before Startup
 
-A context-taking constructor can attach a hosted subject before its object initializer or deserializer has populated configuration. There is no timing delay that guarantees initialization completes first. Construct and populate a detached subject before attaching it, or use a startup scope. The scope keeps context-taking construction available while delaying captured service starts:
+A hosted subject that takes the context in its constructor is attached during construction, which queues its service start. Object initializers, property assignments and deserializers all run afterwards, so the service can start against a subject that is not configured yet.
+
+Either build the subject detached, configure it and attach it once it is ready, or keep the context-taking constructor and wrap the work in a startup scope:
 
 ```csharp
 using (context.DeferHostedServiceStartup())
@@ -152,11 +154,20 @@ using (context.DeferHostedServiceStartup())
 }
 ```
 
-The scope follows the current execution flow for that context. Captured starts wait until it and all enclosing scopes are disposed, including when configuration throws. Services and consumers remain responsible for configuration validity. The extension returns null when hosted services are not configured. Do not await a captured service's startup inside its open scope.
+Attaching still takes effect immediately: the subject joins the graph and is visible to the registry and to sources. Only the service start waits for the block to exit.
 
-Dispose scopes in reverse creation order in the creating flow. Incorrect or repeated disposal does not throw, but ambient-scope cleanup is not guaranteed for misuse. An undisposed scope holds captured starts until host shutdown.
+The contract:
 
-`AddHostedSubject<T>()` defers startup through its configuration callback. HomeBlaze deserialization defers it through configuration population; root loading also waits until the root is published, attached, registered as a context service and signalled through `RootLoaded`.
+- The scope applies to the current execution flow, including asynchronous work awaited inside the block. Attaches made from other flows keep starting immediately.
+- Leaving the block releases the captured starts, including when configuration throws. There is nothing to call on success and no way to report failure through the scope, so validating configuration stays with the service and its caller.
+- A captured start waits for its own scope and for every scope enclosing it.
+- Do not await a captured service's start inside its own block, because that start cannot run until the block exits.
+- Detaching a subject before the block exits cancels its pending start, so the service never runs.
+- A scope that is never disposed holds its starts until the host shuts down. There is no timeout.
+- Dispose scopes in reverse creation order, which nested `using` blocks do. Repeated or out-of-order disposal does not throw, but which attaches such a scope still covers is then undefined.
+- `DeferHostedServiceStartup()` returns null on a context without hosting support, and `using` accepts that.
+
+`AddHostedSubject<T>()` wraps construction and its `configure` callback in a scope, so subjects registered through dependency injection are configured before they start.
 
 ## Deferred Starts and Startup Completion
 

--- a/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurableSubjectStartupTests.cs
+++ b/src/HomeBlaze/HomeBlaze.Services.Tests/Serialization/ConfigurableSubjectStartupTests.cs
@@ -38,7 +38,8 @@ public class ConfigurableSubjectStartupTests
             new SubjectPathResolver(() => manager?.Root), configuration.Object);
         var published = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         probe.Starting = subject => published.TrySetResult(ReferenceEquals(rootManager.Root, subject) &&
-            ReferenceEquals(context.TryGetService<ConfigurableStartupSubject>(), subject));
+            ReferenceEquals(context.TryGetService<ConfigurableStartupSubject>(), subject) &&
+            rootManager.RootLoaded.IsCompletedSuccessfully);
         await handler.StartAsync(CancellationToken.None);
 
         try
@@ -97,7 +98,7 @@ public class ConfigurableSubjectStartupTests
         }
     }
     [Fact]
-    public async Task WhenConfigurationPopulationThrows_ThenThePartiallyConfiguredServiceNeverStarts()
+    public async Task WhenConfigurationPopulationThrows_ThenTheCapturedStartIsStillReleased()
     {
         // Arrange
         using var probe = new ConfigurableStartupProbe { FailPopulation = true };
@@ -119,12 +120,10 @@ public class ConfigurableSubjectStartupTests
             Assert.Throws<System.Reflection.TargetInvocationException>(() => serializer.Deserialize("""
                 {"$type":"HomeBlaze.Services.Tests.Serialization.ConfigurableStartupSubject","configuration":"configured"}
                 """));
-            using var next = new ConfigurableStartupProbe();
-            _ = new ConfigurableStartupSubject(next, context);
-            await next.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
-            // Assert
-            Assert.False(probe.Started.Task.IsCompleted);
+            // Assert - the scope defers the start, it does not decide whether the subject is fit to
+            // run, so unwinding through its disposal releases the start like any other exit.
+            Assert.Equal(string.Empty, await probe.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
         }
         finally
         {

--- a/src/HomeBlaze/HomeBlaze.Services/ConfigurableSubjectSerializer.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/ConfigurableSubjectSerializer.cs
@@ -89,7 +89,6 @@ public class ConfigurableSubjectSerializer
         }
 
         PopulateConfigurationProperties(subject, type, root);
-        startup?.Complete();
         return subject;
     }
 

--- a/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
@@ -122,9 +122,7 @@ public class RootManager : BackgroundService, IConfigurationWriter
         _logger?.LogInformation("Root loaded: {Type}", Root.GetType().FullName);
         _context.AddService(Root);
 
-        // Signalled here rather than by the caller once this returns, because the scope releases the
-        // deferred starts as it goes out of scope below. A hosted service that waits on RootLoaded
-        // inside its own StartAsync would otherwise be racing the caller's assignment.
+        // Publish readiness before scope disposal releases deferred starts.
         _rootLoaded.TrySetResult(Root);
 
         return Root;

--- a/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
+++ b/src/HomeBlaze/HomeBlaze.Services/RootManager.cs
@@ -121,7 +121,11 @@ public class RootManager : BackgroundService, IConfigurationWriter
 
         _logger?.LogInformation("Root loaded: {Type}", Root.GetType().FullName);
         _context.AddService(Root);
-        startup?.Complete();
+
+        // Signalled here rather than by the caller once this returns, because the scope releases the
+        // deferred starts as it goes out of scope below. A hosted service that waits on RootLoaded
+        // inside its own StartAsync would otherwise be racing the caller's assignment.
+        _rootLoaded.TrySetResult(Root);
 
         return Root;
     }

--- a/src/Namotion.Interceptor.Hosting.Tests/HostedServiceStartupScopeTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/HostedServiceStartupScopeTests.cs
@@ -303,7 +303,7 @@ public class HostedServiceStartupScopeTests
     [InlineData("OutOfOrder")]
     [InlineData("OtherFlow")]
     [InlineData("Twice")]
-    public async Task WhenAScopeIsDisposedIrregularly_ThenItStillReleasesAndLeavesNoScopeBehind(string disposal)
+    public async Task WhenAScopeIsDisposedIrregularly_ThenCapturedAndLaterServicesCanStart(string disposal)
     {
         // Arrange
         await using var fixture = new Fixture();
@@ -329,7 +329,6 @@ public class HostedServiceStartupScopeTests
         Assert.Null(irregular);
         Assert.Equal("captured", await captured.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
 
-        // The flow is usable afterwards rather than wedged behind a scope nobody can release again.
         var later = new ProbeService(() => "later");
         await subject.AttachHostedServiceAsync(later, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
     }

--- a/src/Namotion.Interceptor.Hosting.Tests/HostedServiceStartupScopeTests.cs
+++ b/src/Namotion.Interceptor.Hosting.Tests/HostedServiceStartupScopeTests.cs
@@ -43,13 +43,12 @@ public class HostedServiceStartupScopeTests
 
             // Assert
             Assert.False(scoped.Started.Task.IsCompleted);
-            scope!.Complete();
         }
         await scoped.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
     [Fact]
-    public async Task WhenNestedScopeCompletes_ThenStartWaitsForTheOuterScope()
+    public async Task WhenNestedScopeIsDisposed_ThenStartWaitsForTheOuterScope()
     {
         // Arrange
         await using var fixture = new Fixture();
@@ -63,45 +62,14 @@ public class HostedServiceStartupScopeTests
             using (var inner = fixture.Context.DeferHostedServiceStartup())
             {
                 subject.AttachHostedService(service);
-                inner!.Complete();
             }
             await fixture.Handler.StartAsync(CancellationToken.None);
             Assert.False(service.Started.Task.IsCompleted);
             configuration = "configured";
-            outer!.Complete();
         }
 
         // Assert
         Assert.Equal("configured", await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task WhenAScopeFails_ThenItsQueuedStartIsCanceled(bool outerFails)
-    {
-        // Arrange
-        await using var fixture = new Fixture();
-        var service = new ProbeService(() => "started");
-        var subject = new Person(fixture.Context);
-        Task attachment;
-
-        // Act
-        using (var outer = fixture.Context.DeferHostedServiceStartup())
-        {
-            using (var inner = fixture.Context.DeferHostedServiceStartup())
-            {
-                attachment = subject.AttachHostedServiceAsync(service, CancellationToken.None);
-                if (outerFails) inner!.Complete();
-            }
-            if (!outerFails) outer!.Complete();
-        }
-
-        // Assert
-        await fixture.Handler.StartAsync(CancellationToken.None);
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => attachment.WaitAsync(TimeSpan.FromSeconds(10)));
-        Assert.False(service.Started.Task.IsCompleted);
-        await fixture.HoldsReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
     [Theory]
@@ -121,8 +89,6 @@ public class HostedServiceStartupScopeTests
         // Act
         await fixture.Handler.StartAsync(CancellationToken.None);
         await fixture.Handler.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
-        scope!.Complete();
-        scope.Dispose();
 
         // Assert
         foreach (var attachment in attachments)
@@ -251,7 +217,6 @@ public class HostedServiceStartupScopeTests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => firstAttachment.WaitAsync(TimeSpan.FromSeconds(10)));
             await AsyncTestHelpers.WaitUntilAsync(() => Volatile.Read(ref fixture.HoldsDisposed) == 1);
             Assert.False(service.Started.Task.IsCompleted);
-            scope!.Complete();
         }
         if (secondAttachment is not null)
         {
@@ -285,12 +250,10 @@ public class HostedServiceStartupScopeTests
             using (var inner = nested ? fixture.Context.DeferHostedServiceStartup() : null)
             {
                 attachments.Add(subject.AttachHostedServiceAsync(new ProbeService(() => { events.Add("first"); return "first"; }), CancellationToken.None));
-                inner?.Complete();
             }
             attachments.Add(subject.AttachHostedServiceAsync(new ProbeService(() => { events.Add("second"); return "second"; }), CancellationToken.None));
             Assert.Equal(2, fixture.HoldsTaken);
             Assert.Equal(0, fixture.HoldsDisposed);
-            outer!.Complete();
         }
         await Task.WhenAll(attachments).WaitAsync(TimeSpan.FromSeconds(10));
         await fixture.HoldsReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));
@@ -301,14 +264,10 @@ public class HostedServiceStartupScopeTests
     }
 
     [Fact]
-    public async Task WhenHandlerStartsInsideAFailedScope_ThenLaterServicesCanStartTheirChildren()
+    public async Task WhenHandlerStartsInsideAnOpenScope_ThenTheActionLoopDoesNotInheritIt()
     {
         // Arrange
         await using var fixture = new Fixture();
-        using (fixture.Context.DeferHostedServiceStartup())
-        {
-            await fixture.Handler.StartAsync(CancellationToken.None);
-        }
         var subject = new Person(fixture.Context);
         var child = new ProbeService(() => "child");
         var parent = new ProbeService(() =>
@@ -317,11 +276,111 @@ public class HostedServiceStartupScopeTests
             return "parent";
         });
 
+        // Attached from a flow created before the scope below, so the scope never captures this
+        // attach and the loop's own flow is the only thing that can defer the child.
+        var proceed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var independentFlow = Task.Run(async () =>
+        {
+            await proceed.Task;
+            await subject.AttachHostedServiceAsync(parent, CancellationToken.None);
+        });
+
+        // Act - the scope stays open across the start, so a loop that inherited the flow it was
+        // started in would capture the child that parent attaches inside its own StartAsync and
+        // hold it until this scope is disposed.
+        using (fixture.Context.DeferHostedServiceStartup())
+        {
+            await fixture.Handler.StartAsync(CancellationToken.None);
+            proceed.SetResult();
+            await independentFlow.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.Equal("child", await child.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+    }
+
+    [Theory]
+    [InlineData("OutOfOrder")]
+    [InlineData("OtherFlow")]
+    [InlineData("Twice")]
+    public async Task WhenAScopeIsDisposedIrregularly_ThenItStillReleasesAndLeavesNoScopeBehind(string disposal)
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var subject = new Person(fixture.Context);
+        var captured = new ProbeService(() => "captured");
+        var outer = fixture.Context.DeferHostedServiceStartup();
+        var inner = fixture.Context.DeferHostedServiceStartup();
+        subject.AttachHostedService(captured);
+
         // Act
-        await subject.AttachHostedServiceAsync(parent, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+        var irregular = Record.Exception(() =>
+        {
+            switch (disposal)
+            {
+                case "OutOfOrder": outer!.Dispose(); inner!.Dispose(); break;
+                case "OtherFlow": Task.Run(() => inner!.Dispose()).GetAwaiter().GetResult(); inner!.Dispose(); outer!.Dispose(); break;
+                default: inner!.Dispose(); inner.Dispose(); outer!.Dispose(); outer.Dispose(); break;
+            }
+        });
 
         // Assert
-        Assert.Equal("child", await child.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Null(irregular);
+        Assert.Equal("captured", await captured.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        // The flow is usable afterwards rather than wedged behind a scope nobody can release again.
+        var later = new ProbeService(() => "later");
+        await subject.AttachHostedServiceAsync(later, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task WhenAStopIsStillQueuedAtShutdown_ThenTheDetachedServiceIsStillStopped()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var subject = new Person(fixture.Context);
+        var releaseStart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var detached = new ProbeService(() => "detached", () => stopped.TrySetResult());
+        await subject.AttachHostedServiceAsync(detached, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Occupies the loop, so the stop queued below is still waiting when shutdown begins.
+        var blocking = new ProbeService(() => "blocking", startup: releaseStart.Task);
+        subject.AttachHostedService(blocking);
+        await blocking.Started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        subject.DetachHostedService(detached);
+
+        // Act
+        var stopping = fixture.Handler.StopAsync(CancellationToken.None);
+        releaseStart.SetResult();
+
+        // Assert
+        await stopped.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await stopping.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task WhenAnAwaitedAttachResumes_ThenItDoesNotOccupyTheActionLoop()
+    {
+        // Arrange
+        await using var fixture = new Fixture();
+        await fixture.Handler.StartAsync(CancellationToken.None);
+        var subject = new Person(fixture.Context);
+        var next = new ProbeService(() => "next");
+
+        // Act - the continuation attaches another service and waits for it, so it can only finish
+        // if the loop is free to run that start rather than being inside this continuation.
+        var attaching = Task.Run(async () =>
+        {
+            await subject.AttachHostedServiceAsync(new ProbeService(() => "first"), CancellationToken.None);
+            subject.AttachHostedService(next);
+            return next.Started.Task.Wait(TimeSpan.FromSeconds(5));
+        });
+
+        // Assert
+        Assert.True(await attaching.WaitAsync(TimeSpan.FromSeconds(10)));
     }
 
     private sealed class Fixture : IAsyncDisposable, IStartupCompletionDeferrer

--- a/src/Namotion.Interceptor.Hosting.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Hosting.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -4,7 +4,6 @@ namespace Namotion.Interceptor.Hosting
 {
     public sealed class HostedServiceStartupScope : System.IDisposable
     {
-        public void Complete() { }
         public void Dispose() { }
     }
     public static class HostedSubjectServiceCollectionExtensions

--- a/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
@@ -152,9 +152,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
 
             foreach (var action in pending)
             {
-                // Cancelled for starts, which must not begin during shutdown. A stop reads the same
-                // token as "shut down without waiting" and still runs, since the service it stops
-                // has already left _hostedServices and StopAsync above therefore skipped it.
+                // Cancel starts, but still stop detached services omitted from the shutdown snapshot.
                 await action.Execute(new CancellationToken(true));
             }
         }
@@ -182,19 +180,13 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
             IHostedService[] started;
             lock (_hostedServices)
             {
-                // Every attached service, including one whose deferred start never ran: shutdown is
-                // the last owner of the stop, and skipping those would orphan a service that a
-                // detach arriving during shutdown has already been refused
-                // (WhenShutdownCancellationDetachesADeferredService_ThenShutdownStillStopsIt).
-                // Telling the two apart needs a record of which starts actually ran, which this
-                // handler does not keep.
+                // Include deferred services: shutdown owns their cleanup once detach is refused.
                 started = _hostedServices.ToArray();
 
                 _hostedServices.Clear();
             }
 
-            // Materialized outside the lock: an async lambda runs up to its first await inline, so
-            // building the tasks under the lock would enter every StopAsync while holding it.
+            // Async methods run synchronously until their first await; invoke them outside the lock.
             await Task.WhenAll(started.Select(async hostedService =>
             {
                 try
@@ -281,8 +273,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     internal async Task AttachHostedServiceAsync(
         IHostedService hostedService, IInterceptorSubjectContext context, CancellationToken cancellationToken)
     {
-        // Continuations run off the completing thread: the action loop completes this, and a caller
-        // that resumes inline would otherwise run its own work on the loop's only thread.
+        // Inline caller continuations could block the action loop.
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_hostedServices)
         {
@@ -375,9 +366,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
                 {
                     lock (_hostedServices)
                     {
-                        // Under the lock, so a detach cannot be holding this source while it is
-                        // cancelled and disposed here: it takes the entry out under the same lock,
-                        // and whichever of the two removes it owns the rest of its lifetime.
+                        // Serialize disposal with detach cancellation and startup admission.
                         RemoveDeferredStart(hostedService, cancellation);
                         cancellation.Cancel();
                         cancellation.Dispose();
@@ -408,15 +397,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
         }));
     }
 
-    /// <summary>
-    /// Drops the deferred-start entry for <paramref name="hostedService"/>, if it is still the one
-    /// <paramref name="cancellation"/> belongs to. Callers must hold the lock on
-    /// <see cref="_hostedServices"/>.
-    /// </summary>
-    /// <remarks>
-    /// A detach and re-attach in between installs a newer source for the same service, and dropping
-    /// that one would leave the newer start with nothing left to cancel it.
-    /// </remarks>
+    // Caller holds _hostedServices. Preserve any newer start installed by a detach and reattach.
     private void RemoveDeferredStart(IHostedService hostedService, CancellationTokenSource cancellation)
     {
         if (_deferredStarts.TryGetValue(hostedService, out var current) && ReferenceEquals(current, cancellation))
@@ -442,10 +423,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
         {
             try
             {
-                // A grace period inherited from the start path, which no longer has one; nothing is
-                // known to depend on it here. Suppressing the cancellation rather than throwing is
-                // what lets shutdown's drain reach the stop below: the service has already left
-                // _hostedServices, so nothing else stops it.
+                // Cancellation skips the legacy delay, but must still reach the detached service's stop.
                 await Task.Delay(50, token).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
                 _logger?.LogInformation("Stopping detached hosted service {Service}.", hostedService.ToString());

--- a/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceHandler.cs
@@ -149,8 +149,12 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
             {
                 pending.Add(action);
             }
+
             foreach (var action in pending)
             {
+                // Cancelled for starts, which must not begin during shutdown. A stop reads the same
+                // token as "shut down without waiting" and still runs, since the service it stops
+                // has already left _hostedServices and StopAsync above therefore skipped it.
                 await action.Execute(new CancellationToken(true));
             }
         }
@@ -175,31 +179,37 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
                 await _stoppingCts.CancelAsync();
             }
             
-            Task[] tasks;
+            IHostedService[] started;
             lock (_hostedServices)
             {
-                tasks = _hostedServices
-                    .Select(async hostedService =>
-                    {
-                        try
-                        {
-                            _logger?.LogInformation("Stopping hosted service {Service}.", hostedService.ToString());
-                            await hostedService.StopAsync(cancellationToken);
-                        }
-                        catch (Exception exception)
-                        {
-                            if (exception is not OperationCanceledException)
-                            {
-                                _logger?.LogError(exception, "Failed to stop hosted service {Service}.", hostedService.ToString());
-                            }
-                        }
-                    })
-                    .ToArray();
-                
+                // Every attached service, including one whose deferred start never ran: shutdown is
+                // the last owner of the stop, and skipping those would orphan a service that a
+                // detach arriving during shutdown has already been refused
+                // (WhenShutdownCancellationDetachesADeferredService_ThenShutdownStillStopsIt).
+                // Telling the two apart needs a record of which starts actually ran, which this
+                // handler does not keep.
+                started = _hostedServices.ToArray();
+
                 _hostedServices.Clear();
             }
-            
-            await Task.WhenAll(tasks);
+
+            // Materialized outside the lock: an async lambda runs up to its first await inline, so
+            // building the tasks under the lock would enter every StopAsync while holding it.
+            await Task.WhenAll(started.Select(async hostedService =>
+            {
+                try
+                {
+                    _logger?.LogInformation("Stopping hosted service {Service}.", hostedService.ToString());
+                    await hostedService.StopAsync(cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    if (exception is not OperationCanceledException)
+                    {
+                        _logger?.LogError(exception, "Failed to stop hosted service {Service}.", hostedService.ToString());
+                    }
+                }
+            }));
         }
         finally
         {
@@ -271,7 +281,9 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     internal async Task AttachHostedServiceAsync(
         IHostedService hostedService, IInterceptorSubjectContext context, CancellationToken cancellationToken)
     {
-        var tcs = new TaskCompletionSource();
+        // Continuations run off the completing thread: the action loop completes this, and a caller
+        // that resumes inline would otherwise run its own work on the loop's only thread.
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_hostedServices)
         {
             if (IsStopping)
@@ -297,7 +309,8 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
     
     internal async Task DetachHostedServiceAsync(IHostedService hostedService, CancellationToken cancellationToken)
     {
-        var tcs = new TaskCompletionSource();
+        // See AttachHostedServiceAsync for why the continuations must not run inline.
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_hostedServices)
         {
             if (IsStopping)
@@ -340,7 +353,7 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
                     {
                         token.ThrowIfCancellationRequested();
                         cancellation.Token.ThrowIfCancellationRequested();
-                        _deferredStarts.Remove(hostedService);
+                        RemoveDeferredStart(hostedService, cancellation);
                     }
                 }
 
@@ -362,11 +375,10 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
                 {
                     lock (_hostedServices)
                     {
-                        if (_deferredStarts.TryGetValue(hostedService, out var current) &&
-                            ReferenceEquals(current, cancellation))
-                        {
-                            _deferredStarts.Remove(hostedService);
-                        }
+                        // Under the lock, so a detach cannot be holding this source while it is
+                        // cancelled and disposed here: it takes the entry out under the same lock,
+                        // and whichever of the two removes it owns the rest of its lifetime.
+                        RemoveDeferredStart(hostedService, cancellation);
                         cancellation.Cancel();
                         cancellation.Dispose();
                     }
@@ -396,26 +408,53 @@ internal class HostedServiceHandler : IHostedService, ILifecycleHandler, IDispos
         }));
     }
 
+    /// <summary>
+    /// Drops the deferred-start entry for <paramref name="hostedService"/>, if it is still the one
+    /// <paramref name="cancellation"/> belongs to. Callers must hold the lock on
+    /// <see cref="_hostedServices"/>.
+    /// </summary>
+    /// <remarks>
+    /// A detach and re-attach in between installs a newer source for the same service, and dropping
+    /// that one would leave the newer start with nothing left to cancel it.
+    /// </remarks>
+    private void RemoveDeferredStart(IHostedService hostedService, CancellationTokenSource cancellation)
+    {
+        if (_deferredStarts.TryGetValue(hostedService, out var current) && ReferenceEquals(current, cancellation))
+        {
+            _deferredStarts.Remove(hostedService);
+        }
+    }
+
     private void PostStopService(IHostedService hostedService, TaskCompletionSource? tcs)
     {
-        if (_deferredStarts.Remove(hostedService, out var cancellation))
+        if (_deferredStarts.Remove(hostedService, out var deferredStart))
         {
-            cancellation.Cancel();
+            deferredStart.Cancel();
         }
+
         if (IsStopping)
         {
             tcs?.TrySetCanceled();
             return;
         }
+
         _actions.Post((null, Task.CompletedTask, async token =>
         {
             try
             {
-                await Task.Delay(50, token); // TODO: Fix small delay to let sync property assignments/deserialization complete
+                // A grace period inherited from the start path, which no longer has one; nothing is
+                // known to depend on it here. Suppressing the cancellation rather than throwing is
+                // what lets shutdown's drain reach the stop below: the service has already left
+                // _hostedServices, so nothing else stops it.
+                await Task.Delay(50, token).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
                 _logger?.LogInformation("Stopping detached hosted service {Service}.", hostedService.ToString());
                 await hostedService.StopAsync(token);
                 tcs?.TrySetResult();
+            }
+            catch (OperationCanceledException exception)
+            {
+                tcs?.TrySetCanceled(exception.CancellationToken);
             }
             catch (Exception ex)
             {

--- a/src/Namotion.Interceptor.Hosting/HostedServiceStartupScope.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceStartupScope.cs
@@ -1,20 +1,19 @@
 namespace Namotion.Interceptor.Hosting;
 
 /// <summary>
-/// Defers hosted-service starts captured in this scope until it and its enclosing scopes complete.
+/// Defers hosted-service starts captured in this scope until it and its enclosing scopes are disposed.
 /// </summary>
 /// <remarks>
-/// Call <see cref="Complete"/> before disposal to allow startup. Otherwise captured starts are canceled.
-/// Do not await a captured service's startup before completing and disposing the scope.
+/// Disposal is the only release, so a <c>using</c> is the whole contract and an exception unwinding
+/// through it releases the captured starts like any other exit.
+/// Do not await a captured service's startup before disposing the scope.
 /// Scopes must be disposed in reverse creation order in the creating execution flow.
-/// Canceling startup does not detach subjects; normal detach and host shutdown still stop attached services.
 /// </remarks>
 public sealed class HostedServiceStartupScope : IDisposable
 {
     private readonly AsyncLocal<HostedServiceStartupScope?> _current;
     private readonly HostedServiceStartupScope? _parent;
-    private readonly TaskCompletionSource<bool> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private bool _completed;
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private bool _disposed;
 
     internal HostedServiceStartupScope(AsyncLocal<HostedServiceStartupScope?> current)
@@ -25,39 +24,29 @@ public sealed class HostedServiceStartupScope : IDisposable
     }
 
     /// <summary>
-    /// Allows captured starts after this scope and all enclosing scopes are successfully disposed.
-    /// </summary>
-    public void Complete()
-    {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        _completed = true;
-    }
-
-    /// <summary>
-    /// Releases successful startup or cancels captured starts when <see cref="Complete"/> was not called.
+    /// Releases the starts captured in this scope, once its enclosing scopes are released too.
     /// </summary>
     public void Dispose()
     {
-        if (_disposed) return;
-        if (!ReferenceEquals(_current.Value, this))
+        // Ahead of the disposed check, so a scope already released from another execution flow is
+        // still cleared from the flow that created it. Skipping it there would pin that flow's
+        // current scope to a disposed one for good, and every later attach on it would take the
+        // deferred path for a scope nobody can release again.
+        if (ReferenceEquals(_current.Value, this))
         {
-            throw new InvalidOperationException("Hosted-service startup scopes must be disposed in reverse creation order.");
+            _current.Value = _parent;
         }
 
+        if (_disposed) return;
         _disposed = true;
-        _current.Value = _parent;
-        _completion.TrySetResult(_completed);
+        _completion.TrySetResult();
     }
 
-    internal bool IsReady => _completion.Task.IsCompleted &&
-        (!_completion.Task.Result || _parent is null || _parent.IsReady);
+    internal bool IsReady => _completion.Task.IsCompleted && (_parent is null || _parent.IsReady);
 
     internal async Task WaitAsync(CancellationToken cancellationToken)
     {
-        if (!await _completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false))
-        {
-            throw new OperationCanceledException("Hosted-service initialization did not complete.", cancellationToken);
-        }
+        await _completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         if (_parent is not null)
         {

--- a/src/Namotion.Interceptor.Hosting/HostedServiceStartupScope.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedServiceStartupScope.cs
@@ -4,8 +4,7 @@ namespace Namotion.Interceptor.Hosting;
 /// Defers hosted-service starts captured in this scope until it and its enclosing scopes are disposed.
 /// </summary>
 /// <remarks>
-/// Disposal is the only release, so a <c>using</c> is the whole contract and an exception unwinding
-/// through it releases the captured starts like any other exit.
+/// Disposal releases captured starts even when configuration throws.
 /// Do not await a captured service's startup before disposing the scope.
 /// Scopes must be disposed in reverse creation order in the creating execution flow.
 /// </remarks>
@@ -28,10 +27,7 @@ public sealed class HostedServiceStartupScope : IDisposable
     /// </summary>
     public void Dispose()
     {
-        // Ahead of the disposed check, so a scope already released from another execution flow is
-        // still cleared from the flow that created it. Skipping it there would pin that flow's
-        // current scope to a disposed one for good, and every later attach on it would take the
-        // deferred path for a scope nobody can release again.
+        // Restore this flow's parent even if another flow already disposed the scope.
         if (ReferenceEquals(_current.Value, this))
         {
             _current.Value = _parent;

--- a/src/Namotion.Interceptor.Hosting/HostedSubjectServiceCollectionExtensions.cs
+++ b/src/Namotion.Interceptor.Hosting/HostedSubjectServiceCollectionExtensions.cs
@@ -42,7 +42,6 @@ public static class HostedSubjectServiceCollectionExtensions
                 : ActivatorUtilities.CreateInstance<T>(serviceProvider);
 
             configure?.Invoke(instance);
-            startup?.Complete();
             return instance;
         });
 

--- a/src/Namotion.Interceptor.Hosting/InterceptorSubjectContextExtensions.cs
+++ b/src/Namotion.Interceptor.Hosting/InterceptorSubjectContextExtensions.cs
@@ -7,7 +7,8 @@ namespace Namotion.Interceptor.Hosting;
 public static class InterceptorSubjectContextExtensions
 {
     /// <summary>
-    /// Defers hosted-service starts attached in the current execution flow until the scope completes.
+    /// Defers hosted-service starts attached in the current execution flow until the scope and its
+    /// enclosing scopes are disposed.
     /// Returns null when hosted services are not configured on this context.
     /// </summary>
     public static HostedServiceStartupScope? DeferHostedServiceStartup(this IInterceptorSubjectContext context)


### PR DESCRIPTION
Simplifies the startup scope introduced in #532: disposing it releases captured starts, including during exception unwinding. Services and consumers remain responsible for configuration validity. Also fixes older handler defects: detached services whose stops are queued now receive `StopAsync` during shutdown, and attach/detach continuations no longer occupy the action loop.

- Supersedes the startup scope API introduced in #532
- Follow-up: #440

## Contract

- Captured starts wait for disposal of their scope and all enclosing scopes. Do not await them inside an open scope.
- Dispose scopes in reverse creation order in the creating flow. Incorrect or repeated disposal does not throw, but ambient-scope cleanup is not guaranteed for misuse. Undisposed scopes hold starts until host shutdown; there is no timeout or automatic unwinding.
- A stop drained during shutdown receives a cancelled token. Successful completion remains successful; `OperationCanceledException` cancels the awaiting caller.
- `RootLoaded` is signalled before root loading releases deferred starts.
- Shutdown still stops attached services whose deferred start never ran. Changing that requires tracking which services started and belongs with #440.

## Breaking changes

None.

The startup scope has never shipped. The last release is v0.9.2 (2026-08-31), #532 merged after it, and `HostedServiceStartupScope` is absent from that tag and from its public API snapshot. `Complete()`, the cancel-on-failure behaviour and the out-of-order `InvalidOperationException` therefore only ever existed on `master`. This reshapes an unreleased API rather than breaking a released one, and consumers meet the scope for the first time in the shape that lands here.

For the release notes: this pull request and #532 fall between the same two tags, so the startup scope should be described once, in the shape that lands here. #532's description documents `Complete()`, a scope that cancels its captured starts when it is disposed without completing, and an `InvalidOperationException` on out-of-order disposal. None of those ship, and none of them need a migration step.

For anyone tracking `master` rather than a release: drop the `Complete()` call, since a `using` alone now does what `using` plus `Complete()` did. A scope disposed without completing no longer cancels its captured starts, so suppress a hosted service by not attaching the subject or by detaching it, rather than by abandoning the scope. `Dispose()` no longer throws `InvalidOperationException` on out-of-order disposal.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Production code | 6 | 66 | 63 | +3 |
| Tests | 3 | 109 | 53 | +56 |
| Documentation | 1 | 5 | 4 | +1 |
| **Total** | **10** | **180** | **120** | **+60** |

## Verification

- [x] Documentation and public API snapshot updated.
- [x] At `739dd81`: all CI test jobs passed; Hosting 30 and HomeBlaze Services 229 also passed locally. The prior review reports 3,967 passing non-integration tests.
- [x] Wording cleanup: executable content unchanged apart from the test name; all 30 Hosting tests passed again.
- [x] CI integration suites passed: HomeBlaze, MQTT, OPC UA and WebSocket.
- [ ] ~~Benchmarks~~ Not run; no performance claim.
- [ ] ~~Load and chaos tests~~ Not applicable.

Positive controls reported in the preceding review failed when reverting stop-delay cancellation handling, asynchronous attach continuations, or the action loop's ambient-scope reset. The irregular-disposal test checks that captured and later services start, not that the ambient scope is cleared. Cancellation-result handling, asynchronous detach continuations, stop invocation outside the lock, deferred-start identity checks and root-readiness ordering lack discriminating regression tests.

Deferred cancellation and disposal remain under the handler lock. Moving them outside it introduced a start-after-detach race and `ObjectDisposedException`; that change was reverted. The ownership redesign remains in #440.




