### PR TITLE
spike: explore source reconciliation for OPC UA and MQTT

### DIFF
--- a/docs/design/issue-373-source-reconciliation-spike.md
+++ b/docs/design/issue-373-source-reconciliation-spike.md
@@ -1,0 +1,38 @@
+# Source reconciliation spike
+
+This opt-in experiment explores prevention of stale scalar notifications and convergence after application writes stop. It does not resolve issue #373 or propose a merge-ready API. Existing connector behavior remains the default.
+
+## Behavior
+
+After writing `100`, a delayed notification containing `90` requests an authoritative read instead of overwriting the local value. If the source now reports `100`, the model stays at `100`. If it reports a correction, that correction can apply regardless of the notification's timestamp. A notification arriving after that read still requests verification; completing one read does not make later notifications trustworthy.
+
+Source writes also schedule verification, so convergence does not require a write echo or another application write. Failed or incomplete reads retry. A result is rejected when a local write, source operation, notification, reconnect, or ownership change overtakes it. The final check runs under the subject lock immediately before the property commit. Transaction coordination remains active through local confirmation and compensation.
+
+This gives quiescent convergence in the tested scalar cases, assuming the source becomes readable and returns its settled value. Ordinary OPC UA polling requests another refresh without invalidating an active read. Continuously arriving ambiguous notifications can still postpone application indefinitely.
+
+## Integration points
+
+| Layer | Experimental change |
+| --- | --- |
+| Core | `IPropertyWriteGuard` provides conditional admission at the setter terminal. A writer-only check leaves a race before the setter commits. |
+| Tracking | A guarded source setter and `ITransactionWriteCoordinator` extend protection across local transaction application. |
+| Connectors | `ISourcePropertyReader`, a shared reconciler, scalar `SubjectPropertyWriter.WriteValue`, and source-operation scopes. Ownership and connection generations invalidate obsolete reads. |
+| OPC UA | `EnableExperimentalSourceReconciliation = true` enables batched `Read` calls with `maxAge = 0`, reusing node mappings and value conversion. The experiment replaces the existing read-after-write path and routes polling through the coordinator. |
+| MQTT | `ExperimentalReconciliationReader` accepts an application-provided authoritative reader. Notifications and write completion then use the same coordinator. |
+
+MQTT does not gain a generic read protocol here. Its live test supplies a reader over the test broker's model, while writes and notifications use real MQTT connections. It proves reuse of the coordination mechanism; an actual MQTT deployment still needs a request/response or authoritative state contract.
+
+## Evidence
+
+Fourteen deterministic shared tests cover delayed notifications before and after verification, absent echoes, local writes overtaking reads, commit-time races, notification and polling overlap, read failure retries, reconnect, transaction success and failure, operations without local commits, and ownership release/reclaim. A live OPC UA test verifies a transaction, injects a stale subscription callback, reads the server, and follows an external server change. A live MQTT test exercises the equivalent callback path with the supplied reader.
+
+All five affected project suites passed: core 157, tracking 571, connectors 805, OPC UA 357, and MQTT 117, totaling 2,007 tests. Intentional experimental public API additions are recorded in their snapshots. Independent review identified and helped close lifecycle and ordering gaps; its verdict is suitability for an experimental spike, not production approval.
+
+## Decisions before production work
+
+- Decide whether these public interfaces are the right permanent contract. Enable reconciliation before property ownership is claimed and before initial state loading. Existing claims are not registered by late enablement; the built-in integrations use the required order.
+- Reduce and measure costs: conservative notification-triggered reads, tracked-property scans, allocations, and one dedicated observation thread per source.
+- Define graph/collection reconciliation and behavior with continuous notifications. This experiment handles scalars only; structural observations routed through the opted-in scalar writer are currently ignored without a legacy fallback.
+- Define an awaitable settlement contract. `HasPendingReconciliation` is a diagnostic snapshot, and existing source synchronization status is not a verification barrier.
+- Extend failure and protocol coverage, including real device freshness and an actual MQTT read contract. OPC UA currently discards already-collected batch results if a later mapping, conversion, or read fails, so one property can delay healthy properties. Guarding the commit does not undo custom interceptor side effects that execute before the terminal.
+- Agree and run the long Connector Tester and performance measurements before treating this as a production fix. Neither has run for this spike.

--- a/src/Namotion.Interceptor.Connectors.Tests/Reconciliation/SourceReconciliationTests.cs
+++ b/src/Namotion.Interceptor.Connectors.Tests/Reconciliation/SourceReconciliationTests.cs
@@ -1,0 +1,326 @@
+using Namotion.Interceptor.Interceptors;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Namotion.Interceptor.Connectors.Reconciliation;
+using Namotion.Interceptor.Connectors.Tests.Models;
+using Namotion.Interceptor.Connectors.Transactions;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Transactions;
+
+namespace Namotion.Interceptor.Connectors.Tests.Reconciliation;
+
+public class SourceReconciliationTests
+{
+    [Fact]
+    public async Task WhenDelayedNotificationArrives_ThenCommittedValueIsNotReverted()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        // Act
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        var read = await fixture.Reader.Next();
+        Assert.Equal("New", fixture.Person.FirstName);
+        read.Complete("New");
+        await fixture.WaitSettled();
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        (await fixture.Reader.Next()).Complete("New");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("New", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenWriteHasNoEcho_ThenVerificationAppliesSourceCorrection()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        // Act
+        await fixture.WriteLocal("Sent");
+        (await fixture.Reader.Next()).Complete("Adj");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Adj", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenLocalWriteOvertakesRead_ThenOldReadIsRejectedAndNewWriteSettles()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        var first = await fixture.Reader.Next();
+        // Act
+        await fixture.WriteLocal("Next");
+        first.Complete("Old");
+        var second = await fixture.Reader.Next();
+        Assert.Equal("Next", fixture.Person.FirstName);
+        second.Complete("Next");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Next", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenNotificationOvertakesRead_ThenAnotherReadResolvesIt()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        var first = await fixture.Reader.Next();
+        // Act
+        fixture.Writer.WriteValue(fixture.Property, "Adj");
+        first.Complete("Old");
+        (await fixture.Reader.Next()).Complete("Adj");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Adj", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenPollingRequestsRefreshDuringRead_ThenReadCanStillApply()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Writer.RequestReconciliation(fixture.Property);
+        var first = await fixture.Reader.Next();
+        // Act
+        fixture.Writer.RequestReconciliation(fixture.Property);
+        first.Complete("Adj");
+        var second = await fixture.Reader.Next();
+        Assert.Equal("Adj", fixture.Person.FirstName);
+        second.Complete("Adj");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Adj", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenReadFails_ThenItRetriesWithoutAnotherWrite()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        // Act
+        fixture.Writer.WriteValue(fixture.Property, "Adj");
+        (await fixture.Reader.Next()).Completion.SetException(new IOException("Disconnected"));
+        (await fixture.Reader.Next()).Complete("Adj");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Adj", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenReconnectOvertakesRead_ThenOldSessionCannotApply()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        var first = await fixture.Reader.Next();
+        // Act
+        fixture.Writer.StartBuffering();
+        await fixture.Writer.LoadInitialStateAndResumeAsync(CancellationToken.None);
+        first.Complete("Old");
+        (await fixture.Reader.Next()).Complete("New");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("New", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenTransactionCommits_ThenVerificationRunsAfterLocalConfirmation()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Context.WithTransactions();
+        fixture.Context.AddService<ITransactionWriter>(new SourceTransactionWriter());
+        // Act
+        using (var transaction = await fixture.Context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            fixture.Person.FirstName = "Sent";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+        Assert.Equal("Sent", fixture.Person.FirstName);
+        (await fixture.Reader.Next()).Complete("Adj");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Adj", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenOwnershipIsReleasedAndReclaimed_ThenPreviousReadCannotApply()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        var first = await fixture.Reader.Next();
+        // Act
+        fixture.Property.RemoveSource(fixture.Source);
+        fixture.Property.SetSource(fixture.Source);
+        fixture.Writer.RequestReconciliation(fixture.Property);
+        first.Complete("Old");
+        var second = await fixture.Reader.Next();
+        Assert.Equal("New", fixture.Person.FirstName);
+        second.Complete("New");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("New", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenSetterOvertakesReadInsideInterceptor_ThenTerminalGuardRejectsRead()
+    {
+        // Arrange
+        using var blocker = new BlockingSourceInterceptor();
+        using var fixture = await Fixture.Create(blocker);
+        fixture.Writer.WriteValue(fixture.Property, "Adj");
+        // Act
+        (await fixture.Reader.Next()).Complete("Adj");
+        await blocker.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        try { await fixture.WriteLocal("Next"); }
+        finally { blocker.Release.Set(); }
+        (await fixture.Reader.Next()).Complete("Next");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Next", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenAlreadyVerifiedLocalObservationArrivesLate_ThenItDoesNotScheduleAnotherRead()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        var change = await fixture.WriteLocal("Sent");
+        (await fixture.Reader.Next()).Complete("Sent");
+        await fixture.WaitSettled();
+        // Act
+        fixture.Writer.Reconciler!.ProcessChange(change);
+        // Assert
+        Assert.False(fixture.Writer.HasPendingReconciliation);
+        Assert.Equal("Sent", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenSourceOperationHasNoLocalCommit_ThenItStillInvalidatesAnEarlierRead()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        var first = await fixture.Reader.Next();
+        var change = SubjectPropertyChange.Create(fixture.Property, ChangeOrigin.Local, DateTimeOffset.UtcNow, null, "New", "Adj", 0);
+        // Act
+        await fixture.Source.WriteChangesInBatchesAsync(new[] { change }, CancellationToken.None);
+        first.Complete("Old");
+        var second = await fixture.Reader.Next();
+        Assert.Equal("New", fixture.Person.FirstName);
+        second.Complete("Adj");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("Adj", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenTransactionSourceWriteFails_ThenReconciliationIsNotLeftBlocked()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create(failWrites: true);
+        fixture.Context.WithTransactions();
+        fixture.Context.AddService<ITransactionWriter>(new SourceTransactionWriter());
+        // Act
+        using (var transaction = await fixture.Context.BeginTransactionAsync(TransactionFailureHandling.Rollback))
+        {
+            fixture.Person.FirstName = "Sent";
+            await Assert.ThrowsAsync<SubjectTransactionException>(() => transaction.CommitAsync(CancellationToken.None).AsTask());
+        }
+        (await fixture.Reader.Next()).Complete("New");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("New", fixture.Person.FirstName);
+    }
+
+    [Fact]
+    public async Task WhenCallbackArrivesAfterRelease_ThenItCannotResurrectOldOwnership()
+    {
+        // Arrange
+        using var fixture = await Fixture.Create();
+        fixture.Property.RemoveSource(fixture.Source);
+        // Act
+        fixture.Writer.WriteValue(fixture.Property, "Old");
+        fixture.Property.SetSource(fixture.Source);
+        fixture.Writer.RequestReconciliation(fixture.Property);
+        (await fixture.Reader.Next()).Complete("New");
+        await fixture.WaitSettled();
+        // Assert
+        Assert.Equal("New", fixture.Person.FirstName);
+    }
+
+    private sealed class BlockingSourceInterceptor : IWriteInterceptor, IDisposable
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public ManualResetEventSlim Release { get; } = new();
+        public void WriteProperty<T>(ref PropertyWriteContext<T> context, WriteInterceptionDelegate<T> next)
+        {
+            if (context.Origin.Kind == ChangeOriginKind.FromSource)
+            {
+                Entered.TrySetResult();
+                if (!Release.Wait(TimeSpan.FromSeconds(10))) throw new TimeoutException("Blocked source apply was not released.");
+            }
+            next(ref context);
+        }
+        public void Dispose() { Release.Set(); Release.Dispose(); }
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        public required IInterceptorSubjectContext Context { get; init; }
+        public required Person Person { get; init; }
+        public required TestSubjectSource Source { get; init; }
+        public required ControlledReader Reader { get; init; }
+        public required PropertyReference Property { get; init; }
+        public SubjectPropertyWriter Writer => Source.PropertyWriter;
+        public static async Task<Fixture> Create(IWriteInterceptor? interceptor = null, bool failWrites = false)
+        {
+            var context = InterceptorSubjectContext.Create().WithFullPropertyTracking();
+            if (interceptor is not null) context.WithService<IWriteInterceptor>(() => interceptor, _ => false);
+            var person = new Person(context) { FirstName = "New" };
+            var source = new TestSubjectSource(person, context, NullLogger.Instance)
+            {
+                WriteChangesOverride = failWrites ? (changes, _) => ValueTask.FromResult(WriteResult.Failure(changes, new IOException("Unknown write outcome"))) : null
+            };
+            var reader = new ControlledReader();
+            source.PropertyWriter.EnableReconciliation(reader);
+            var property = new PropertyReference(person, nameof(Person.FirstName));
+            property.SetSource(source);
+            await source.PropertyWriter.LoadInitialStateAndResumeAsync(CancellationToken.None);
+            return new Fixture { Context = context, Person = person, Source = source, Reader = reader, Property = property };
+        }
+        public async Task<SubjectPropertyChange> WriteLocal(string value)
+        {
+            using var changes = Context.CreatePropertyChangeQueueSubscription();
+            Person.FirstName = value;
+            Assert.True(changes.TryDequeueImmediate(out var change));
+            await Source.WriteChangesInBatchesAsync(new[] { change }, CancellationToken.None);
+            return change;
+        }
+        public Task WaitSettled() => AsyncTestHelpers.WaitUntilAsync(() => !Writer.HasPendingReconciliation);
+        public void Dispose() => Source.Dispose();
+    }
+
+    private sealed class ControlledReader : ISourcePropertyReader
+    {
+        private readonly Channel<Request> _requests = Channel.CreateUnbounded<Request>();
+        public async ValueTask<IReadOnlyList<SourcePropertyValue>> ReadPropertiesAsync(ReadOnlyMemory<PropertyReference> properties, CancellationToken cancellationToken)
+        {
+            var request = new Request(properties.ToArray());
+            await _requests.Writer.WriteAsync(request, cancellationToken);
+            return await request.Completion.Task.WaitAsync(cancellationToken);
+        }
+        public Task<Request> Next() => _requests.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private sealed class Request(PropertyReference[] properties)
+    {
+        public TaskCompletionSource<IReadOnlyList<SourcePropertyValue>> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public void Complete(string value) => Completion.SetResult(properties.Select(property => new SourcePropertyValue(property, value)).ToArray());
+    }
+}

--- a/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Connectors.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -130,9 +130,14 @@ namespace Namotion.Interceptor.Connectors
     }
     public sealed class SubjectPropertyWriter
     {
+        public bool HasPendingReconciliation { get; }
+        public long VerificationReadCount { get; }
+        public void EnableReconciliation(Namotion.Interceptor.Connectors.Reconciliation.ISourcePropertyReader reader) { }
         public System.Threading.Tasks.Task LoadInitialStateAndResumeAsync(System.Threading.CancellationToken cancellationToken) { }
+        public void RequestReconciliation(Namotion.Interceptor.PropertyReference property) { }
         public void StartBuffering() { }
         public void Write<TState>(TState state, System.Action<TState> update) { }
+        public void WriteValue(Namotion.Interceptor.PropertyReference property, object? value, System.DateTimeOffset? timestamp = default, System.DateTimeOffset? receivedTimestamp = default) { }
     }
     public abstract class SubjectSourceBase : Namotion.Interceptor.Connectors.SubjectConnectorBase, Namotion.Interceptor.Connectors.ISubjectConnector, Namotion.Interceptor.Connectors.ISubjectSource
     {
@@ -374,6 +379,21 @@ namespace Namotion.Interceptor.Connectors.Paths
         public static System.Collections.Generic.IEnumerable<string> UpdatePropertyValuesFromPaths(this Namotion.Interceptor.IInterceptorSubject subject, System.Collections.Generic.IReadOnlyDictionary<string, object?> pathsAndValues, System.DateTimeOffset timestamp, Namotion.Interceptor.Registry.Paths.PathProviderBase pathProvider, object? source) { }
         public static System.Collections.Generic.IEnumerable<string> UpdatePropertyValuesFromPaths(this Namotion.Interceptor.IInterceptorSubject subject, System.Collections.Generic.IEnumerable<string> paths, System.DateTimeOffset timestamp, System.Func<Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty, string, object?> getPropertyValue, Namotion.Interceptor.Registry.Paths.PathProviderBase pathProvider, object? source) { }
         public static System.Collections.Generic.IReadOnlyCollection<string> VisitPropertiesFromPaths(this Namotion.Interceptor.IInterceptorSubject subject, System.Collections.Generic.IEnumerable<string> paths, System.Action<Namotion.Interceptor.Registry.Abstractions.RegisteredSubjectProperty, string, object?> visitProperty, Namotion.Interceptor.Registry.Paths.PathProviderBase pathProvider, Namotion.Interceptor.Connectors.ISubjectFactory? subjectFactory = null) { }
+    }
+}
+namespace Namotion.Interceptor.Connectors.Reconciliation
+{
+    public interface ISourcePropertyReader
+    {
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyList<Namotion.Interceptor.Connectors.Reconciliation.SourcePropertyValue>> ReadPropertiesAsync(System.ReadOnlyMemory<Namotion.Interceptor.PropertyReference> properties, System.Threading.CancellationToken cancellationToken);
+    }
+    public readonly struct SourcePropertyValue : System.IEquatable<Namotion.Interceptor.Connectors.Reconciliation.SourcePropertyValue>
+    {
+        public SourcePropertyValue(Namotion.Interceptor.PropertyReference Property, object? Value, System.DateTimeOffset? Timestamp = default, System.DateTimeOffset? ReceivedTimestamp = default) { }
+        public Namotion.Interceptor.PropertyReference Property { get; init; }
+        public System.DateTimeOffset? ReceivedTimestamp { get; init; }
+        public System.DateTimeOffset? Timestamp { get; init; }
+        public object? Value { get; init; }
     }
 }
 namespace Namotion.Interceptor.Connectors.Resilience

--- a/src/Namotion.Interceptor.Connectors/Reconciliation/ISourcePropertyReader.cs
+++ b/src/Namotion.Interceptor.Connectors/Reconciliation/ISourcePropertyReader.cs
@@ -1,0 +1,13 @@
+namespace Namotion.Interceptor.Connectors.Reconciliation;
+
+/// <summary>Experimental capability for reading authoritative scalar source values.</summary>
+/// <remarks>Return current source values, not cached notifications. Omitted properties remain pending and are retried.</remarks>
+public interface ISourcePropertyReader
+{
+    ValueTask<IReadOnlyList<SourcePropertyValue>> ReadPropertiesAsync(
+        ReadOnlyMemory<PropertyReference> properties, CancellationToken cancellationToken);
+}
+
+/// <summary>A scalar value read from the authoritative source.</summary>
+public readonly record struct SourcePropertyValue(
+    PropertyReference Property, object? Value, DateTimeOffset? Timestamp = null, DateTimeOffset? ReceivedTimestamp = null);

--- a/src/Namotion.Interceptor.Connectors/Reconciliation/SourcePropertyReconciler.cs
+++ b/src/Namotion.Interceptor.Connectors/Reconciliation/SourcePropertyReconciler.cs
@@ -1,0 +1,311 @@
+using Namotion.Interceptor.Registry;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Connectors.Reconciliation;
+
+// Experimental conservative reader strategy. Notifications request verification; they never certify freshness.
+internal sealed class SourcePropertyReconciler : IDisposable
+{
+    private readonly SubjectSourceBase _source;
+    private readonly ISourcePropertyReader _reader;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<PropertyReference, Entry> _entries = new(PropertyReference.Comparer);
+    private readonly Channel<bool> _wake = Channel.CreateBounded<bool>(new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropWrite });
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly PropertyChangeQueueSubscription _changes;
+    private readonly Task _worker;
+    private readonly Task _observer;
+    private volatile bool _running;
+    private volatile bool _disposed;
+    private int _disposeStarted;
+    private long _epoch;
+    private long _readCount;
+
+    public SourcePropertyReconciler(SubjectSourceBase source, ISourcePropertyReader reader, ILogger logger)
+    {
+        _source = source;
+        _reader = reader;
+        _logger = logger;
+        _changes = source.RootSubject.Context.CreatePropertyChangeQueueSubscription();
+        // Neither background flow may inherit a caller's ambient transaction.
+        using (ExecutionContext.SuppressFlow())
+        {
+            _worker = Task.Run(RunAsync);
+            _observer = Task.Factory.StartNew(ObserveChanges, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+    }
+
+    public long ReadCount => Interlocked.Read(ref _readCount);
+    public bool HasPending => _changes.Count != 0 || _entries.Values.Any(entry => { lock (entry.Gate) return entry.Dirty || entry.InFlight || entry.Operations != 0; });
+
+    public void Register(PropertyReference property)
+    {
+        if (property.TryGetRegisteredProperty()?.CanContainSubjects == true) return;
+        // Called while ownership is established under the same subject lock as property commits.
+        property.TryGetWriteState(false, out var revision, out _);
+        _entries.TryAdd(property, new Entry(property, revision, Interlocked.Read(ref _epoch)));
+    }
+
+    public void Unregister(PropertyReference property)
+    {
+        if (!_entries.TryRemove(property, out var entry)) return;
+        lock (entry.Gate)
+        {
+            entry.Version++;
+            entry.Dirty = false;
+        }
+    }
+
+    public void Observe(PropertyReference property)
+    {
+        if (_disposed || property.TryGetRegisteredProperty()?.CanContainSubjects == true) return;
+        if (!_entries.TryGetValue(property, out var entry)) return;
+        lock (entry.Gate)
+        {
+            entry.Version++;
+            entry.Dirty = true;
+        }
+        Signal();
+    }
+
+    public void RequestRefresh(PropertyReference property)
+    {
+        if (_disposed || property.TryGetRegisteredProperty()?.CanContainSubjects == true) return;
+        if (!_entries.TryGetValue(property, out var entry)) return;
+        lock (entry.Gate)
+        {
+            entry.Dirty = true;
+            if (entry.InFlight) entry.RefreshAfterRead = true;
+        }
+        Signal();
+    }
+
+    public void Resume()
+    {
+        _running = true;
+        Signal();
+    }
+
+    public void Invalidate()
+    {
+        _running = false;
+        var epoch = Interlocked.Increment(ref _epoch);
+        foreach (var entry in _entries.Values)
+        {
+            lock (entry.Gate)
+            {
+                entry.Epoch = Math.Max(entry.Epoch, epoch);
+                entry.Version++;
+                entry.Dirty = true;
+            }
+        }
+    }
+
+    public IDisposable BeginOperation(ReadOnlyMemory<SubjectPropertyChange> changes)
+    {
+        var entries = new List<(Entry Entry, long Revision)>(changes.Length);
+        foreach (var change in changes.Span)
+        {
+            if (change.Property.TryGetRegisteredProperty()?.CanContainSubjects == true) continue;
+            if (!change.Property.TryGetSource(out var owner) || !ReferenceEquals(owner, _source)) continue;
+            if (!_entries.TryGetValue(change.Property, out var entry)) continue;
+            lock (entry.Gate)
+            {
+                entry.Operations++;
+                entry.Version++;
+                entry.Dirty = true;
+            }
+            entries.Add((entry, change.Revision));
+        }
+        return new Operation(this, entries);
+    }
+
+    private void ObserveChanges()
+    {
+        try
+        {
+            while (_changes.TryDequeue(out var change, _cancellation.Token))
+            {
+                ProcessChange(change);
+            }
+        }
+        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested) { }
+    }
+
+    internal void ProcessChange(SubjectPropertyChange change)
+    {
+        if (change.Property.TryGetRegisteredProperty()?.CanContainSubjects == true) return;
+        if (!change.Property.TryGetSource(out var owner) || !ReferenceEquals(owner, _source)) return;
+        if (change.Origin.Kind == ChangeOriginKind.FromSource && ReferenceEquals(change.Origin.Source, _source)) return;
+        if (!_entries.TryGetValue(change.Property, out var entry)) return;
+        lock (entry.Gate)
+        {
+            if (change.Revision <= entry.CoveredRevision) return;
+            // Confirmed is stamped by local transaction application after its source accepted the write.
+            if (change.Origin.Kind == ChangeOriginKind.Confirmed && ReferenceEquals(change.Origin.Source, _source))
+                entry.CoveredRevision = Math.Max(entry.CoveredRevision, change.Revision);
+            entry.Dirty = true;
+        }
+        Signal();
+    }
+
+    private void Signal() => _wake.Writer.TryWrite(true);
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            await foreach (var unused in _wake.Reader.ReadAllAsync(_cancellation.Token).ConfigureAwait(false))
+            {
+                if (!_running || _disposed) continue;
+                var tickets = new List<ReadTicket>();
+                foreach (var entry in _entries.Values)
+                {
+                    lock (entry.Gate)
+                    {
+                        if (!entry.Dirty || entry.InFlight || entry.Operations != 0) continue;
+                        if (!entry.Property.TryGetSource(out var owner) || !ReferenceEquals(owner, _source))
+                        {
+                            entry.Dirty = false;
+                            continue;
+                        }
+                        entry.Property.TryGetWriteState(false, out var revision, out _);
+                        if (revision > entry.CoveredRevision) continue;
+                        entry.InFlight = true;
+                        entry.RefreshAfterRead = false;
+                        tickets.Add(new ReadTicket(entry, revision, entry.Version, entry.Epoch));
+                    }
+                }
+                if (tickets.Count == 0) continue;
+                var retry = false;
+                try
+                {
+                    Interlocked.Increment(ref _readCount);
+                    var properties = tickets.Select(ticket => ticket.Entry.Property).ToArray();
+                    var values = await _reader.ReadPropertiesAsync(properties, _cancellation.Token).ConfigureAwait(false);
+                    var byProperty = values.ToDictionary(value => value.Property, PropertyReference.Comparer);
+                    foreach (var ticket in tickets)
+                    {
+                        if (!byProperty.TryGetValue(ticket.Entry.Property, out var value)) { retry = true; continue; }
+                        var guard = new ReadGuard(this, ticket);
+                        try
+                        {
+                            var unchanged = false;
+                            lock (value.Property.Subject.SyncRoot)
+                            {
+                                if (Equals(value.Property.Metadata.GetValue?.Invoke(value.Property.Subject), value.Value) && guard.TryEnter(value.Property))
+                                {
+                                    guard.Exit(true);
+                                    unchanged = true;
+                                }
+                            }
+                            if (!unchanged) value.Property.SetValueFromSource(_source, value.Timestamp, value.ReceivedTimestamp, value.Value, guard);
+                        }
+                        catch (Exception exception)
+                        {
+                            _logger.LogWarning(exception, "Experimental reconciliation apply failed for {Property}.", value.Property.Name);
+                        }
+                        if (!guard.Committed) retry = true;
+                    }
+                }
+                catch (OperationCanceledException) when (_cancellation.IsCancellationRequested) { throw; }
+                catch (Exception exception)
+                {
+                    retry = true;
+                    _logger.LogWarning(exception, "Experimental source verification failed; pending values will be retried.");
+                }
+                finally
+                {
+                    foreach (var ticket in tickets)
+                    {
+                        lock (ticket.Entry.Gate)
+                        {
+                            ticket.Entry.InFlight = false;
+                            if (ticket.Entry.Dirty) retry = true;
+                        }
+                    }
+                }
+                if (retry)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), _cancellation.Token).ConfigureAwait(false);
+                    Signal();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested) { }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0) return;
+        _disposed = true;
+        Invalidate();
+        _cancellation.Cancel();
+        _changes.Dispose();
+        _wake.Writer.TryComplete();
+        _ = Task.WhenAll(_worker, _observer).ContinueWith(_ => _cancellation.Dispose(), TaskScheduler.Default);
+    }
+
+    private sealed class Entry(PropertyReference property, long coveredRevision, long epoch)
+    {
+        public readonly object Gate = new();
+        public readonly PropertyReference Property = property;
+        public long CoveredRevision = coveredRevision;
+        public long Epoch = epoch;
+        public long Version;
+        public int Operations;
+        public bool Dirty;
+        public bool InFlight;
+        public bool RefreshAfterRead;
+    }
+
+    private readonly record struct ReadTicket(Entry Entry, long Revision, long Version, long Epoch);
+
+    private sealed class ReadGuard(SourcePropertyReconciler owner, ReadTicket ticket) : IPropertyWriteGuard
+    {
+        public bool Committed { get; private set; }
+        public bool TryEnter(PropertyReference property)
+        {
+            Monitor.Enter(ticket.Entry.Gate);
+            property.TryGetWriteState(false, out var revision, out _);
+            if (owner._disposed || !owner._running || !owner._entries.TryGetValue(property, out var currentEntry) ||
+                !ReferenceEquals(currentEntry, ticket.Entry) || Interlocked.Read(ref owner._epoch) != ticket.Epoch || ticket.Entry.Epoch != ticket.Epoch ||
+                ticket.Entry.Version != ticket.Version || ticket.Entry.Operations != 0 || revision != ticket.Revision ||
+                !property.TryGetSource(out var source) || !ReferenceEquals(source, owner._source))
+            {
+                Monitor.Exit(ticket.Entry.Gate);
+                return false;
+            }
+            return true;
+        }
+        public void Exit(bool committed)
+        {
+            Committed = committed;
+            if (committed) ticket.Entry.Dirty = ticket.Entry.RefreshAfterRead;
+            Monitor.Exit(ticket.Entry.Gate);
+        }
+    }
+
+    private sealed class Operation(SourcePropertyReconciler owner, List<(Entry Entry, long Revision)> entries) : IDisposable
+    {
+        private int _disposed;
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            foreach (var (entry, revision) in entries)
+            {
+                lock (entry.Gate)
+                {
+                    entry.CoveredRevision = Math.Max(entry.CoveredRevision, revision);
+                    entry.Operations--;
+                    entry.Dirty = true;
+                }
+            }
+            owner.Signal();
+        }
+    }
+}

--- a/src/Namotion.Interceptor.Connectors/Reconciliation/SourceWriteCoordinationScope.cs
+++ b/src/Namotion.Interceptor.Connectors/Reconciliation/SourceWriteCoordinationScope.cs
@@ -1,0 +1,23 @@
+namespace Namotion.Interceptor.Connectors.Reconciliation;
+
+internal sealed class SourceWriteCoordinationScope : IDisposable
+{
+    private static readonly AsyncLocal<SourceWriteCoordinationScope?> Ambient = new();
+    private readonly SourceWriteCoordinationScope? _previous = Ambient.Value;
+    private readonly List<IDisposable> _operations = [];
+
+    public SourceWriteCoordinationScope() => Ambient.Value = this;
+
+    public static IDisposable? RetainOrReturn(IDisposable? operation)
+    {
+        if (operation is null || Ambient.Value is not { } scope) return operation;
+        lock (scope._operations) scope._operations.Add(operation);
+        return null;
+    }
+
+    public void Dispose()
+    {
+        Ambient.Value = _previous;
+        foreach (var operation in _operations) operation.Dispose();
+    }
+}

--- a/src/Namotion.Interceptor.Connectors/SourcePropertyExtensions.cs
+++ b/src/Namotion.Interceptor.Connectors/SourcePropertyExtensions.cs
@@ -31,15 +31,24 @@ public static class SourcePropertyExtensions
     /// </returns>
     public static bool SetSource(this PropertyReference property, ISubjectSource source)
     {
-        // Add-if-absent, not GetOrSet: only this distinguishes a fresh claim from a re-claim.
-        if (property.TryAddPropertyData(SourceKey, source))
+        bool claimed;
+        var reconciler = (source as SubjectSourceBase)?.PropertyWriter.Reconciler;
+        if (reconciler is not null)
         {
-            PublishOwnershipChange(property, source, SourceEventKind.PropertyClaimed);
-            return true;
+            lock (property.Subject.SyncRoot)
+            {
+                claimed = property.TryAddPropertyData(SourceKey, source);
+                if (!claimed && (!property.TryGetPropertyData(SourceKey, out var existing) || !ReferenceEquals(existing, source))) return false;
+                reconciler.Register(property);
+            }
         }
-
-        // Check-then-act: the result reflects ownership at this read, not a lasting guarantee.
-        return property.TryGetPropertyData(SourceKey, out var existing) && ReferenceEquals(existing, source);
+        else
+        {
+            claimed = property.TryAddPropertyData(SourceKey, source);
+            if (!claimed && (!property.TryGetPropertyData(SourceKey, out var existing) || !ReferenceEquals(existing, source))) return false;
+        }
+        if (claimed) PublishOwnershipChange(property, source, SourceEventKind.PropertyClaimed);
+        return true;
     }
 
     /// <summary>
@@ -72,10 +81,15 @@ public static class SourcePropertyExtensions
     /// <returns><c>true</c> if the source was removed; <c>false</c> if the property had no source or a different source.</returns>
     public static bool RemoveSource(this PropertyReference property, ISubjectSource expectedSource)
     {
-        if (!property.TryRemovePropertyData(SourceKey, expectedSource))
+        if ((expectedSource as SubjectSourceBase)?.PropertyWriter.Reconciler is not null)
         {
-            return false;
+            lock (property.Subject.SyncRoot)
+            {
+                if (!property.TryRemovePropertyData(SourceKey, expectedSource)) return false;
+                ((SubjectSourceBase)expectedSource).PropertyWriter.Reconciler!.Unregister(property);
+            }
         }
+        else if (!property.TryRemovePropertyData(SourceKey, expectedSource)) return false;
 
         PublishOwnershipChange(property, expectedSource, SourceEventKind.PropertyReleased);
         return true;

--- a/src/Namotion.Interceptor.Connectors/SubjectPropertyWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectPropertyWriter.cs
@@ -1,3 +1,5 @@
+using Namotion.Interceptor.Connectors.Reconciliation;
+using Namotion.Interceptor.Tracking.Change;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Namotion.Interceptor.Connectors.Diagnostics;
@@ -16,6 +18,41 @@ namespace Namotion.Interceptor.Connectors;
 /// </remarks>
 public sealed class SubjectPropertyWriter
 {
+    internal SourcePropertyReconciler? Reconciler { get; private set; }
+
+    /// <summary>Enables experimental scalar reconciliation. Call before claiming property ownership or loading initial state.</summary>
+    public void EnableReconciliation(ISourcePropertyReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        lock (_lock)
+        {
+            if (Reconciler is not null) return;
+            if (_updates is null) throw new InvalidOperationException("Enable reconciliation before loading initial state.");
+            Reconciler = new SourcePropertyReconciler(_source, reader, _logger);
+        }
+    }
+
+    /// <summary>A snapshot of known experimental verification work; not a synchronization barrier.</summary>
+    public bool HasPendingReconciliation => Reconciler?.HasPending ?? false;
+
+    /// <summary>Number of experimental verification read batches started.</summary>
+    public long VerificationReadCount => Reconciler?.ReadCount ?? 0;
+
+    /// <summary>Applies a scalar observation, or schedules authoritative verification when enabled.</summary>
+    public void WriteValue(PropertyReference property, object? value, DateTimeOffset? timestamp = null, DateTimeOffset? receivedTimestamp = null)
+    {
+        if (Reconciler is { } reconciler)
+        {
+            reconciler.Observe(property);
+            return;
+        }
+        Write((property, value, timestamp, receivedTimestamp, source: _source), static state =>
+            state.property.SetValueFromSource(state.source, state.timestamp, state.receivedTimestamp, state.value));
+    }
+
+    /// <summary>Requests an authoritative refresh without invalidating an in-flight read.</summary>
+    public void RequestReconciliation(PropertyReference property) => Reconciler?.RequestRefresh(property);
+
     private readonly SubjectSourceBase _source;
     private readonly ILogger _logger;
     private readonly QueueMetrics? _inboundBufferMetrics;
@@ -77,6 +114,7 @@ public sealed class SubjectPropertyWriter
     /// </summary>
     public void StartBuffering()
     {
+        Reconciler?.Invalidate();
         lock (_lock)
         {
             // The replaced list is a superseded snapshot that must not be applied. Counted anyway,
@@ -106,6 +144,7 @@ public sealed class SubjectPropertyWriter
     /// </remarks>
     internal void InvalidateGeneration()
     {
+        Reconciler?.Invalidate();
         lock (_lock)
         {
             _generation++;
@@ -174,6 +213,7 @@ public sealed class SubjectPropertyWriter
             // Lock order writer._lock -> _stateLock -> monitor._lock (TransitionTo can reach a
             // registered monitor synchronously) is never reversed anywhere, so it cannot deadlock.
             _source.TransitionStateTo(SourceState.Synchronized);
+            Reconciler?.Resume();
         }
     }
 

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceBase.cs
@@ -26,6 +26,7 @@ public abstract class SubjectSourceBase : SubjectConnectorBase, ISubjectSource
     private const ChangeDeliveryRule DeliveryRule = ChangeDeliveryRule.SourceValuesMayBeStale;
     private readonly TimeSpan _retryTime;
     private readonly SubjectPropertyWriter _propertyWriter;
+    internal SubjectPropertyWriter PropertyWriter => _propertyWriter;
 
     private static readonly TimeSpan ConnectWindowDrainInterval = TimeSpan.FromSeconds(1);
 
@@ -175,6 +176,7 @@ public abstract class SubjectSourceBase : SubjectConnectorBase, ISubjectSource
             // This source will never pump. Reporting a stop keeps it in scope as never-synchronized,
             // so in-scope waits answer Incomplete; unwinding left them on a vacuous Synchronized.
             // Nothing unregisters it until Dispose, which a graph-attached source may never get.
+            _propertyWriter.Reconciler?.Dispose();
             WriteRetryQueue.Retire();
             TransitionStateTo(SourceState.Stopped);
             throw;
@@ -334,6 +336,7 @@ public abstract class SubjectSourceBase : SubjectConnectorBase, ISubjectSource
         }
         finally
         {
+            _propertyWriter.Reconciler?.Dispose();
             WriteRetryQueue.Retire();
             TransitionStateTo(SourceState.Stopped);
         }
@@ -631,6 +634,7 @@ public abstract class SubjectSourceBase : SubjectConnectorBase, ISubjectSource
     /// <inheritdoc />
     public override void Dispose()
     {
+        _propertyWriter.Reconciler?.Dispose();
         // Close outbound admission before publishing the final Stopped, so an observer blocked inside
         // the notification cannot still hand a write to the transport. Publishing while registered keeps
         // a dispose without a stop visible to the monitors.

--- a/src/Namotion.Interceptor.Connectors/SubjectSourceExtensions.cs
+++ b/src/Namotion.Interceptor.Connectors/SubjectSourceExtensions.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Connectors.Reconciliation;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Namotion.Interceptor.Tracking.Change;
@@ -33,6 +34,9 @@ public static class SubjectSourceExtensions
         {
             return WriteResult.Success;
         }
+
+        using var reconciliation = SourceWriteCoordinationScope.RetainOrReturn(
+            (source as SubjectSourceBase)?.PropertyWriter.Reconciler?.BeginOperation(changes));
 
         // Skip synchronization for sources that handle their own concurrency
         if (source is ISupportsConcurrentWrites)

--- a/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
+++ b/src/Namotion.Interceptor.Connectors/Transactions/SourceTransactionWriter.cs
@@ -9,8 +9,10 @@ namespace Namotion.Interceptor.Connectors.Transactions;
 /// Only writes changes that have an associated source; local (no-source) changes are
 /// skipped and left for the transaction to apply.
 /// </summary>
-internal sealed class SourceTransactionWriter : ITransactionWriter
+internal sealed class SourceTransactionWriter : ITransactionWriter, ITransactionWriteCoordinator
 {
+    public IDisposable BeginCoordination() => new Reconciliation.SourceWriteCoordinationScope();
+
     /// <summary>
     /// One source's changes with their snapshot indices in lockstep, so accepted slots can be marked.
     /// Also serves as the multi-source revert state.

--- a/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientLivenessTests.ReconciliationSpike.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientLivenessTests.ReconciliationSpike.cs
@@ -1,0 +1,58 @@
+using System.Collections.Concurrent;
+using System.Reactive.Concurrency;
+using Namotion.Interceptor.Connectors.Reconciliation;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Mqtt.Tests.Client;
+
+public partial class MqttClientLivenessTests
+{
+    [Fact]
+    public async Task WhenApplicationReaderIsProvided_ThenDelayedMqttMessageIsVerifiedBeforeApplying()
+    {
+        // Arrange: real MQTT transport; the authoritative read capability is supplied by the test application.
+        var port = GetFreeTcpPort();
+        await using var broker = CreateBroker(port);
+        var brokerRoot = (LivenessTestRoot)broker.RootSubject;
+        await using var source = CreateClientSource(port, reconciliationReader: new BrokerModelReader(brokerRoot));
+        var root = (LivenessTestRoot)source.RootSubject;
+        await broker.StartAsync(CancellationToken.None);
+        await source.StartAsync(CancellationToken.None);
+        try
+        {
+            await AsyncTestHelpers.WaitUntilAsync(() => root.Name == "Initial" && !source.PropertyWriter.HasPendingReconciliation);
+            root.Name = "Current";
+            await AsyncTestHelpers.WaitUntilAsync(() => brokerRoot.Name == "Current" && !source.PropertyWriter.HasPendingReconciliation);
+            var observed = new ConcurrentQueue<string>();
+            using var changes = ((IInterceptorSubject)root).Context.GetPropertyChangeObservable(ImmediateScheduler.Instance)
+                .Subscribe(change => { if (change.Property.Name == nameof(LivenessTestRoot.Name)) observed.Enqueue(change.GetNewValue<string>()); });
+            var readCount = source.PropertyWriter.VerificationReadCount;
+            var callback = Assert.Single(GetApplicationMessageHandlers(GetCurrentClient(source)));
+
+            // Act
+            await callback(CreateMessageReceivedEventArgs("Old"));
+            await AsyncTestHelpers.WaitUntilAsync(() => source.PropertyWriter.VerificationReadCount > readCount && !source.PropertyWriter.HasPendingReconciliation);
+
+            // Assert
+            Assert.Equal("Current", root.Name);
+            Assert.DoesNotContain("Old", observed);
+            brokerRoot.Name = "External";
+            await AsyncTestHelpers.WaitUntilAsync(() => root.Name == "External" && !source.PropertyWriter.HasPendingReconciliation);
+        }
+        finally
+        {
+            await source.StopAsync(CancellationToken.None);
+            await broker.StopAsync(CancellationToken.None);
+        }
+    }
+
+    // This deliberately does not claim that MQTT itself has a read service.
+    private sealed class BrokerModelReader(LivenessTestRoot root) : ISourcePropertyReader
+    {
+        public ValueTask<IReadOnlyList<SourcePropertyValue>> ReadPropertiesAsync(ReadOnlyMemory<PropertyReference> properties, CancellationToken cancellationToken)
+            => ValueTask.FromResult<IReadOnlyList<SourcePropertyValue>>(
+                properties.ToArray().Select(property => new SourcePropertyValue(property, root.Name)).ToArray());
+    }
+}

--- a/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientLivenessTests.cs
+++ b/src/Namotion.Interceptor.Mqtt.Tests/Client/MqttClientLivenessTests.cs
@@ -413,7 +413,8 @@ public partial class MqttClientLivenessTests
         int brokerPort,
         TimeSpan? reconnectDelay = null,
         IMqttValueConverter? valueConverter = null,
-        IWriteInterceptor? writeInterceptor = null)
+        IWriteInterceptor? writeInterceptor = null,
+        Namotion.Interceptor.Connectors.Reconciliation.ISourcePropertyReader? reconciliationReader = null)
     {
         var context = InterceptorSubjectContext
             .Create()
@@ -434,6 +435,7 @@ public partial class MqttClientLivenessTests
             {
                 // The broker binds IPv4 only, so dialling it by name would let the client spend its
                 // connect timeout on the IPv6 loopback first.
+                ExperimentalReconciliationReader = reconciliationReader,
                 BrokerHost = "127.0.0.1",
                 BrokerPort = brokerPort,
                 Mapper = CreateMapper(),

--- a/src/Namotion.Interceptor.Mqtt.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Mqtt.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -45,6 +45,7 @@ namespace Namotion.Interceptor.Mqtt.Client
         public string ClientId { get; init; }
         public System.TimeSpan ConnectTimeout { get; init; }
         public MQTTnet.Protocol.MqttQualityOfServiceLevel DefaultQualityOfService { get; init; }
+        public Namotion.Interceptor.Connectors.Reconciliation.ISourcePropertyReader? ExperimentalReconciliationReader { get; init; }
         public System.TimeSpan HealthCheckInterval { get; init; }
         public System.TimeSpan KeepAliveInterval { get; init; }
         public Namotion.Interceptor.Connectors.Mapping.IReversePropertyMapper<Namotion.Interceptor.Mqtt.Mapping.MqttPropertyMapping, Namotion.Interceptor.Mqtt.Mapping.MqttLookupKey> Mapper { get; init; }

--- a/src/Namotion.Interceptor.Mqtt/Client/MqttClientConfiguration.cs
+++ b/src/Namotion.Interceptor.Mqtt/Client/MqttClientConfiguration.cs
@@ -152,6 +152,9 @@ public class MqttClientConfiguration
     /// </summary>
     public string? SourceTimestampPropertyName { get; init; } = "ts";
 
+    /// <summary>Provides an application-specific authoritative reader for experimental scalar reconciliation.</summary>
+    public Namotion.Interceptor.Connectors.Reconciliation.ISourcePropertyReader? ExperimentalReconciliationReader { get; init; }
+
     /// <summary>
     /// Gets or sets the function for serializing timestamps to bytes for MQTT user properties.
     /// Default converts to Unix milliseconds as UTF8. Must be paired with a matching <see cref="SourceTimestampDeserializer"/>.

--- a/src/Namotion.Interceptor.Mqtt/Client/MqttSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.Mqtt/Client/MqttSubjectClientSource.cs
@@ -107,6 +107,7 @@ internal sealed class MqttSubjectClientSource : SubjectSourceBase, IFaultInjecta
     protected override async Task<IAsyncDisposable?> StartListeningAsync(SubjectPropertyWriter propertyWriter, CancellationToken cancellationToken)
     {
         _propertyWriter = propertyWriter;
+        if (_configuration.ExperimentalReconciliationReader is { } reader) propertyWriter.EnableReconciliation(reader);
 
         IMqttClient? client = null;
         MqttConnectionMonitor? connectionMonitor = null;
@@ -712,11 +713,10 @@ internal sealed class MqttSubjectClientSource : SubjectSourceBase, IFaultInjecta
                     {
                         if (ReferenceEquals(state.source._client, state.client))
                         {
-                            state.propertyReference.SetValueFromSource(
-                                state.source,
-                                state.sourceTimestamp,
-                                state.receivedTimestamp,
-                                state.value);
+                            if (state.source._configuration.ExperimentalReconciliationReader is not null)
+                                state.source._propertyWriter!.WriteValue(state.propertyReference, state.value, state.sourceTimestamp, state.receivedTimestamp);
+                            else
+                                state.propertyReference.SetValueFromSource(state.source, state.sourceTimestamp, state.receivedTimestamp, state.value);
                         }
                     }
                     finally

--- a/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaSourceReconciliationSpikeTests.cs
+++ b/src/Namotion.Interceptor.OpcUa.Tests/Integration/OpcUaSourceReconciliationSpikeTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Concurrent;
+using System.Reactive.Concurrency;
+using Namotion.Interceptor.OpcUa.Client;
+using Namotion.Interceptor.OpcUa.Tests.Integration.Testing;
+using Namotion.Interceptor.Testing;
+using Namotion.Interceptor.Tracking;
+using Namotion.Interceptor.Tracking.Change;
+using Namotion.Interceptor.Tracking.Transactions;
+using Opc.Ua;
+using Xunit.Abstractions;
+
+namespace Namotion.Interceptor.OpcUa.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public class OpcUaSourceReconciliationSpikeTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task WhenDelayedCallbackFollowsTransaction_ThenReadbackPreservesStateAndAcceptsLaterSourceChange()
+    {
+        // Arrange
+        var logger = new TestLogger(output);
+        using var port = await OpcUaTestPortPool.AcquireAsync();
+        await using var server = new OpcUaTestServer<SelfWriteTestRoot>(logger);
+        await server.StartAsync(context => new SelfWriteTestRoot(context), (_, root) => root.Value = "initial",
+            baseAddress: port.BaseAddress, certificateStoreBasePath: port.CertificateStoreBasePath);
+        await using var client = new OpcUaTestClient<SelfWriteTestRoot>(logger, configuration =>
+        {
+            configuration.EnableExperimentalSourceReconciliation = true;
+            configuration.SubscriptionSequentialPublishing = true;
+        });
+        await client.StartAsync(context => new SelfWriteTestRoot(context), root => root.Value == "initial",
+            serverUrl: port.ServerUrl, certificateStoreBasePath: port.CertificateStoreBasePath + "-client");
+        var source = (OpcUaSubjectClientSource)client.Source!;
+        using (var transaction = await client.Context.BeginTransactionAsync(TransactionFailureHandling.BestEffort))
+        {
+            client.Root!.Value = "committed";
+            await transaction.CommitAsync(CancellationToken.None);
+        }
+        await AsyncTestHelpers.WaitUntilAsync(() => server.Root!.Value == "committed" && !source.PropertyWriter.HasPendingReconciliation);
+        var subscription = source.SessionManager!.CurrentSession!.Subscriptions.Single();
+        var item = subscription.MonitoredItems.Single();
+        var changes = new ConcurrentQueue<string?>();
+        using var changeSubscription = client.Context.GetPropertyChangeObservable(ImmediateScheduler.Instance)
+            .Subscribe(change => { if (change.Property.Name == nameof(SelfWriteTestRoot.Value)) changes.Enqueue(change.GetNewValue<string?>()); });
+        var readsBefore = source.PropertyWriter.VerificationReadCount;
+
+        // Act: inject a delayed SDK callback, then use a real verification read over OPC UA.
+        source.SessionManager.SubscriptionManager.OnFastDataChange(subscription, new DataChangeNotification
+        {
+            MonitoredItems = [new MonitoredItemNotification
+            {
+                ClientHandle = item.ClientHandle,
+                Value = new DataValue { Value = "initial", SourceTimestamp = DateTime.UtcNow.AddMinutes(-1), StatusCode = StatusCodes.Good }
+            }]
+        }, []);
+        await AsyncTestHelpers.WaitUntilAsync(() => source.PropertyWriter.VerificationReadCount > readsBefore && !source.PropertyWriter.HasPendingReconciliation);
+
+        // Assert
+        Assert.Equal("committed", client.Root!.Value);
+        Assert.DoesNotContain("initial", changes);
+        server.Root!.Value = "external";
+        await AsyncTestHelpers.WaitUntilAsync(() => client.Root.Value == "external" && !source.PropertyWriter.HasPendingReconciliation);
+        Assert.Equal("external", client.Root.Value);
+    }
+}

--- a/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.OpcUa.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -93,6 +93,7 @@ namespace Namotion.Interceptor.OpcUa.Client
         public int DefaultPublishingInterval { get; set; }
         public uint? DefaultQueueSize { get; set; }
         public int? DefaultSamplingInterval { get; set; }
+        public bool EnableExperimentalSourceReconciliation { get; set; }
         public bool EnablePollingFallback { get; set; }
         public bool EnableReadAfterWrite { get; set; }
         public System.TimeSpan KeepAliveInterval { get; set; }

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SessionManager.cs
@@ -216,7 +216,7 @@ internal sealed class SessionManager : IAsyncDisposable, IDisposable
             PollingManager.Start();
         }
 
-        if (_configuration.EnableReadAfterWrite)
+        if (_configuration.EnableReadAfterWrite && !_configuration.EnableExperimentalSourceReconciliation)
         {
             ReadAfterWriteManager = new ReadAfterWriteManager(
                 sessionProvider: () => CurrentSession,

--- a/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Connection/SubscriptionManager.cs
@@ -247,7 +247,10 @@ internal class SubscriptionManager : IAsyncDisposable
                     var change = s.changes[i];
                     try
                     {
-                        change.Property.SetValueFromSource(s.source, change.Timestamp, s.receivedTimestamp, change.Value);
+                        if (s.manager._configuration.EnableExperimentalSourceReconciliation)
+                            s.manager._propertyWriter.WriteValue(change.Property, change.Value, change.Timestamp, s.receivedTimestamp);
+                        else
+                            change.Property.SetValueFromSource(s.source, change.Timestamp, s.receivedTimestamp, change.Value);
                     }
                     catch (Exception e)
                     {

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaClientConfiguration.cs
@@ -223,6 +223,9 @@ public class OpcUaClientConfiguration
     /// </summary>
     public bool EnableReadAfterWrite { get; set; } = true;
 
+    /// <summary>Enables the experimental scalar source reconciliation strategy with authoritative reads.</summary>
+    public bool EnableExperimentalSourceReconciliation { get; set; }
+
     /// <summary>
     /// Gets or sets the base path for certificate stores.
     /// Default is "pki". Change this to isolate certificate stores for parallel test execution.

--- a/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/OpcUaSubjectClientSource.cs
@@ -1,3 +1,4 @@
+using Namotion.Interceptor.Connectors.Reconciliation;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
@@ -14,7 +15,7 @@ using Opc.Ua.Client;
 
 namespace Namotion.Interceptor.OpcUa.Client;
 
-internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjectClientSource, IFaultInjectable, IAsyncDisposable
+internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjectClientSource, IFaultInjectable, IAsyncDisposable, ISourcePropertyReader
 {
     private const int DefaultChunkSize = 512;
 
@@ -172,6 +173,7 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
         Metrics.MarkNotOperational();
 
         _propertyWriter = propertyWriter;
+        if (_configuration.EnableExperimentalSourceReconciliation) propertyWriter.EnableReconciliation(this);
         _logger.LogInformation("Connecting to OPC UA server at {ServerUrl}.", _configuration.ServerUrl);
 
         _sessionManager = new SessionManager(
@@ -310,11 +312,43 @@ internal sealed class OpcUaSubjectClientSource : SubjectSourceBase, IOpcUaSubjec
             foreach (var (property, dataValue) in result)
             {
                 var value = _configuration.ValueConverter.ConvertToPropertyValue(dataValue.Value, property);
-                property.SetValueFromSource(this, dataValue.SourceTimestamp, null, value);
+                if (_configuration.EnableExperimentalSourceReconciliation)
+                    _propertyWriter!.WriteValue(property.Reference, value, dataValue.SourceTimestamp);
+                else
+                    property.SetValueFromSource(this, dataValue.SourceTimestamp, null, value);
             }
 
             _logger.LogInformation("Updated {Count} properties with OPC UA node values.", itemCount);
         };
+    }
+
+    public async ValueTask<IReadOnlyList<SourcePropertyValue>> ReadPropertiesAsync(
+        ReadOnlyMemory<PropertyReference> properties, CancellationToken cancellationToken)
+    {
+        var session = _sessionManager?.CurrentSession ?? throw new InvalidOperationException("No active OPC UA session.");
+        var requested = properties.ToArray();
+        var output = new List<SourcePropertyValue>(requested.Length);
+        var batchSize = (int)(session.OperationLimits?.MaxNodesPerRead ?? DefaultChunkSize);
+        if (batchSize <= 0) batchSize = DefaultChunkSize;
+        for (var offset = 0; offset < requested.Length; offset += batchSize)
+        {
+            var batch = requested.Skip(offset).Take(batchSize).ToArray();
+            var nodes = new ReadValueIdCollection(batch.Select(property => new ReadValueId
+            {
+                NodeId = TryGetNodeId(property, out var nodeId) ? nodeId : throw new InvalidOperationException("Property has no OPC UA node."),
+                AttributeId = Opc.Ua.Attributes.Value
+            }));
+            var response = await session.ReadAsync(null, 0, TimestampsToReturn.Source, nodes, cancellationToken).ConfigureAwait(false);
+            if (!ReferenceEquals(session, _sessionManager?.CurrentSession)) throw new InvalidOperationException("OPC UA session changed during verification.");
+            for (var index = 0; index < Math.Min(batch.Length, response.Results.Count); index++)
+            {
+                var value = response.Results[index];
+                if (!StatusCode.IsGood(value.StatusCode)) continue;
+                var property = batch[index].TryGetRegisteredProperty()!;
+                output.Add(new SourcePropertyValue(batch[index], _configuration.ValueConverter.ConvertToPropertyValue(value.Value, property), value.SourceTimestamp, DateTimeOffset.UtcNow));
+            }
+        }
+        return output;
     }
 
     /// <inheritdoc />

--- a/src/Namotion.Interceptor.OpcUa/Client/Polling/PollingManager.cs
+++ b/src/Namotion.Interceptor.OpcUa/Client/Polling/PollingManager.cs
@@ -322,6 +322,11 @@ internal sealed class PollingManager : IAsyncDisposable
 
     private async Task ReadBatchAsync(ISession session, ArraySegment<PollingItem> batch, CancellationToken cancellationToken)
     {
+        if (_configuration.EnableExperimentalSourceReconciliation)
+        {
+            foreach (var item in batch) _propertyWriter.RequestReconciliation(item.Property.Reference);
+            return;
+        }
         try
         {
             // Build read request - pre-size to avoid resizing

--- a/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -75,6 +75,11 @@ namespace Namotion.Interceptor
         bool TryAddService<TService>(System.Func<TService> factory, System.Func<TService, bool> exists);
         TInterface? TryGetService<TInterface>();
     }
+    public interface IPropertyWriteGuard
+    {
+        void Exit(bool committed);
+        bool TryEnter(Namotion.Interceptor.PropertyReference property);
+    }
     public interface IRaisePropertyChanged
     {
         void RaisePropertyChanged(string propertyName);

--- a/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
+++ b/src/Namotion.Interceptor.Tracking.Tests/VerifyChecksTests.PublicApi.verified.txt
@@ -75,6 +75,7 @@ namespace Namotion.Interceptor.Tracking.Change
         public static void SetValueFromOrigin(this Namotion.Interceptor.PropertyReference property, Namotion.Interceptor.ChangeOrigin origin, System.DateTimeOffset? changedTimestamp, System.DateTimeOffset? receivedTimestamp, object? value) { }
         public static void SetValueFromOrigin(this Namotion.Interceptor.PropertyReference property, Namotion.Interceptor.ChangeOrigin origin, System.DateTimeOffset? changedTimestamp, System.DateTimeOffset? receivedTimestamp, object? value, object? sentValue) { }
         public static void SetValueFromSource(this Namotion.Interceptor.PropertyReference property, object source, System.DateTimeOffset? changedTimestamp, System.DateTimeOffset? receivedTimestamp, object? valueFromSource) { }
+        public static void SetValueFromSource(this Namotion.Interceptor.PropertyReference property, object source, System.DateTimeOffset? changedTimestamp, System.DateTimeOffset? receivedTimestamp, object? value, Namotion.Interceptor.IPropertyWriteGuard guard) { }
     }
     public readonly struct SubjectPropertyChange : System.IEquatable<Namotion.Interceptor.Tracking.Change.SubjectPropertyChange>
     {
@@ -247,6 +248,10 @@ namespace Namotion.Interceptor.Tracking.Recorder
 }
 namespace Namotion.Interceptor.Tracking.Transactions
 {
+    public interface ITransactionWriteCoordinator
+    {
+        System.IDisposable BeginCoordination();
+    }
     public interface ITransactionWriter
     {
         System.Threading.Tasks.ValueTask<Namotion.Interceptor.Tracking.Transactions.SourceRevertResult> RevertSourceWritesAsync(System.Collections.Generic.IReadOnlyList<Namotion.Interceptor.Tracking.Change.SubjectPropertyChange> written, object? revertState, System.Threading.CancellationToken cancellationToken);

--- a/src/Namotion.Interceptor.Tracking/Change/SubjectChangeContextExtensions.cs
+++ b/src/Namotion.Interceptor.Tracking/Change/SubjectChangeContextExtensions.cs
@@ -4,6 +4,15 @@ namespace Namotion.Interceptor.Tracking.Change;
 
 public static class SubjectChangeContextExtensions
 {
+    /// <summary>Attempts a source apply with admission validated at the property commit boundary.</summary>
+    public static void SetValueFromSource(this PropertyReference property, object source,
+        DateTimeOffset? changedTimestamp, DateTimeOffset? receivedTimestamp, object? value, IPropertyWriteGuard guard)
+    {
+        using (SubjectChangeContext.WithTimestamps(changedTimestamp, receivedTimestamp))
+        using (PendingOrigin.Set(property, ChangeOrigin.FromSource(source), value, guard))
+            property.Metadata.SetValue?.Invoke(property.Subject, value);
+    }
+
     /// <summary>
     /// Sets the value of the property, arming the pending origin so the resulting write carries the
     /// given <paramref name="origin"/> instead of scoping an ambient source. This is the intent-level

--- a/src/Namotion.Interceptor.Tracking/Transactions/ITransactionWriteCoordinator.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/ITransactionWriteCoordinator.cs
@@ -1,0 +1,10 @@
+using Namotion.Interceptor.Tracking.Change;
+
+namespace Namotion.Interceptor.Tracking.Transactions;
+
+/// <summary>Experimental synchronization spanning source writes, local application, and compensation.</summary>
+public interface ITransactionWriteCoordinator
+{
+    /// <summary>Begins a scope that ends after local reconciliation and source compensation.</summary>
+    IDisposable BeginCoordination();
+}

--- a/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
+++ b/src/Namotion.Interceptor.Tracking/Transactions/SubjectTransaction.cs
@@ -452,6 +452,8 @@ public sealed class SubjectTransaction : IDisposable
         Memory<SubjectPropertyChange> changes,
         CancellationToken cancellationToken)
     {
+        using var coordination = (writer as ITransactionWriteCoordinator)?.BeginCoordination();
+
         // The writer marks accepted snapshot slots with the confirming source so the local apply and
         // revert notifications are echo-suppressed by the outbound connector queue (#343).
         var capturedProperties = ValidateWriterContract ? CaptureSnapshotProperties(changes.Span) : null;

--- a/src/Namotion.Interceptor/AttemptedOrigin.cs
+++ b/src/Namotion.Interceptor/AttemptedOrigin.cs
@@ -12,10 +12,12 @@ internal readonly struct AttemptedOrigin
 
     /// <summary>The value the source sent, valid when <see cref="Origin"/> is stamped.</summary>
     public readonly object? SentValue;
+    internal readonly IPropertyWriteGuard? Guard;
 
-    public AttemptedOrigin(ChangeOrigin origin, object? sentValue)
+    public AttemptedOrigin(ChangeOrigin origin, object? sentValue, IPropertyWriteGuard? guard = null)
     {
         Origin = origin;
         SentValue = sentValue;
+        Guard = guard;
     }
 }

--- a/src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs
+++ b/src/Namotion.Interceptor/Cache/WriteInterceptorFactory.cs
@@ -18,25 +18,31 @@ internal static class WriteInterceptorFactory<TProperty>
                 var subject = property.Subject;
                 lock (subject.SyncRoot)
                 {
-                    innerWriteValue(subject, context.NewValue);
-                    context.IsWritten = true;
-                    // Plain increment, no Interlocked: the enclosing lock is the subject's SyncRoot and the
-                    // executor belongs to that subject, so the increment is exclusive. The lock half is
-                    // lexically enclosing and therefore compiler-guaranteed; the executor-owns-subject half
-                    // is only a construction-site convention, so it is asserted. A mismatched executor would
-                    // increment another subject's counter under the wrong lock, silently and undetectably.
-                    Debug.Assert(ReferenceEquals(context.Executor.Subject, subject),
-                        "The context's executor must own the subject being locked: the plain increment relies on that pairing.");
-                    context.Revision = ++context.Executor.Revision;
-                    // Before FinalizeOrigin, which demotes a stamped origin to Local when a hook changed
-                    // the value. That demotion is right for publishing and wrong here: the write still
-                    // came from the source, and counting it as local would let it discard a local write
-                    // that had already committed.
-                    var isFromSource = context.Origin.Kind == ChangeOriginKind.FromSource;
+                    var guard = context.WriteGuard;
+                    if (guard is not null && !guard.TryEnter(property)) return;
+                    try
+                    {
+                        innerWriteValue(subject, context.NewValue);
+                        context.IsWritten = true;
+                        // Plain increment, no Interlocked: the enclosing lock is the subject's SyncRoot and the
+                        // executor belongs to that subject, so the increment is exclusive. The lock half is
+                        // lexically enclosing and therefore compiler-guaranteed; the executor-owns-subject half
+                        // is only a construction-site convention, so it is asserted. A mismatched executor would
+                        // increment another subject's counter under the wrong lock, silently and undetectably.
+                        Debug.Assert(ReferenceEquals(context.Executor.Subject, subject),
+                            "The context's executor must own the subject being locked: the plain increment relies on that pairing.");
+                        context.Revision = ++context.Executor.Revision;
+                        // Before FinalizeOrigin, which demotes a stamped origin to Local when a hook changed
+                        // the value. That demotion is right for publishing and wrong here: the write still
+                        // came from the source, and counting it as local would let it discard a local write
+                        // that had already committed.
+                        var isFromSource = context.Origin.Kind == ChangeOriginKind.FromSource;
 
-                    context.FinalizeOrigin();
-                    var raw = context.WriteTimestampRaw;
-                    property.SetWriteState(raw > 0 ? raw : 0, context.Revision, isFromSource);
+                        context.FinalizeOrigin();
+                        var raw = context.WriteTimestampRaw;
+                        property.SetWriteState(raw > 0 ? raw : 0, context.Revision, isFromSource);
+                    }
+                    finally { guard?.Exit(context.IsWritten); }
                 }
             };
         }
@@ -49,22 +55,28 @@ internal static class WriteInterceptorFactory<TProperty>
                 var subject = property.Subject;
                 lock (subject.SyncRoot)
                 {
-                    innerWriteValue(subject, context.NewValue);
-                    context.IsWritten = true;
-                    // See the zero-interceptor terminal above for why the property is hoisted, why the
-                    // increment needs no Interlocked, and what the assert covers that the lock does not.
-                    Debug.Assert(ReferenceEquals(context.Executor.Subject, subject),
-                        "The context's executor must own the subject being locked: the plain increment relies on that pairing.");
-                    context.Revision = ++context.Executor.Revision;
-                    // Before FinalizeOrigin, which demotes a stamped origin to Local when a hook changed
-                    // the value. That demotion is right for publishing and wrong here: the write still
-                    // came from the source, and counting it as local would let it discard a local write
-                    // that had already committed.
-                    var isFromSource = context.Origin.Kind == ChangeOriginKind.FromSource;
+                    var guard = context.WriteGuard;
+                    if (guard is not null && !guard.TryEnter(property)) return context.NewValue;
+                    try
+                    {
+                        innerWriteValue(subject, context.NewValue);
+                        context.IsWritten = true;
+                        // See the zero-interceptor terminal above for why the property is hoisted, why the
+                        // increment needs no Interlocked, and what the assert covers that the lock does not.
+                        Debug.Assert(ReferenceEquals(context.Executor.Subject, subject),
+                            "The context's executor must own the subject being locked: the plain increment relies on that pairing.");
+                        context.Revision = ++context.Executor.Revision;
+                        // Before FinalizeOrigin, which demotes a stamped origin to Local when a hook changed
+                        // the value. That demotion is right for publishing and wrong here: the write still
+                        // came from the source, and counting it as local would let it discard a local write
+                        // that had already committed.
+                        var isFromSource = context.Origin.Kind == ChangeOriginKind.FromSource;
 
-                    context.FinalizeOrigin();
-                    var raw = context.WriteTimestampRaw;
-                    property.SetWriteState(raw > 0 ? raw : 0, context.Revision, isFromSource);
+                        context.FinalizeOrigin();
+                        var raw = context.WriteTimestampRaw;
+                        property.SetWriteState(raw > 0 ? raw : 0, context.Revision, isFromSource);
+                    }
+                    finally { guard?.Exit(context.IsWritten); }
                 }
                 return context.NewValue;
             }

--- a/src/Namotion.Interceptor/IPropertyWriteGuard.cs
+++ b/src/Namotion.Interceptor/IPropertyWriteGuard.cs
@@ -1,0 +1,12 @@
+namespace Namotion.Interceptor;
+
+/// <summary>Experimental conditional admission for one synchronous property write.</summary>
+/// <remarks>Methods run under the property's subject lock. Implementations must not invoke subject setters or acquire locks shared with unrelated subjects.</remarks>
+public interface IPropertyWriteGuard
+{
+    /// <summary>Attempts admission. A false result must leave no guard lock held.</summary>
+    bool TryEnter(PropertyReference property);
+
+    /// <summary>Releases successful admission, including when the setter throws.</summary>
+    void Exit(bool committed);
+}

--- a/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
+++ b/src/Namotion.Interceptor/Interceptors/IWriteInterceptor.cs
@@ -30,6 +30,8 @@ public delegate void WriteInterceptionDelegate<TProperty>(ref PropertyWriteConte
 /// </summary>
 public struct PropertyWriteContext<TProperty>
 {
+    internal IPropertyWriteGuard? WriteGuard;
+
     // Lazy-cache for the write timestamp. One long encodes three states:
     //   == 0    uninitialized; first read calls ResolveAndCacheWriteTimestamp() to populate it.
     //   >  0    real UtcNow ticks.
@@ -131,6 +133,7 @@ public struct PropertyWriteContext<TProperty>
         IsWritten = false;
         _writeTimestamp = 0;
         PendingOrigin.TryConsume(in property, out _attempted);
+        WriteGuard = _attempted.Guard;
     }
 
     /// <summary>
@@ -154,6 +157,7 @@ public struct PropertyWriteContext<TProperty>
         FinalValueIsNewValue = true;
         _writeTimestamp = rawTimestamp;
         PendingOrigin.TryConsume(in property, out _attempted);
+        WriteGuard = _attempted.Guard;
     }
 
     /// <summary>

--- a/src/Namotion.Interceptor/PendingOrigin.cs
+++ b/src/Namotion.Interceptor/PendingOrigin.cs
@@ -34,14 +34,14 @@ internal static class PendingOrigin
 
     [ThreadStatic] private static PendingFrame _frame;
 
-    internal static PendingOriginScope Set(PropertyReference target, ChangeOrigin origin, object? sentValue)
+    internal static PendingOriginScope Set(PropertyReference target, ChangeOrigin origin, object? sentValue, IPropertyWriteGuard? guard = null)
     {
         var scope = new PendingOriginScope(_frame);
         _frame = new PendingFrame
         {
             HasValue = true,
             Target = target,
-            Attempted = new AttemptedOrigin(origin, sentValue)
+            Attempted = new AttemptedOrigin(origin, sentValue, guard)
         };
         return scope;
     }


### PR DESCRIPTION
This spike explores preventing stale scalar notifications from reverting local writes and achieving quiescent convergence without another application write. It adds a shared source reconciliation mechanism, an opt-in OPC UA implementation, and an MQTT integration that requires an application-provided authoritative reader.

For example, after writing `100`, a delayed notification carrying `90` requests verification rather than overwriting the model. A current source read can confirm `100` or apply a real correction. A later delayed notification still triggers verification. Completing one read does not certify subsequent notifications as fresh.

Related to #373. This is an experimental draft for design review and does not resolve the issue. The test isolation and characterization work from #533 is already on the base branch.

## Contract

- Default connector behavior is unchanged. OPC UA opts in with `EnableExperimentalSourceReconciliation`; MQTT opts in with `ExperimentalReconciliationReader`.
- Source writes schedule verification even if no echo arrives. Failed or incomplete reads retry without another application write.
- Local write revisions, pending source operations, notification versions, connection epochs, and ownership intervals reject obsolete results. The final admission check runs under the subject lock immediately before commit.
- Transaction coordination spans source writes, local confirmation, and compensation. Polling requests refresh without invalidating an active read.
- Convergence is demonstrated for the tested scalar cases when source traffic settles and authoritative reads succeed. This does not establish a guarantee for graphs, continuous traffic, or unreadable sources.

The proposed integration points are `IPropertyWriteGuard` in core, a guarded source setter and `ITransactionWriteCoordinator` in tracking, and `ISourcePropertyReader` plus shared coordination in connectors. OPC UA uses batched `Read` calls with `maxAge = 0`. The live MQTT test supplies a reader over its broker model; it does not implement a general MQTT read protocol.

[Spike findings and limitations](https://github.com/RicoSuter/Namotion.Interceptor/blob/spike/source-reconciliation-opcua/docs/design/issue-373-source-reconciliation-spike.md)

## Open design decisions and further investigation

- **Public API and writer design:** decide whether conditional admission belongs in the core setter, whether the scalar writer API should replace or complement callback-based writes, and whether the transaction coordination interface and ambient scope are the right permanent abstractions. A check outside the setter terminal leaves a race before commit. Reconciliation currently must be enabled before property ownership is claimed and before initial state loading; enabling it after claims does not register existing properties. The built-in integrations use the required order. Decide whether late enablement should be supported or rejected explicitly.
- **Read strategy and cost:** the conservative policy reads after ambiguous notifications as well as writes. Investigate safe ways to reduce read amplification, coalesce batches, avoid full property scans, reduce allocations, and replace the dedicated observation thread per source. Measure latency, throughput, and allocations before choosing defaults.
- **Continuous traffic and fairness:** notifications can repeatedly invalidate active reads and postpone application. Define progress expectations under sustained updates, polling, slow readers, and multiple properties or sources; avoid solving quiescent convergence by introducing starvation elsewhere.
- **Source authority and corrections:** define how source readback interacts with validation, local correction generation, write retries, concurrent external writers, and persistent disagreement. Commit admission does not undo custom interceptor side effects that ran before the terminal. Multi-property source reads are not an atomic snapshot.
- **OPC UA protocol behavior:** validate freshness against real servers and devices, including delayed writes, cached acquisition, timestamp-only notifications, reconnect/session replacement, bad or uncertain status, missing mappings, operation limits, and partial batch results. A missing mapping, conversion error, or later-batch exception currently discards results already collected from healthy batches and retries the whole pending set; investigate per-property/batch fault isolation. Decide how the new path integrates with existing read-after-write configuration, polling, and diagnostics.
- **MQTT protocol contract:** choose an actual authoritative read/request-response or application acknowledgment contract. Define correlation, ordering, retained messages, duplicate delivery, reconnect behavior, and publishers that cannot provide readback. Assess in-band fencing only where the application's channel ordering can support it; the current test reader is a capability demonstration.
- **Failure and lifecycle policy:** extend coverage for timeouts, cancellation, repeated/partial read failures, overlapping writes and compensation, disposal, detach/reclaim, and reconnect. Decide retry/backoff, resource cleanup, and how permanent failures are reported.
- **Settlement and observability:** define an awaitable settlement contract and useful pending/error/read metrics. `HasPendingReconciliation` is only a diagnostic snapshot; existing source synchronization status is not a verification barrier.
- **Graph and other connector scope:** design subject, collection, and dictionary reconciliation. The current scalar writer routes opted-in structural observations into a reconciler that ignores them, with no legacy fallback; do not use this experiment as a graph-capable source. Decide whether unsupported observations should fail explicitly, retain their old path, or gain coordinated graph support. The structural-correction/empty-diff case in #373 and WebSocket behavior remain open. Determine the boundary with the general reconciliation work in #342 and behavior when a source neither reads nor echoes.
- **Production validation and documentation:** agree and run benchmarks plus Connector Tester load/chaos profiles before production adoption. Update the existing OPC UA and transaction ordering caveats only when stronger guarantees actually land, as tracked in #373. Decide API stability, rollout, and defaults after these findings.

## Breaking changes

None for existing consumers: existing signatures and default connector behavior remain available. Public additions are experimental: `IPropertyWriteGuard`, the guarded source-setter overload, `ITransactionWriteCoordinator`, `ISourcePropertyReader`/`SourcePropertyValue`, writer reconciliation methods/diagnostics, and the OPC UA/MQTT opt-in configuration. These APIs are provisional and may change before any production proposal.

## Diff composition

| Area | Files | Added | Removed | Net |
|---|---:|---:|---:|---:|
| Namotion.Interceptor | 5 | 67 | 37 | +30 |
| Namotion.Interceptor.Connectors | 8 | 421 | 10 | +411 |
| Namotion.Interceptor.Mqtt | 2 | 8 | 5 | +3 |
| Namotion.Interceptor.OpcUa | 5 | 49 | 4 | +45 |
| Namotion.Interceptor.Tracking | 3 | 21 | 0 | +21 |
| Tests and benchmarks | 9 | 486 | 3 | +483 |
| Documentation | 1 | 38 | 0 | +38 |
| **Total** | **33** | **1,090** | **59** | **+1,031** |

## Verification

Fourteen deterministic shared tests cover delayed notifications, absent echoes, read/write and commit-time races, notification/polling overlap, retries, reconnect, transaction success/failure, operations without local commits, and ownership changes. Live OPC UA and MQTT tests exercise stale callbacks and subsequent external changes. Independent review is for the experimental scope, not production approval.

- [x] Documentation updated: concise spike findings and limitations.
- [x] Affected project suites and API snapshots verified after rebasing onto current master: core 157, tracking 571, connectors 805, OPC UA 357, and MQTT 117, totaling 2,007 passing tests.
- [x] Full OPC UA and MQTT project suites, including their live integration tests, passed (counts above).
- [ ] Full solution unit-test run. Validation is scoped to the five affected projects.
- [ ] Benchmarks. Costs are unmeasured and remain a design decision.
- [ ] Load tests. Long Connector Tester runs are deferred until production planning.
- [ ] Chaos tests. Long Connector Tester runs are deferred until production planning.
